### PR TITLE
Fix Quattro upgrade package pass on aarch64 (#208)

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -134,6 +134,26 @@ switch_checkout_to_quattro() {
   git -C "$checkout" merge --ff-only "origin/$upgrade_ref"
 }
 
+# A 3.x machine's /etc/pacman.conf predates the [omarchy-aarch64] repo. Without
+# it, every Quattro package that the ARM repo serves as a prebuilt binary
+# resolves to an hours-long AUR build instead -- quickshell-git's build even
+# fails outright on Wayland-only systems whose GL stack predates the upgrade
+# (#208). Mirrors install.sh's ensure_arm_package_repo; must run before
+# install_quattro_packages.
+ensure_arm_package_repo() {
+  grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf && return 0
+
+  local block
+  block=$(sed -n '/^\[omarchy-aarch64\]/,/^Server[[:space:]]*=/p' \
+    "$checkout/default/pacman/pacman-stable.conf")
+  [[ -n $block ]] || fail "default/pacman/pacman-stable.conf has no [omarchy-aarch64] section."
+
+  log "Adding the Omarchy ARM package repo"
+  printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
+  sudo pacman -Sy --noconfirm >/dev/null 2>&1 ||
+    warn "Could not refresh package databases after adding the ARM repo."
+}
+
 install_quattro_packages() {
   local package skipped=()
 
@@ -276,6 +296,7 @@ switch_to_networkmanager() {
 main() {
   backup_user_config
   switch_checkout_to_quattro
+  ensure_arm_package_repo
   install_quattro_packages
   wire_system_paths
   update_bashrc

--- a/install/omarchy-aarch64-unavailable.packages
+++ b/install/omarchy-aarch64-unavailable.packages
@@ -24,14 +24,13 @@ obs-studio
 # emitting a misleading "skipped" warning for a package that cannot install here.
 dotnet-runtime
 
-# quickshell-git builds on aarch64 -- and then the build is thrown away. The
-# omarchy package depends on plain `quickshell`, which Arch Linux ARM now ships
-# in extra (0.3.0-2), so pacman satisfies the dependency from the repo and the
-# freshly compiled quickshell-git is never installed. Measured on a clean
-# install: the artifact sat unused in yay's cache while `pacman -Qi quickshell`
-# reported the repo package installed as a dependency of omarchy. Skipping it
-# changes nothing about what ends up on the machine, and drops a Qt/C++ compile
-# plus its cli11 and vulkan-headers makedepends from every install.
+# quickshell-git builds on aarch64, but the package pass skips it anyway: the
+# omarchy package depends on plain `quickshell`, which Arch Linux ARM ships in
+# extra (0.3.0-2), and installing both in one pass would fight over the
+# conflict. Migration 1784672586 swaps plain quickshell for the quickshell-git
+# binary from the [omarchy-aarch64] repo at login; until that binary is
+# published, the desktop stays on the repo package and only synchronous shell
+# restarts wait-for-exit is lost.
 quickshell-git
 
 # pinta is arch=('x86_64') in the AUR, so makepkg refuses it in seconds -- but

--- a/migrations/1784672586.sh
+++ b/migrations/1784672586.sh
@@ -1,6 +1,17 @@
 echo "Switch to the Omarchy quickshell-git build so shell restarts wait for instance exit"
 
 if ! omarchy-pkg-present quickshell-git; then
+  # pacman only resolves packages from sync repos, and quickshell-git is served
+  # by the [omarchy-aarch64] repo. If this machine cannot see it there -- a 3.x
+  # pacman.conf predating the repo section, or the binary not published yet --
+  # skip instead of failing: a failed migration aborts omarchy-migrate's whole
+  # run and retries at every login. Plain quickshell keeps the desktop working;
+  # only synchronous shell restarts wait-for-exit is lost until it appears.
+  if ! pacman -Si quickshell-git &>/dev/null; then
+    echo "quickshell-git is not in any configured repo; keeping plain quickshell" >&2
+    exit 0
+  fi
+
   # One transaction with --ask 4 so pacman accepts replacing the conflicting
   # quickshell package in place; packages depending on quickshell stay
   # satisfied through the provides.

--- a/test/shell.d/aarch64-packages-test.sh
+++ b/test/shell.d/aarch64-packages-test.sh
@@ -60,3 +60,27 @@ set_call=$(grep -n '^  install_default_package_set$' "$ROOT/install.sh" | cut -d
 (( repo_call < set_call )) ||
   fail "the ARM repo is added before the default package set is installed"
 pass "the ARM repo is added before the default package set is installed"
+
+# The Quattro upgrade has the same trap with a twist: a 3.x machine's
+# /etc/pacman.conf predates the ARM repo entirely, and installing packages
+# first sent quickshell-git to an AUR build that fails on Wayland-only GL
+# stacks (#208). The upgrade must wire the repo in from its own fresh checkout
+# before the package pass.
+repo_call=$(grep -n '^  ensure_arm_package_repo$' "$ROOT/bin/omarchy-upgrade-to-quattro-mac" | cut -d: -f1)
+checkout_call=$(grep -n '^  switch_checkout_to_quattro$' "$ROOT/bin/omarchy-upgrade-to-quattro-mac" | cut -d: -f1)
+set_call=$(grep -n '^  install_quattro_packages$' "$ROOT/bin/omarchy-upgrade-to-quattro-mac" | cut -d: -f1)
+[[ -n $repo_call && -n $checkout_call && -n $set_call ]] ||
+  fail "the upgrade switches checkout, adds the ARM repo, and installs the set"
+(( checkout_call < repo_call )) ||
+  fail "the ARM repo block is read from the Quattro checkout, so switch first"
+(( repo_call < set_call )) ||
+  fail "the upgrade adds the ARM repo before installing the Quattro set"
+pass "the Quattro upgrade adds the ARM repo before installing packages"
+
+# Migration 1784672586 swaps plain quickshell for quickshell-git with a raw
+# pacman call, which only resolves sync-repo targets. Without an availability
+# guard, machines that cannot see the ARM repo fail the migration outright --
+# and one failed migration aborts omarchy-migrate's whole run at every login.
+grep -qF 'pacman -Si quickshell-git' "$ROOT/migrations/1784672586.sh" ||
+  fail "the quickshell-git migration checks sync-repo availability before pacman"
+pass "the quickshell-git migration skips cleanly when the repo cannot serve it"


### PR DESCRIPTION
## The issue

#208: `omarchy-upgrade-to-quattro-mac` fails to install `quickshell-git` on Apple Silicon, and the failure cascades:

1. **The upgrade installs packages before any pacman config wiring.** A 3.x machine's `/etc/pacman.conf` predates the `[omarchy-aarch64]` repo section entirely (3.x never shipped it), so every Quattro package that the ARM repo serves as a prebuilt binary resolves to an AUR source build instead.
2. **The `quickshell-git` source build dies in CMake.** `FindOpenGL` can't satisfy Qt6Gui's `WrapOpenGL`: it wants GLVND's `libOpenGL.so`/`libGLX.so`, which were absent on the reporter's Wayland-only GL stack at build time. (ALARM's `libglvnd` 1.7.0-3 does ship both files, so a healthy system builds fine — but nobody should compile Qt for half an hour per machine regardless.)
3. **Migration `1784672586` then wedges all migrations.** It calls raw `sudo pacman -S quickshell-git`, and pacman only resolves sync-repo targets — `quickshell-git` is not published to `[omarchy-aarch64]` yet — so it fails "target not found", aborting `omarchy-migrate`'s `-euo pipefail` run and retrying at every login.

## The fix

- **`bin/omarchy-upgrade-to-quattro-mac`**: add `ensure_arm_package_repo` (verbatim pattern from `install.sh`) and run it after switching to the Quattro checkout but before `install_quattro_packages`. Now yay sees published binaries for the whole pass — not just quickshell-git, but also herdr, omacalc, omacut, omawrite, localsend, etc.
- **`migrations/1784672586.sh`**: guard with `pacman -Si quickshell-git`; when no configured repo can serve the binary, warn and exit cleanly instead of failing. Plain quickshell keeps the desktop working; only synchronous shell restarts wait-for-exit is lost until the binary appears.
- **`install/omarchy-aarch64-unavailable.packages`**: refresh the stale quickshell-git rationale to describe the migration-swap mechanism.
- **`test/shell.d/aarch64-packages-test.sh`**: assert the upgrade orders repo-before-packages (mirroring the existing installer ordering assertion) and that the migration checks sync-repo availability.

## How it works

The fresh-install path already solved this exact ordering problem (`ensure_arm_package_repo` runs before the package set, with a test asserting the order); the upgrade path was missed. This ports the same mechanism into the self-contained upgrade script — it reads the repo block out of the freshly checked out `default/pacman/pacman-stable.conf`, appends it to `/etc/pacman.conf`, and refreshes databases before any package is requested. With that in place:

- Once `quickshell-git` is published via `omarchy-pkg-publish-aarch64 quickshell-git` (the tooling exists and defaults to this package), both the upgrade's yay loop and the migration's pacman call resolve it instantly as an aarch64 binary.
- Until then, every path degrades gracefully: skipped packages are logged by the upgrade, and the migration skips with a warning rather than blocking later migrations forever.

**Follow-up ops step:** publish the binary from Apple Silicon hardware — `omarchy-pkg-publish-aarch64 quickshell-git`.

## Compatibility

Purely aarch64-targeted shell logic; x86_64 paths untouched. The published package is natively built via makepkg on Apple Silicon (`arch=(x86_64 aarch64)` in the upstream PKGBUILD).

## Verification

- `test/shell.d/aarch64-packages-test.sh` passes (8/8)
- `bin/omarchy commands --check` passes
- No new failures vs baseline in `./test/shell`

Fixes #208