### PR TITLE
Install prebuilt packages on the Quattro upgrade, not doomed AUR builds

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -182,18 +182,59 @@ ensure_arm_package_repo() {
     warn "Could not refresh package databases after adding the ARM repo."
 }
 
+# install.sh keeps the packages with no aarch64 build out of the set rather than
+# spend hours on one that fails an architecture check. The upgrade reads the same
+# list, so a 3.x machine is not the one path that still attempts them.
+load_unavailable_packages() {
+  local unavailable="$checkout/install/omarchy-aarch64-unavailable.packages" line
+
+  unavailable_packages=()
+  [[ -f $unavailable ]] || return 0
+
+  while read -r line; do
+    [[ -n $line ]] && unavailable_packages+=("$line")
+  done < <(grep -vE '^[[:space:]]*(#|$)' "$unavailable")
+}
+
+package_is_unavailable_here() {
+  local package="$1" candidate
+
+  for candidate in ${unavailable_packages[@]+"${unavailable_packages[@]}"}; do
+    [[ $candidate == "$package" ]] && return 0
+  done
+
+  return 1
+}
+
 install_quattro_packages() {
-  local package skipped=()
+  local package skipped=() unbuildable=()
+
+  load_unavailable_packages
 
   log "Installing the Quattro package set (this builds AUR packages and takes a while)"
   while read -r package; do
+    # OMARCHY_TRY_UNAVAILABLE=1 attempts them anyway: an AUR package can gain
+    # aarch64 support at any time, so a stale entry costs a flag, not a release.
+    if [[ ${OMARCHY_TRY_UNAVAILABLE:-0} != "1" ]] && package_is_unavailable_here "$package"; then
+      unbuildable+=("$package")
+      continue
+    fi
     if ! yay -S --needed --noconfirm "$package" </dev/null; then
       skipped+=("$package")
     fi
   done < <(grep -vE '^\s*(#|$)' "$checkout/install/omarchy-base.packages")
 
+  # A packaged install gets Quickshell as a dependency of the omarchy package,
+  # which this layout never installs, and quickshell-git is skipped above. Arch
+  # Linux ARM ships a prebuilt quickshell, so ask for that instead (#208).
+  yay -S --needed --noconfirm quickshell </dev/null
+
   # Apple GPUs cannot run gpu-screen-recorder; screen recording falls back to wf-recorder.
   yay -S --needed --noconfirm wf-recorder </dev/null
+
+  if (( ${#unbuildable[@]} )); then
+    log "No aarch64 build is known, so these were not attempted: ${unbuildable[*]}"
+  fi
 
   if (( ${#skipped[@]} )); then
     warn "Skipped packages that would not install on aarch64: ${skipped[*]}"

--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -227,7 +227,8 @@ install_quattro_packages() {
   # A packaged install gets Quickshell as a dependency of the omarchy package,
   # which this layout never installs, and quickshell-git is skipped above. Arch
   # Linux ARM ships a prebuilt quickshell, so ask for that instead (#208).
-  yay -S --needed --noconfirm quickshell </dev/null
+  yay -S --needed --noconfirm quickshell </dev/null ||
+    fail "Could not install quickshell, which the Quattro shell needs. Is Arch Linux ARM's extra repo reachable?"
 
   # Apple GPUs cannot run gpu-screen-recorder; screen recording falls back to wf-recorder.
   yay -S --needed --noconfirm wf-recorder </dev/null

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -117,17 +117,52 @@ pass "the upgrade one-liner agrees between the script and the guide"
 install_body=$(function_body install_quattro_packages)
 [[ -n $install_body ]] || fail "the Mac Quattro upgrade has an install_quattro_packages step"
 
-[[ $install_body == *package_is_unavailable_here* ]] ||
-  fail "the upgrade filters the package set through the aarch64 unavailable list"
-grep -qF 'OMARCHY_TRY_UNAVAILABLE' "$upgrade_to_quattro_mac" ||
-  fail "the unavailable list stays overridable on the upgrade path"
+# Naming the matcher proves nothing: without the load the list is empty and the
+# filter answers no to everything. Pin the call, its order, and the override.
+install_code=$(grep -vE '^[[:space:]]*#' <<<"$install_body")
+[[ $install_code == *load_unavailable_packages* ]] ||
+  fail "the package pass loads the aarch64 unavailable list"
+[[ ${install_code%%while read*} == *load_unavailable_packages* ]] ||
+  fail "the unavailable list is loaded before the package loop reads it"
+grep -qF '${OMARCHY_TRY_UNAVAILABLE:-0} != "1" ]] && package_is_unavailable_here' <<<"$install_code" ||
+  fail "the filter runs on the loop and stays overridable with OMARCHY_TRY_UNAVAILABLE"
 pass "the upgrade filters the package set through the aarch64 unavailable list"
 
+# Exercise the matcher against a list on disk rather than trust its name.
+matcher_probe=$(mktemp -d)
+mkdir -p "$matcher_probe/install"
+printf '# a comment\n\nlisted-package\n' >"$matcher_probe/install/omarchy-aarch64-unavailable.packages"
+(
+  checkout="$matcher_probe"
+  eval "$(awk '/^load_unavailable_packages\(\) \{/,/^\}/' "$upgrade_to_quattro_mac")"
+  eval "$(awk '/^package_is_unavailable_here\(\) \{/,/^\}/' "$upgrade_to_quattro_mac")"
+  load_unavailable_packages
+  package_is_unavailable_here listed-package || exit 1
+  ! package_is_unavailable_here some-other-package || exit 1
+) || fail "the unavailable matcher answers from the list on disk"
+rm -rf "$matcher_probe"
+pass "the unavailable matcher answers from the list on disk"
+
 # Skipping quickshell-git is only safe where something else provides Quickshell.
-# A packaged install gets it as a dependency of the omarchy package; this layout
-# installs no such package, so the upgrade has to name the prebuilt one.
+# A packaged install gets it from the omarchy package; this layout installs no
+# such package, so state the invariant rather than one spelling of it.
+quickshell_git_skipped=0
 if grep -qxF 'quickshell-git' "$ROOT/install/omarchy-aarch64-unavailable.packages"; then
-  grep -qE 'yay -S --needed --noconfirm quickshell( |$)' <<<"$install_body" ||
-    fail "the upgrade installs the prebuilt quickshell when quickshell-git is skipped"
-  pass "the upgrade installs the prebuilt quickshell when quickshell-git is skipped"
+  quickshell_git_skipped=1
+fi
+installs_quickshell=0
+if grep -qE '^[[:space:]]*yay -S .*[[:space:]]quickshell([[:space:]]|$)' <<<"$install_code"; then
+  installs_quickshell=1
+fi
+(( ! quickshell_git_skipped || installs_quickshell )) ||
+  fail "quickshell-git is skipped and nothing installs quickshell: the upgrade leaves no shell"
+pass "the upgrade always ends up with Quickshell installed"
+
+# Every other fatal step reports through fail(); a bare set -e abort here would
+# die silently after the checkout has already been switched.
+if (( installs_quickshell )); then
+  grep -A1 -E '^[[:space:]]*yay -S .*[[:space:]]quickshell([[:space:]]|$)' <<<"$install_code" |
+    grep -qF 'fail "' ||
+    fail "a failed quickshell install reports through fail(), not a silent set -e abort"
+  pass "a failed quickshell install reports through fail()"
 fi

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -110,3 +110,24 @@ doc_url=$(grep -oE 'https://[^ ]*omarchy-upgrade-to-quattro-mac' "$ROOT/docs/upg
   fail "the upgrade one-liner agrees between script and guide" "script: $script_url
 doc:    $doc_url"
 pass "the upgrade one-liner agrees between the script and the guide"
+
+# Issue #208: the package pass attempted every name in the default set, so a 3.x
+# machine spent hours on AUR builds install.sh deliberately skips -- and one of
+# them, quickshell-git, fails outright on the pre-upgrade GL stack.
+install_body=$(function_body install_quattro_packages)
+[[ -n $install_body ]] || fail "the Mac Quattro upgrade has an install_quattro_packages step"
+
+[[ $install_body == *package_is_unavailable_here* ]] ||
+  fail "the upgrade filters the package set through the aarch64 unavailable list"
+grep -qF 'OMARCHY_TRY_UNAVAILABLE' "$upgrade_to_quattro_mac" ||
+  fail "the unavailable list stays overridable on the upgrade path"
+pass "the upgrade filters the package set through the aarch64 unavailable list"
+
+# Skipping quickshell-git is only safe where something else provides Quickshell.
+# A packaged install gets it as a dependency of the omarchy package; this layout
+# installs no such package, so the upgrade has to name the prebuilt one.
+if grep -qxF 'quickshell-git' "$ROOT/install/omarchy-aarch64-unavailable.packages"; then
+  grep -qE 'yay -S --needed --noconfirm quickshell( |$)' <<<"$install_body" ||
+    fail "the upgrade installs the prebuilt quickshell when quickshell-git is skipped"
+  pass "the upgrade installs the prebuilt quickshell when quickshell-git is skipped"
+fi


### PR DESCRIPTION
`install.sh` filters the default package set through `install/omarchy-aarch64-unavailable.packages`, so a fresh install never starts a build that was measured to fail an architecture check. The upgrade never read that list, so a 3.x machine attempted every entry on it — including `quickshell-git`, whose AUR build fails outright on the GL stack that predates the upgrade. That's how #208 ended with a machine that finished upgrading and came up with no shell.

#208 wired the ARM repo in before the package pass, which fixed the packages that repo serves as prebuilt binaries. It doesn't cover `quickshell-git`, which the ARM repo has no build for — so that build was still being attempted, and still failing.

So this does both halves: apply the unavailable list on the upgrade path too (overridable with `OMARCHY_TRY_UNAVAILABLE=1`, the same escape hatch `install.sh` offers), and ask for the prebuilt `quickshell` that Arch Linux ARM ships in `extra`. The second part isn't optional — skipping `quickshell-git` is only safe where something else provides Quickshell, and unlike a packaged install this layout installs no `omarchy` package to pull it in as a dependency.

Two new assertions in `test/shell.d/upgrade-to-quattro-mac-test.sh`. I checked they actually pin the change: reverting the script turns the suite red at the filter assertion rather than staying green.

Tested: `./test/cli`, `omarchy commands --check` (440 commands) and `bash -n` over `bin/` all pass. `./test/shell` reports 5 of 194 files failing — all 5 fail identically on `quattro` without this branch, and `bin-style-test` does not name the file this touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
