### PR TITLE
Install rtkit with the Apple Silicon audio stack

### DIFF
--- a/install/hardware/apple/audio.sh
+++ b/install/hardware/apple/audio.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Sound on Apple Silicon needs two things this install would otherwise never
-# get, for two different reasons.
+# Sound on Apple Silicon needs three things this install would otherwise never
+# get, for three different reasons.
 #
 # PipeWire's PulseAudio server: install/omarchy-other.packages lists
 # pipewire-pulse and says why it is not in the base set -- "Utilized by ISO
@@ -10,6 +10,13 @@
 # nothing can talk to: pactl says "Connection refused", and every Omarchy audio
 # command exits 1 -- the volume and mute keys do nothing while brightness works
 # fine, because brightness never touches PulseAudio.
+#
+# Realtime scheduling: rtkit is only an optional dependency of pipewire, so
+# nothing here would pull it in. Without it pipewire's data threads run at
+# normal priority, and any load spike delays the DSP cycle long enough to
+# underrun -- heard as crackling or popping that gets worse under load. The
+# Asahi speaker filter chain runs several convolvers per cycle, so it is more
+# exposed to this than a plain sink.
 #
 # Then the Apple parts: asahi-audio carries the UCM profiles and the DSP filter
 # chain that makes a speaker sink exist at all, and speakersafetyd is what
@@ -27,14 +34,14 @@ OMARCHY_ASAHI_AUDIO_PACKAGES_CHANGED=0
 
 # pkg-missing rather than a bare pkg-add, so the migration can tell whether this
 # actually installed anything and only then ask for a reboot.
-if omarchy-pkg-missing pipewire-pulse pipewire-alsa asahi-audio speakersafetyd; then
+if omarchy-pkg-missing rtkit pipewire-pulse pipewire-alsa asahi-audio speakersafetyd; then
   echo "Installing the Apple Silicon audio stack"
-  omarchy-pkg-add pipewire-pulse pipewire-alsa asahi-audio speakersafetyd ||
+  omarchy-pkg-add rtkit pipewire-pulse pipewire-alsa asahi-audio speakersafetyd ||
     echo "Warning: some audio packages could not be installed; sound may not work."
 
   # A warning rather than a failure: hardware setup runs under set -e, so failing
   # here would abort the whole install over speakers that can be fixed later.
-  if omarchy-pkg-present pipewire-pulse pipewire-alsa asahi-audio speakersafetyd; then
+  if omarchy-pkg-present rtkit pipewire-pulse pipewire-alsa asahi-audio speakersafetyd; then
     OMARCHY_ASAHI_AUDIO_PACKAGES_CHANGED=1
   else
     echo "Warning: the protected Asahi audio stack is incomplete; the speakers stay muted." >&2

--- a/test/shell.d/asahi-audio-install-test.sh
+++ b/test/shell.d/asahi-audio-install-test.sh
@@ -94,7 +94,7 @@ run_audio_setup() {
 : >"$calls"
 run_audio_setup "$leaf" aarch64 apple,j413
 
-expected_call=$'omarchy-pkg-add\tpipewire-pulse\tpipewire-alsa\tasahi-audio\tspeakersafetyd'
+expected_call=$'omarchy-pkg-add\trtkit\tpipewire-pulse\tpipewire-alsa\tasahi-audio\tspeakersafetyd'
 grep -Fxq "$expected_call" "$calls" ||
   fail "fresh Apple Silicon installs get the complete protected audio stack" "$(cat "$calls")"
 pass "fresh Apple Silicon installs get the complete protected audio stack"


### PR DESCRIPTION
## Problem

Fresh Apple Silicon installs end up without `rtkit`: it is only an *optional* dependency of pipewire, and nothing in the package sets (base, other, or `install/hardware/apple/audio.sh`) pulls it in. PipeWire then logs `RTKit error: ServiceUnknown` at every startup and its data-loop threads run at nice 0 with no realtime priority.

Without RT scheduling, any load spike delays the DSP cycle long enough to underrun the buffer — audible as crackling/popping that worsens under load. The Asahi speaker filter chain (`asahi-audio`) is more exposed than a plain sink because it runs bankstown, two loudness compensators, four convolvers, and woofer compressors every cycle.

Verified on a MacBook Pro J293 (M1) before/after installing rtkit:

- before: `ps -o rtprio -C pipewire` → `-`, journal full of RTKit errors, crackling under load
- after: all three `data-loop.0` threads at RT priority 20, zero underruns

## Fix

Add `rtkit` to the Apple Silicon audio leaf so fresh installs get it:

- `omarchy-pkg-missing` / `omarchy-pkg-add` / `omarchy-pkg-present` now include it
- the existing-install migration inherits the change automatically (it sources this leaf)
- header comment extended in the file's existing style (now three things, three reasons)

## Testing

- `test/shell.d/asahi-audio-install-test.sh` updated for the new package list: all 6 assertions pass
- `bash test/shell.d/asahi-audio-install-test.sh` → pass
- `./test/all`: 189/194 files pass; the 5 failures (`bin-style`, `config`, `locale-env`, `snapper`, `unowned-system-paths`) reproduce identically on an unmodified checkout of this commit's parent on my dev host (environment-dependent, e.g. locale resolves to `C`) and are unrelated to this change