### PR TITLE
Prefer the DCP panel backlight on Apple Silicon Macs

### DIFF
--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -11,9 +11,10 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
 # gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
 # dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
-# apple-panel-bl is the DCP panel backlight on Apple Silicon. Some of those Macs also
-# expose a DSI backlight that sorts first alphabetically and accepts writes without
-# driving the panel, so prefer the real one when present.
+# apple-panel-bl is the DCP panel backlight on Apple Silicon. On M1 MacBook Pros the
+# Touch Bar's own MIPI panel registers a DSI backlight (apple,summit, e.g. 228600000.dsi.0)
+# that sorts first alphabetically: brightness controls would visibly dim the Touch Bar
+# while the screen stays unchanged. Prefer the panel's backlight when present.
 for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/apple-panel-bl "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"

--- a/bin/omarchy-hw-display
+++ b/bin/omarchy-hw-display
@@ -11,7 +11,10 @@ backlight_path="${OMARCHY_BACKLIGHT_PATH:-/sys/class/backlight}"
 device="$(ls -1 "$backlight_path" 2>/dev/null | grep -vx appletb_backlight | head -n1)"
 # gmux comes first: apple-gmux only registers when the kernel has already picked it, and on
 # dual-GPU Macs the GPU's own PWM stops driving the panel once that GPU suspends.
-for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
+# apple-panel-bl is the DCP panel backlight on Apple Silicon. Some of those Macs also
+# expose a DSI backlight that sorts first alphabetically and accepts writes without
+# driving the panel, so prefer the real one when present.
+for candidate in "$backlight_path"/gmux_backlight "$backlight_path"/apple-panel-bl "$backlight_path"/amdgpu_bl* "$backlight_path"/intel_backlight "$backlight_path"/acpi_video*; do
   if [[ -e $candidate ]]; then
     device="${candidate##*/}"
     break


### PR DESCRIPTION
## Problem

On Apple Silicon Macs running Asahi, the brightness slider and hardware keys update the OSD value but the panel brightness never actually changes — while the **Touch Bar's** brightness visibly does change.

## Root cause

On M1 MacBook Pros (verified on a 13-inch, M1, 2020), Asahi exposes **two** backlight class devices:

- `228600000.dsi.0` — the Touch Bar's own MIPI panel backlight (`apple,summit` compatible string, driven by `adpdrm_mipi`, DRM connector `card2-DSI-1`). It accepts writes and really does dim the Touch Bar.
- `apple-panel-bl` — the real DCP panel backlight.

`omarchy-hw-display` starts with the first entry in `ls -1` order and refines via known candidates (`gmux_backlight`, `amdgpu_bl*`, `intel_backlight`, `acpi_video*`). The Touch Bar device sorts first alphabetically and none of the candidates match on Apple Silicon, so brightness controls were adjusting the Touch Bar instead of the screen. This is the Apple Silicon sibling of the already-handled T2 case (`appletb_backlight` is filtered explicitly).

## Fix

Add `$backlight_path/apple-panel-bl` as a refinement candidate, right after `gmux_backlight`. It only exists when the DCP panel backlight driver has registered, so this is safe on all other hardware.

## Testing

- `bash -n` passes
- On an affected machine (Omarchy 4.0.1rc1, MacBook Pro 13" M1 2020): script now resolves `apple-panel-bl`; brightness slider and keys work end-to-end, Touch Bar no longer dims
- `./test/all`: the only failures are 5 pre-existing `test/shell.d/*` files that fail identically on a clean checkout of `quattro`; no new failures introduced