### PR TITLE
Read charge cycles from the battery's own sysfs directory

### DIFF
--- a/bin/omarchy-battery-status
+++ b/bin/omarchy-battery-status
@@ -117,7 +117,11 @@ if [[ $shell_output == "true" ]]; then
   printf 'size\t%s\n' "${capacity}Wh"
   printf 'time\t%s\n' "$time_remaining"
 
-  cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
+  # The device's own sysfs directory first -- native-path names it, whatever
+  # it is called -- and only then the BAT* guess, which never matches
+  # macsmc-battery.
+  cycles=$(cat "$battery_path"/cycle_count 2>/dev/null | head -1)
+  [[ -z $cycles ]] && cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
 
   [[ -n $cycles ]] && printf 'cycles\t%s\n' "$cycles"
 

--- a/test/shell.d/battery-status-test.sh
+++ b/test/shell.d/battery-status-test.sh
@@ -11,6 +11,7 @@ mkdir -p "$tmp_dir/bin"
 mkdir -p "$tmp_dir/power/BAT0"
 printf '900000\n' >"$tmp_dir/power/BAT0/current_now"
 printf '12000000\n' >"$tmp_dir/power/BAT0/voltage_now"
+printf '312\n' >"$tmp_dir/power/BAT0/cycle_count"
 cat >"$tmp_dir/bin/upower" <<'STUB'
 #!/bin/bash
 
@@ -43,6 +44,7 @@ grep -Fx $'state\tdischarging' <<<"$shell_output" >/dev/null || fail "battery st
 grep -Fx $'rate\t10.8W' <<<"$shell_output" >/dev/null || fail "battery status reports live sysfs power rate"
 grep -Fx $'size\t56Wh' <<<"$shell_output" >/dev/null || fail "battery status reports full capacity"
 grep -Fx $'time\t2h 30m' <<<"$shell_output" >/dev/null || fail "battery status reports remaining time"
+grep -Fx $'cycles\t312' <<<"$shell_output" >/dev/null || fail "battery status reports charge cycles"
 
 
 # Apple Silicon names the device macsmc-battery, with no uppercase BAT
@@ -54,6 +56,7 @@ trap 'rm -rf "$tmp_dir" "$asahi_dir"' EXIT
 mkdir -p "$asahi_dir/bin" "$asahi_dir/power/macsmc-battery"
 printf '1500000\n' >"$asahi_dir/power/macsmc-battery/power_now"
 printf '80\n' >"$asahi_dir/power/macsmc-battery/charge_control_end_threshold"
+printf '405\n' >"$asahi_dir/power/macsmc-battery/cycle_count"
 cat >"$asahi_dir/bin/upower" <<'STUB'
 #!/bin/bash
 
@@ -87,6 +90,7 @@ grep -Fx $'percentage\t88%' <<<"$asahi_output" >/dev/null || fail "Apple Silicon
 grep -Fx $'size\t69Wh' <<<"$asahi_output" >/dev/null || fail "Apple Silicon capacity is read"
 grep -Fx $'rate\t1.5W' <<<"$asahi_output" >/dev/null || fail "Apple Silicon rate comes from its own sysfs"
 grep -Fx $'threshold\t80%' <<<"$asahi_output" >/dev/null || fail "Apple Silicon charge threshold is read"
+grep -Fx $'cycles\t405' <<<"$asahi_output" >/dev/null || fail "Apple Silicon charge cycles are read"
 
 pass "battery status reads an Apple Silicon battery"
 


### PR DESCRIPTION
## Problem

On Apple Silicon Macs, the battery sysfs device is named `macsmc-battery`, but the charge-cycles lookup in `omarchy-battery-status --shell` only read:

```bash
cycles=$(cat "$power_supply_path"/BAT*/cycle_count 2>/dev/null | head -1)
```

The `BAT*` glob matches nothing on these machines, so no `cycles` key was emitted and the power panel's dropdown always showed a dash for **Charge cycles**, even though the kernel exposes it fine (`/sys/class/power_supply/macsmc-battery/cycle_count`).

## Fix

Read `cycle_count` from the device's own sysfs directory first — UPower's `native-path` already names it and `` is already resolved for the threshold lookup — and keep the `BAT*` glob as the fallback for classic x86 naming. This mirrors the existing comment-and-pattern used for `charge_control_*_threshold`, which got this exact treatment for the same reason.

## Testing

- Extended `test/shell.d/battery-status-test.sh`:
  - BAT0 scenario now asserts `cycles\t312`
  - Apple Silicon scenario now asserts `cycles\t405` (its stub has no `BAT*` match at all, so this only passes via native-path resolution)
- `bash test/shell.d/battery-status-test.sh` passes; `./test/shell` shows no new failures vs. pristine `quattro` (5 pre-existing environment-dependent failures in snapper/locale/pkg-ownership tests are identical on both).
- `bin/omarchy commands --check` passes.

Verified on real hardware (Apple Silicon, Asahi): `omarchy-battery-status --shell` now emits `cycles\t405`.