### PR TITLE
fix(menu): show Mac F-key names for brightness keys in keybindings menu

### DIFF
--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -59,6 +59,12 @@ parse_keycodes() {
         symbol = mouse_symbol[code]
         if (symbol == "") symbol = "mouse:" code
         sub("mouse:" code, symbol)
+      } else {
+        # On Apple Silicon MacBooks XF86MonBrightnessUp/Down ARE the physical
+        # F2/F1 keys (verified on apple,j414c), so name the physical key
+        # instead of leaking raw XKB symbols into the menu. Issue #194.
+        gsub(/XF86MonBrightnessUp/, "F2")
+        gsub(/XF86MonBrightnessDown/, "F1")
       }
 
       print

--- a/bin/omarchy-menu-keybindings
+++ b/bin/omarchy-menu-keybindings
@@ -536,7 +536,7 @@ output_binding_records_uncached() {
 
 keybindings_cache_key() {
   {
-    printf 'v13\n'
+    printf 'v14\n'
     hyprctl devices 2>/dev/null | grep -F 'active keymap:'
     hyprctl binds 2>/dev/null
   } | sha256sum | awk '{ print $1 }'

--- a/test/shell.d/menu-keybindings-fkeys-test.sh
+++ b/test/shell.d/menu-keybindings-fkeys-test.sh
@@ -74,14 +74,26 @@ KEYMAP
 SH
 chmod +x "$mock_bin/xkbcli"
 
-# Pre-seed a v13-era cache file: stale rendering must NOT be served even
-# though the mocked inputs (keymap, binds) are identical to its own run.
+cat >"$mock_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 1
+SH
+chmod +x "$mock_bin/omarchy-cmd-present"
+
+# Pre-seed the exact cache file that v13 production would read for these
+# mocked inputs. Cached records use the rendered row as field 1, followed by
+# the dispatcher and argument fields.
 mkdir -p "$cache_dir/omarchy"
-v13_key=$(printf 'v13\nApple Keyboard (apple_vndr)\n' | sha256sum | awk '{ print $1 }')
+v13_key=$({
+  printf 'v13\n'
+  "$mock_bin/hyprctl" devices 2>/dev/null | grep -F 'active keymap:'
+  "$mock_bin/hyprctl" binds 2>/dev/null
+} | sha256sum | awk '{ print $1 }')
 cat >"$cache_dir/omarchy/keybindings-$v13_key.records" <<'EOF'
-1	SHIFT + XF86MonBrightnessUp	Keyboard brightness up
-8	ALT + XF86MonBrightnessUp	Brightness up precise
-64	SUPER + Q	Close window
+SHIFT + XF86MonBrightnessUp → Keyboard brightness up	exec	omarchy-brightness-keyboard up
+SHIFT + XF86MonBrightnessDown → Keyboard brightness down	exec	omarchy-brightness-keyboard down
+ALT + XF86MonBrightnessUp → Brightness up precise	exec	omarchy-brightness-display +1%
+SUPER + Q → Close window	killactive
 EOF
 
 output=$(PATH="$mock_bin:$PATH" XDG_CACHE_HOME="$cache_dir" "$ROOT/bin/omarchy-menu-keybindings" --print)

--- a/test/shell.d/menu-keybindings-fkeys-test.sh
+++ b/test/shell.d/menu-keybindings-fkeys-test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# The keybindings menu must show Mac physical key names: on Apple Silicon
+# MacBook keyboards XF86MonBrightnessUp/Down ARE F2/F1, so raw symbols leak
+# meaningless rows like "SHIFT + XF86MonBrightnessUp" (issue #194).
+# Regression guard for the cache too: a pre-seeded stale cache file from the
+# v13 era must not win over current rendering (cache key bumped to v14).
+
+mock_bin=$(mktemp -d)
+cache_dir=$(mktemp -d)
+cleanup() {
+  rm -rf "$mock_bin" "$cache_dir"
+}
+trap cleanup EXIT
+
+cat >"$mock_bin/hyprctl" <<'SH'
+#!/bin/bash
+if [[ $1 == "devices" ]]; then
+  echo "Keyboards:"
+  echo "	active keymap: Apple Keyboard (apple_vndr)"
+  exit 0
+fi
+cat <<'BINDS'
+bindl
+	modmask: 1
+	key: XF86MonBrightnessUp
+	keycode: 0
+	description: Keyboard brightness up
+	dispatcher: exec
+	arg: omarchy-brightness-keyboard up
+
+bindl
+	modmask: 1
+	key: XF86MonBrightnessDown
+	keycode: 0
+	description: Keyboard brightness down
+	dispatcher: exec
+	arg: omarchy-brightness-keyboard down
+
+bindi
+	modmask: 8
+	key: XF86MonBrightnessUp
+	keycode: 0
+	description: Brightness up precise
+	dispatcher: exec
+	arg: omarchy-brightness-display +1%
+
+bindm
+	modmask: 64
+	key: Q
+	keycode: 0
+	description: Close window
+	dispatcher: killactive
+	arg:
+BINDS
+SH
+chmod +x "$mock_bin/hyprctl"
+
+# Minimal valid keymap so keycode resolution has something to chew on.
+cat >"$mock_bin/xkbcli" <<'SH'
+#!/bin/bash
+cat <<'KEYMAP'
+xkb_keycodes {
+    <AD01> = 24;
+};
+xkb_symbols {
+    key <AD01> { [ q ] };
+};
+KEYMAP
+SH
+chmod +x "$mock_bin/xkbcli"
+
+# Pre-seed a v13-era cache file: stale rendering must NOT be served even
+# though the mocked inputs (keymap, binds) are identical to its own run.
+mkdir -p "$cache_dir/omarchy"
+v13_key=$(printf 'v13\nApple Keyboard (apple_vndr)\n' | sha256sum | awk '{ print $1 }')
+cat >"$cache_dir/omarchy/keybindings-$v13_key.records" <<'EOF'
+1	SHIFT + XF86MonBrightnessUp	Keyboard brightness up
+8	ALT + XF86MonBrightnessUp	Brightness up precise
+64	SUPER + Q	Close window
+EOF
+
+output=$(PATH="$mock_bin:$PATH" XDG_CACHE_HOME="$cache_dir" "$ROOT/bin/omarchy-menu-keybindings" --print)
+
+tr -s ' ' <<<"$output" | grep -qF 'SHIFT + F2 → Keyboard brightness up' || \
+  fail "SHIFT + XF86MonBrightnessUp renders as SHIFT + F2 with its description" "$output"
+
+tr -s ' ' <<<"$output" | grep -qF 'SHIFT + F1 → Keyboard brightness down' || \
+  fail "SHIFT + XF86MonBrightnessDown renders as SHIFT + F1 with its description" "$output"
+
+tr -s ' ' <<<"$output" | grep -qF 'ALT + F2 → Brightness up precise' || \
+  fail "modifier combos keep the F-key name (ALT + F2)" "$output"
+
+grep -qF 'XF86MonBrightness' <<<"$output" && \
+  fail "raw XF86MonBrightness symbols no longer leak into the menu" "$output"
+
+tr -s ' ' <<<"$output" | grep -qF 'SUPER + Q → Close window' || \
+  fail "unrelated bindings render unchanged (SUPER + Q)" "$output"
+
+pass "keybindings menu shows Mac physical key names (F1/F2), stale caches ignored"


### PR DESCRIPTION
## Problem

The keybindings menu shows XKB symbol names instead of the physical Mac keys they represent. On Apple Silicon MacBook keyboards, `XF86MonBrightnessUp`/`XF86MonBrightnessDown` are emitted by the F2/F1 keys, so users see rows like `SHIFT + XF86MonBrightnessUp` even though the repo's own comments describe these binds as "SHIFT+F1/F2" (`default/hypr/bindings/media.lua`). That is exactly the gap reported in #194: Omarchy Mac specific keybindings missing from the menu "with proper names".

## Approach

Extend the existing key-name mapping in `bin/omarchy-menu-keybindings` (the same `case` that already maps `comma`→`COMMA`, `period`→`PERIOD`, etc.):

- `XF86MonBrightnessUp` → `F2`
- `XF86MonBrightnessDown` → `F1`

Menu rows now render as `SHIFT + F2 → Keyboard brightness up` and `ALT + F1 → Brightness down precise`. All other bindings, including non-Mac keyboards where those symbols may come from real brightness keys, keep working; only the display name changes.

Alternatives considered: renaming the keys inside Hyprland config (would change bind matching, not just display), or special-casing descriptions (descriptions already exist and are fine). The menu script is the single display surface, so it is the right place.

## Testing

- New regression test `test/shell.d/menu-keybindings-fkeys-test.sh`: stubs `hyprctl binds` with the exact SHIFT+F1/F2 and ALT-precise records plus an unrelated SUPER+Q bind, runs `omarchy-menu-keybindings --print`, and asserts the F-key rendering, the untouched neighbor row, and no raw `XF86MonBrightness` leak.
- Verified RED on unfixed code and GREEN with the fix; a sabotage run (fix reverted) fails the test as expected.
- `bash -n` clean on changed scripts. Full `./test/all`: 97 of 194 shell test
  files fail on this Windows dev host; verified via a pristine worktree at the
  base commit that exactly those 97 fail identically without this change (plus
  one load-order flake, `launch-shell-test.sh`, which passes standalone on both
  trees). The new regression test passes in-suite and standalone.

Disclosure: prepared by the sambai-dev agent (Hermes) under human supervision of the diff, per the note on the tracking issue comment.
