### PR TITLE
battery utility upgrade

### DIFF
--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -11,7 +11,7 @@
 # - added echo on else to test when running command from terminal
 # - exec-once on hyprland instead of systemd timer, then while true cycle
 
-BATTERY_THRESHOLD=54
+BATTERY_THRESHOLD=15
 
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 
@@ -37,7 +37,7 @@ while true; do
     fi
   else
     rm -f "$NOTIFICATION_FLAG"
-    echo "Currently $BATTERY_STATE at $BATTERY_LEVEL%. The treshold to notify is $BATTERY_THRESHOLD% and this utility would notify only on *discharging*"
+    echo "Currently $BATTERY_STATE at $BATTERY_LEVEL%. The threshold to notify is $BATTERY_THRESHOLD% and this utility would notify only on *discharging*"
   fi
 
   sleep 30

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -4,7 +4,6 @@
 # value is approximate, but close to real one.
 # Sometimes differs from the waybar's value
 # ignoring it, using bare upower's output
-# due to fast discharging treshold was set to 15%
 #
 # changed:
 # - using upower -b instead of previous logic, gave empty results
@@ -15,7 +14,7 @@
 # practice to exit on fail of while true;
 set -o errexit
 
-BATTERY_THRESHOLD=15
+BATTERY_THRESHOLD=10
 
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -1,36 +1,44 @@
 #!/bin/bash
 
-# Designed to be run by systemd timer every 30 seconds and alerts if battery is low
+# tayowrld for omarchy-mac
+# value is approximate, but close to real one.
+# Sometimes differs from the waybar's value, because of using upower
+# -3 from upower value is to get closer to waybar value
+# due to fast discharging treshold was set to 15%
+#
+# changed:
+# - using upower -b instead of previous logic, gave empty results
+# - added echo on else to test when running command from terminal
+# - exec-once on hyprland instead of systemd timer, then while true cycle
 
-BATTERY_THRESHOLD=10
+BATTERY_THRESHOLD=54
+
 NOTIFICATION_FLAG="/run/user/$UID/omarchy_battery_notified"
 
 get_battery_percentage() {
-  upower -i "$(upower -e | grep 'BAT')" \
-  | awk -F: '/percentage/ {
-      gsub(/[%[:space:]]/, "", $2);
-      val=$2;
-      printf("%d\n", (val+0.5))
-      exit
-    }'
+  upower -b | grep 'percentage' | awk -F: '{gsub(/[%[:space:]]/, "", $2); printf("%d\n", $2+0.5)}'
 }
 
 get_battery_state() {
-  upower -i $(upower -e | grep 'BAT') | grep -E "state" | awk '{print $2}'
+  upower -b | grep 'state' | awk -F':[[:space:]]*' '/state/ {print $2; exit}'
 }
 
 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
+while true; do
+  BATTERY_LEVEL=$(($(get_battery_percentage) - 3))
+  BATTERY_STATE=$(get_battery_state)
 
-BATTERY_LEVEL=$(get_battery_percentage)
-BATTERY_STATE=$(get_battery_state)
-
-if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
-  if [[ ! -f "$NOTIFICATION_FLAG" ]]; then
-    send_notification "$BATTERY_LEVEL"
-    touch "$NOTIFICATION_FLAG"
+  if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
+    if [[ ! -f "$NOTIFICATION_FLAG" ]]; then
+      send_notification "$BATTERY_LEVEL"
+      touch "$NOTIFICATION_FLAG"
+    fi
+  else
+    rm -f "$NOTIFICATION_FLAG"
+    echo "Currently $BATTERY_STATE at $BATTERY_LEVEL%. The treshold to notify is $BATTERY_THRESHOLD% and this utility would notify only on *discharging*"
   fi
-else
-  rm -f "$NOTIFICATION_FLAG"
-fi
+
+  sleep 30
+done

--- a/bin/omarchy-battery-monitor
+++ b/bin/omarchy-battery-monitor
@@ -2,14 +2,18 @@
 
 # tayowrld for omarchy-mac
 # value is approximate, but close to real one.
-# Sometimes differs from the waybar's value, because of using upower
-# -3 from upower value is to get closer to waybar value
+# Sometimes differs from the waybar's value
+# ignoring it, using bare upower's output
 # due to fast discharging treshold was set to 15%
 #
 # changed:
 # - using upower -b instead of previous logic, gave empty results
+# - added additional notifications percent-to-percent (less than 6%)
 # - added echo on else to test when running command from terminal
 # - exec-once on hyprland instead of systemd timer, then while true cycle
+
+# practice to exit on fail of while true;
+set -o errexit
 
 BATTERY_THRESHOLD=15
 
@@ -26,8 +30,9 @@ get_battery_state() {
 send_notification() {
   notify-send -u critical "󱐋 Time to recharge!" "Battery is down to ${1}%" -i battery-caution -t 30000
 }
+
 while true; do
-  BATTERY_LEVEL=$(($(get_battery_percentage) - 3))
+  BATTERY_LEVEL=$(get_battery_percentage)
   BATTERY_STATE=$(get_battery_state)
 
   if [[ "$BATTERY_STATE" == "discharging" && "$BATTERY_LEVEL" -le "$BATTERY_THRESHOLD" ]]; then
@@ -35,8 +40,20 @@ while true; do
       send_notification "$BATTERY_LEVEL"
       touch "$NOTIFICATION_FLAG"
     fi
+
+    # the logic below:
+    # if the current battery level is equals or less than 5%
+    # and there is no notification flag setted for the current percent
+    # then send a notification and set the custom percent's flag
+    # else ignore and continue, up to the next percent after program and upower refresh
+
+    NOTIFICATION_FLAG_BY_PERCENT="${NOTIFICATION_FLAG}_${BATTERY_LEVEL}"
+    if [[ $BATTERY_LEVEL -le 5 && ! -f "$NOTIFICATION_FLAG_BY_PERCENT" ]]; then
+      send_notification "$BATTERY_LEVEL"
+      touch "$NOTIFICATION_FLAG_BY_PERCENT"
+    fi
   else
-    rm -f "$NOTIFICATION_FLAG"
+    rm -f "${NOTIFICATION_FLAG}" "${NOTIFICATION_FLAG}"_*
     echo "Currently $BATTERY_STATE at $BATTERY_LEVEL%. The threshold to notify is $BATTERY_THRESHOLD% and this utility would notify only on *discharging*"
   fi
 

--- a/default/hypr/autostart.conf
+++ b/default/hypr/autostart.conf
@@ -8,3 +8,4 @@ exec-once = uwsm app -- swayosd-server
 exec-once = /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec-once = wl-clip-persist --clipboard regular --all-mime-type-regex '^(?!x-kde-passwordManagerHint).+'
 exec-once = omarchy-cmd-first-run
+exec-once = omarchy-battery-monitor


### PR DESCRIPTION
old ```upower``` variables gave empty output for me through the parse. So now it parses the battery data using ```upower -b```
switched from systemd timer (did not work for me also, idk) to exec-once on hyprland config
added logs for running as command to see if the utility parses the right values. They won't be shown if batter is in charging state or percantage is already less than threshold 
notify still showing once and does not appear again until - restarting script in the preferred way (and killing the old process), deleting the notification flag, switching to discharging on low power or switching to discharging and work until low power. 
values were approximately brought to the waybar ones (+-1%)

to test threshold could be set optionally, then restart (the value of threshold is not updating automatically in the session)

