### PR TITLE
Seed the SDDM user on first install

### DIFF
--- a/install/login/sddm.sh
+++ b/install/login/sddm.sh
@@ -1,7 +1,19 @@
 # Prevent password-based SDDM logins from creating an encrypted login keyring
 # that conflicts with Omarchy's passwordless default keyring behavior. The ISO
 # owns autologin/session state because it knows whether the target is encrypted.
-if [[ -f /etc/pam.d/sddm ]]; then
-  sed -i '/-auth.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
-  sed -i '/-password.*pam_gnome_keyring\.so/d' /etc/pam.d/sddm
+pam_file="${OMARCHY_SDDM_PAM_FILE:-/etc/pam.d/sddm}"
+state_file="${OMARCHY_SDDM_STATE_FILE:-/var/lib/sddm/state.conf}"
+
+if [[ -f $pam_file ]]; then
+  sed -i '/-auth.*pam_gnome_keyring\.so/d' "$pam_file"
+  sed -i '/-password.*pam_gnome_keyring\.so/d' "$pam_file"
+fi
+
+# The by-hand Mac install has no ISO provisioning step to seed Last/User. The
+# theme submits userModel.lastUser, so a missing state file logs in as an empty
+# username. Preserve state supplied by the ISO or a previous SDDM login.
+if (( ${OMARCHY_FIRST_INSTALL:-0} )) &&
+  [[ -n ${OMARCHY_INSTALL_USER:-} && ! -e $state_file ]]; then
+  mkdir -p "$(dirname "$state_file")"
+  printf '[Last]\nUser=%s\n' "$OMARCHY_INSTALL_USER" >"$state_file"
 fi

--- a/test/shell.d/sddm-login-test.sh
+++ b/test/shell.d/sddm-login-test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+pam_file="$test_tmp/etc/pam.d/sddm"
+state_file="$test_tmp/var/lib/sddm/state.conf"
+
+run_sddm_setup() {
+  OMARCHY_SDDM_PAM_FILE="$pam_file" \
+    OMARCHY_SDDM_STATE_FILE="$state_file" \
+    OMARCHY_FIRST_INSTALL="${OMARCHY_FIRST_INSTALL:-0}" \
+    OMARCHY_INSTALL_USER="${OMARCHY_INSTALL_USER:-}" \
+    bash -e "$ROOT/install/login/sddm.sh"
+}
+
+OMARCHY_FIRST_INSTALL=1 OMARCHY_INSTALL_USER=owner run_sddm_setup
+[[ -f $state_file ]] ||
+  fail "first install seeds SDDM's last user"
+[[ $(cat "$state_file") == $'[Last]\nUser=owner' ]] ||
+  fail "SDDM state names the install user" "$(cat "$state_file")"
+pass "first install seeds SDDM's last user"
+
+printf '[Last]\nSession=custom.desktop\nUser=existing\n' >"$state_file"
+OMARCHY_FIRST_INSTALL=1 OMARCHY_INSTALL_USER=owner run_sddm_setup
+[[ $(cat "$state_file") == $'[Last]\nSession=custom.desktop\nUser=existing' ]] ||
+  fail "first install preserves existing SDDM state" "$(cat "$state_file")"
+pass "first install preserves existing SDDM state"
+
+rm -f "$state_file"
+OMARCHY_FIRST_INSTALL=0 OMARCHY_INSTALL_USER=owner run_sddm_setup
+[[ ! -e $state_file ]] ||
+  fail "upgrade does not create SDDM state"
+pass "upgrade does not create SDDM state"
+
+OMARCHY_FIRST_INSTALL=1 OMARCHY_INSTALL_USER="" run_sddm_setup
+[[ ! -e $state_file ]] ||
+  fail "deferred provisioning does not create SDDM state without a user"
+pass "deferred provisioning does not create SDDM state without a user"


### PR DESCRIPTION
Closes #212

Seeds `/var/lib/sddm/state.conf` with the install user when the manual first-install path has no existing SDDM state. The theme reads `userModel.lastUser`; without this file it submits an empty username and rejects a valid password.

Existing ISO or previous-login state is preserved, and upgrades or deferred provisioning do not create a user entry.

Tests:
- `bash test/shell.d/sddm-login-test.sh`
- `bash test/shell.d/install-mac-test.sh`
- `bash test/shell.d/install-stage-wiring-test.sh`
- `bash -n install/login/sddm.sh test/shell.d/sddm-login-test.sh`