### PR TITLE
Drain stdin in the keyboard test's gum stub

### DIFF
--- a/tests/test-keyboard-layouts.sh
+++ b/tests/test-keyboard-layouts.sh
@@ -40,8 +40,12 @@ pick() {
   local selection="$1"
   rm -rf "$WORK/bin"
   mkdir -p "$WORK/bin"
+  # The prompt pipes the layout list into gum, so the stub has to drain stdin:
+  # exiting first kills cut with SIGPIPE, and pipefail reads that as a failed
+  # prompt, which returns before any of the variables below are set.
   cat >"$WORK/bin/gum" <<STUB
 #!/bin/bash
+cat >/dev/null
 printf '%s\n' '$selection'
 STUB
   chmod +x "$WORK/bin/gum"


### PR DESCRIPTION
`tests/test-keyboard-layouts.sh`, added in #196, fails intermittently — 6 of 10 runs here, on a different layout each time, which reads like a bad mapping and isn't one.

The prompt is `printf … | cut -d'|' -f1 | gum choose …`. The test's `gum` stub prints its answer and exits without reading stdin, so `cut` takes SIGPIPE; under `pipefail` the prompt treats that as a failed selection and returns before setting `keyboard`, `keyboard_xkb_layout` or `keyboard_xkb_variant`, leaving the assertions comparing empty strings. Whether it fires depends on whether `cut` finishes writing 48 lines before the stub exits.

Draining stdin in the stub fixes it: 12 of 12 runs clean before rebase, 8 of 8 after. Same trap as the one `brcmfmac-supplicant-test.sh` documents for #6608.
