### PR TITLE
document mac-specific keybindings and input defaults

### DIFF
--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -32,7 +32,7 @@ Windows folks: your Win + V clipboard history lives on `Super + Ctrl + V`, and i
 | ------------- | ---------- |
 | Spotlight / Raycast / Start menu | `Super + Space` — the Omarchy menu |
 | AirDrop | LocalSend, via `Super + Ctrl + S` — see [GUIs](22-guis.md) |
-| Cmd + Shift + 4 / Win + Shift + S | `Super + Fn + F11` on an Apple keyboard, or `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
+| Cmd + Shift + 4 / Win + Shift + S | `Super + F11` on an Apple keyboard, or `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
 | Notification Center | Notification history on `Super + Shift + Alt + ,` |
 | Time Machine (for the system) | Automatic [system snapshots](47-system-snapshots.md) on every update |
 | App Store / downloading an installer | _Install_ in the menu, or `omarchy pkg add` — see [other packages](29-other-packages.md) |

--- a/manual/03-coming-from-mac-or-windows.md
+++ b/manual/03-coming-from-mac-or-windows.md
@@ -32,7 +32,7 @@ Windows folks: your Win + V clipboard history lives on `Super + Ctrl + V`, and i
 | ------------- | ---------- |
 | Spotlight / Raycast / Start menu | `Super + Space` — the Omarchy menu |
 | AirDrop | LocalSend, via `Super + Ctrl + S` — see [GUIs](22-guis.md) |
-| Cmd + Shift + 4 / Win + Shift + S | `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
+| Cmd + Shift + 4 / Win + Shift + S | `Super + Fn + F11` on an Apple keyboard, or `Print Screen` — see [screenshots & recording](12-screenshots-recording.md) |
 | Notification Center | Notification history on `Super + Shift + Alt + ,` |
 | Time Machine (for the system) | Automatic [system snapshots](47-system-snapshots.md) on every update |
 | App Store / downloading an installer | _Install_ in the menu, or `omarchy pkg add` — see [other packages](29-other-packages.md) |
@@ -50,7 +50,10 @@ And when you close a window, the app actually quits. There's no macOS limbo wher
 
 ### On Mac hardware
 
-Omarchy runs well on Intel Macs — see [Mac support](44-mac-support.md). And the keyboard is kind to you: Omarchy doesn't remap anything, and Linux treats the Command key as Super, so Super sits right where Cmd always was. Your thumb won't notice the move.
+Omarchy runs well on Intel Macs — see [Mac support](44-mac-support.md). On an
+Apple keyboard, use Command wherever this manual says `Super`. Omarchy
+configures the top row like macOS: media controls work directly, while `Fn`
+gives you F1-F12.
 
 ### Give it two weeks
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -83,8 +83,7 @@ You can see all the main keyboard bindings with `Super + K` (Tmux bindings with 
 
 | Hotkey                  | Function              |
 | ----------------------- | --------------------- |
-| `Shift + Brightness Up` | Maximum screen brightness |
-| `Shift + Brightness Down` | Minimum screen brightness |
+| `Shift + Brightness Up/Down` | Keyboard backlight brighter/dimmer when available |
 | `Alt + Brightness Up/Down` | Precise 1% brightness changes |
 | `Alt + Volume Up/Down` | Precise 1% volume changes |
 | `Keyboard Brightness Up/Down` | Keyboard backlight brighter/dimmer |
@@ -146,6 +145,10 @@ Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal 
 | `Alt + Print Screen`            | Screenrecord                     |
 | `Super + Print Screen` | Color picker |
 | `Super + Ctrl + Print Screen` | Text extraction to clipboard |
+| `Super + Fn + F12` | Screenshot full display on Apple keyboards |
+| `Super + Fn + F11` | Screenshot region on Apple keyboards |
+| `Super + Fn + F10` | Screenshot window on Apple keyboards |
+| `Super + Alt + Fn + F12` | Start/stop fullscreen recording without audio on Apple keyboards |
 | `Super + Alt + [` | Make webcam overlay smaller while recording |
 | `Super + Alt + ]` | Make webcam overlay larger while recording |
 | `Alt + Shift + L` | Copy current URL from webapp or Chromium |
@@ -153,7 +156,15 @@ Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal 
 | `Super + Ctrl + X` | Start/stop dictation (requires _Install > AI > Dictation_) |
 | `F9` | Push-to-talk dictation (requires _Install > AI > Dictation_) |
 
-With screenrecordings, the hotkey first asks which audio you want, then starts recording. Hit it again to stop. See [screenshots and recording](12-screenshots-recording.md) for the details.
+The standard screenrecording hotkey asks which audio you want, then starts
+recording. The Apple-specific fullscreen hotkey starts immediately without
+audio. Hit the same hotkey again to stop. See [screenshots and
+recording](12-screenshots-recording.md) for the details.
+
+Apple keyboards use their top row for media controls by default. Hold `Fn` in
+the Apple-specific shortcuts above so the keys emit F10-F12. The keybindings
+viewer omits `Fn` because the keyboard driver handles it before Hyprland sees
+the key.
 
 All capture options are also accessible under _Trigger > Capture_ in the Omarchy menu (`Super + Space`).
 

--- a/manual/07-hotkeys.md
+++ b/manual/07-hotkeys.md
@@ -145,10 +145,10 @@ Usually on Linux, you need `Ctrl + Shift + C/V` to copy'n'paste in the terminal 
 | `Alt + Print Screen`            | Screenrecord                     |
 | `Super + Print Screen` | Color picker |
 | `Super + Ctrl + Print Screen` | Text extraction to clipboard |
-| `Super + Fn + F12` | Screenshot full display on Apple keyboards |
-| `Super + Fn + F11` | Screenshot region on Apple keyboards |
-| `Super + Fn + F10` | Screenshot window on Apple keyboards |
-| `Super + Alt + Fn + F12` | Start/stop fullscreen recording without audio on Apple keyboards |
+| `Super + F12` | Screenshot full display on Apple keyboards |
+| `Super + F11` | Screenshot region on Apple keyboards |
+| `Super + F10` | Screenshot window on Apple keyboards |
+| `Super + Alt + F12` | Start/stop fullscreen recording without audio on Apple keyboards |
 | `Super + Alt + [` | Make webcam overlay smaller while recording |
 | `Super + Alt + ]` | Make webcam overlay larger while recording |
 | `Alt + Shift + L` | Copy current URL from webapp or Chromium |
@@ -161,10 +161,8 @@ recording. The Apple-specific fullscreen hotkey starts immediately without
 audio. Hit the same hotkey again to stop. See [screenshots and
 recording](12-screenshots-recording.md) for the details.
 
-Apple keyboards use their top row for media controls by default. Hold `Fn` in
-the Apple-specific shortcuts above so the keys emit F10-F12. The keybindings
-viewer omits `Fn` because the keyboard driver handles it before Hyprland sees
-the key.
+Apple keyboards use their top row for media controls by default. The
+Apple-specific shortcuts above work whether or not you hold `Fn`.
 
 All capture options are also accessible under _Trigger > Capture_ in the Omarchy menu (`Super + Space`).
 

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -1,6 +1,9 @@
 # Screenshots & Recording
 
-Everything you can grab off the screen hangs off the Print Screen key. One key on its own takes a picture, and the modifiers take a recording, a colour, or the text inside a region. If your keyboard doesn't have a Print Screen key at all, `Super + Ctrl + C` opens the same set as a menu.
+On keyboards with a Print Screen key, one key and its modifiers handle
+screenshots, recording, colour picking, and text extraction. If your keyboard
+doesn't have one, use `Super + Ctrl + C` to open the same set as a menu. Apple
+keyboards also have direct F-key alternatives:
 
 | Hotkey | Function |
 | ------ | -------- |
@@ -10,6 +13,13 @@ Everything you can grab off the screen hangs off the Print Screen key. One key o
 | `Super + Ctrl + Print Screen` | Extract text from a region |
 | `Super + Ctrl + C` | Capture menu |
 | `Super + Ctrl + .` | Transcode a picture or video |
+| `Super + Fn + F10` | Screenshot a window on an Apple keyboard |
+| `Super + Fn + F11` | Screenshot a region on an Apple keyboard |
+| `Super + Fn + F12` | Screenshot the full display on an Apple keyboard |
+| `Super + Alt + Fn + F12` | Start/stop fullscreen recording without audio on an Apple keyboard |
+
+Omarchy configures the top row on Apple keyboards as media keys. Hold `Fn` in
+these shortcuts so the keys emit F10-F12.
 
 ## Screenshots
 
@@ -38,7 +48,16 @@ The arrows and Tab move the cursor to the window they pick, so the highlight fol
 
 `Alt + Print Screen` opens _Trigger > Capture > Screenrecord_, which asks what you want on the soundtrack: no audio, desktop audio, desktop plus microphone, or desktop plus microphone plus webcam. That last one only shows up if you actually have a camera plugged in. Pick one and you get the same picker as a screenshot: drag a region, or click a window or monitor.
 
-Recording runs on gpu-screen-recorder, which encodes on the GPU at 60fps and falls back to the CPU if it has to. The result is an MP4 in `~/Videos`, named `screenrecording-2026-08-13_14-22-05.mp4`. Set `OMARCHY_SCREENRECORD_DIR` to change that — but note that unlike the screenshot directory, this one has to exist already, or the recording refuses to start.
+On Apple Silicon, `Super + Alt + Fn + F12` starts a fullscreen recording
+immediately without audio. The same hotkey stops it.
+
+Recording normally runs on gpu-screen-recorder, which encodes on the GPU at
+60fps and falls back to the CPU if it has to. On Apple Silicon it uses
+wf-recorder with CPU encoding because the Asahi GPU has no supported hardware
+video encoder. The result is an MP4 in `~/Videos`, named
+`screenrecording-2026-08-13_14-22-05.mp4`. Set `OMARCHY_SCREENRECORD_DIR` to
+change that — but note that unlike the screenshot directory, this one has to
+exist already, or the recording refuses to start.
 
 While you're recording, a little indicator shows up in the bar. Click it to stop. You can also stop with `Alt + Print Screen` again, or with the _Stop Screenrecording_ entry under _Trigger > Capture > Screenrecord_, which only appears while something is actually recording.
 

--- a/manual/12-screenshots-recording.md
+++ b/manual/12-screenshots-recording.md
@@ -13,13 +13,13 @@ keyboards also have direct F-key alternatives:
 | `Super + Ctrl + Print Screen` | Extract text from a region |
 | `Super + Ctrl + C` | Capture menu |
 | `Super + Ctrl + .` | Transcode a picture or video |
-| `Super + Fn + F10` | Screenshot a window on an Apple keyboard |
-| `Super + Fn + F11` | Screenshot a region on an Apple keyboard |
-| `Super + Fn + F12` | Screenshot the full display on an Apple keyboard |
-| `Super + Alt + Fn + F12` | Start/stop fullscreen recording without audio on an Apple keyboard |
+| `Super + F10` | Screenshot a window on an Apple keyboard |
+| `Super + F11` | Screenshot a region on an Apple keyboard |
+| `Super + F12` | Screenshot the full display on an Apple keyboard |
+| `Super + Alt + F12` | Start/stop fullscreen recording without audio on an Apple keyboard |
 
-Omarchy configures the top row on Apple keyboards as media keys. Hold `Fn` in
-these shortcuts so the keys emit F10-F12.
+Omarchy configures the top row on Apple keyboards as media keys, and binds both
+the media keycodes and F10-F12. These shortcuts work with or without `Fn`.
 
 ## Screenshots
 
@@ -48,8 +48,8 @@ The arrows and Tab move the cursor to the window they pick, so the highlight fol
 
 `Alt + Print Screen` opens _Trigger > Capture > Screenrecord_, which asks what you want on the soundtrack: no audio, desktop audio, desktop plus microphone, or desktop plus microphone plus webcam. That last one only shows up if you actually have a camera plugged in. Pick one and you get the same picker as a screenshot: drag a region, or click a window or monitor.
 
-On Apple Silicon, `Super + Alt + Fn + F12` starts a fullscreen recording
-immediately without audio. The same hotkey stops it.
+On Apple Silicon, `Super + Alt + F12` starts a fullscreen recording immediately
+without audio. The same hotkey stops it, and holding `Fn` works too.
 
 Recording normally runs on gpu-screen-recorder, which encodes on the GPU at
 60fps and falls back to the CPU if it has to. On Apple Silicon it uses

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -37,6 +37,19 @@ o.window("(Alacritty|kitty|foot)", { scroll_touchpad = 1.5 })
 
 You can [see all the input options](https://wiki.hypr.land/Configuring/Basics/Variables/#input) on the Hyprland wiki for inputs.
 
+### Apple keyboard and trackpad defaults
+
+On an Apple keyboard, Command is the `Super` key used throughout this manual.
+The top row behaves as it does in macOS: press a key by itself for its media
+function, or hold `Fn` to send F1-F12.
+
+The Mac-specific brightness and capture combinations are listed in
+[Hotkeys](07-hotkeys.md).
+
+Apple trackpads default to natural scrolling, physical clicks instead of
+tap-to-click, two-finger right-click, and a `0.4` scroll factor. Override any
+of these in `~/.config/hypr/input.lua` using the options shown above.
+
 ### Trackpad gestures
 
 You can also turn on [touchpad gestures](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/), like swiping with three fingers to change workspaces:

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -41,7 +41,8 @@ You can [see all the input options](https://wiki.hypr.land/Configuring/Basics/Va
 
 On an Apple keyboard, Command is the `Super` key used throughout this manual.
 The top row behaves as it does in macOS: press a key by itself for its media
-function, or hold `Fn` to send F1-F12.
+function, or hold `Fn` to send F1-F12. Omarchy binds its Mac-specific capture
+shortcuts to both forms, so `Fn` is optional for those combinations.
 
 The Mac-specific brightness and capture combinations are listed in
 [Hotkeys](07-hotkeys.md).


### PR DESCRIPTION
closes #195

documents Mac-specific keyboard, capture, and trackpad behavior already configured in the codebase

- adds apple screenshot and recording shortcuts
- corrects keyboard brightness bindings
- explains command/super and FN behavior
- documents pple trackpad defaults

verified against the current configuration 

M1/M2 hardware confirmation is welcome 😄 