### PR TITLE
Fix zram, DNS, and keyring gaps in the Apple Silicon install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 readonly checkout="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly package_output="$checkout/build-output"
+readonly asahi_alarm_key="12CE6799A94A3F1B5DDFFE88F576553597FB8FEB"
 
 # gum is how the rest of Omarchy talks to people, but it arrives with the
 # omarchy package well into this script, so every helper falls back to plain
@@ -113,23 +114,44 @@ install_omarchy_packages() {
   source /usr/share/omarchy/default/bash/env-bootstrap
 }
 
+# The Asahi Alarm image normally ships this keyring already. A generic
+# aarch64 base does not, and pacman refuses to create the asahi-alarm database
+# until its master key is trusted. Install the keyring before the first refresh
+# so later AUR and ARM-repo package operations do not fail with a misleading
+# "database does not exist" error.
+ensure_asahi_alarm_keyring() {
+  grep -q '^\[asahi-alarm\]' /etc/pacman.conf || return 0
+  pacman -Q asahi-alarm-keyring >/dev/null 2>&1 && return 0
+
+  if ! sudo pacman-key --list-keys "$asahi_alarm_key" >/dev/null 2>&1; then
+    log "Importing the Asahi Alarm package signing key"
+    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keys.openpgp.org
+  fi
+  sudo pacman-key --lsign-key "$asahi_alarm_key" >/dev/null
+
+  log "Installing the Asahi Alarm package keyring"
+  sudo pacman -Sy --needed --noconfirm asahi-alarm-keyring
+}
+
 # Compared in bash rather than with grep against a process substitution, which
 # ugrep answers differently from GNU grep.
 # The shipped pacman.conf only lands during post-install, after the package set
 # is already installed, so the repo has to be added now: otherwise herdr builds
 # zig0.15 from source for two hours and aarch64 rejects it anyway.
 ensure_arm_package_repo() {
-  grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf && return 0
+  if ! grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf; then
+    local block
+    block=$(sed -n '/^\[omarchy-aarch64\]/,/^Server[[:space:]]*=/p' \
+      "$checkout/default/pacman/pacman-stable.conf")
+    [[ -n $block ]] || fail "default/pacman/pacman-stable.conf has no [omarchy-aarch64] section."
 
-  local block
-  block=$(sed -n '/^\[omarchy-aarch64\]/,/^Server[[:space:]]*=/p' \
-    "$checkout/default/pacman/pacman-stable.conf")
-  [[ -n $block ]] || fail "default/pacman/pacman-stable.conf has no [omarchy-aarch64] section."
+    log "Adding the Omarchy ARM package repo"
+    printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
+  fi
 
-  log "Adding the Omarchy ARM package repo"
-  printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
-  sudo pacman -Sy --noconfirm >/dev/null 2>&1 ||
-    warn "Could not refresh package databases after adding the ARM repo."
+  ensure_asahi_alarm_keyring
+  log "Refreshing package databases for ARM packages"
+  sudo pacman -Sy --noconfirm
 }
 
 load_unavailable_packages() {

--- a/install/hardware/network.sh
+++ b/install/hardware/network.sh
@@ -52,7 +52,12 @@ if systemctl is-active --quiet NetworkManager.service 2>/dev/null; then
   systemctl stop systemd-networkd.service 2>/dev/null || true
 fi
 
-# enable-services.sh turns systemd-resolved on, but nothing points resolv.conf
-# at its stub, so a fresh install reboots with whatever the old resolver left
-# behind and cannot resolve a hostname. The Quattro upgrade already does this.
-ln -sfn ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+# Prefer systemd-resolved's stub when it is already available. During a live
+# install enable-services.sh only enables daemons; it deliberately does not
+# start them before reboot. Do not replace a working resolver with a dangling
+# stub link in that window, or later hardware setup loses network access.
+if [[ -e /run/systemd/resolve/stub-resolv.conf ]]; then
+  ln -sfn ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+elif [[ -e /run/NetworkManager/resolv.conf ]]; then
+  ln -sfn ../run/NetworkManager/resolv.conf /etc/resolv.conf
+fi

--- a/install/omarchy-base.packages
+++ b/install/omarchy-base.packages
@@ -148,4 +148,5 @@ yaru-icon-theme
 yay
 yt-dlp
 zbar
+zram-generator
 zoxide

--- a/migrations/1787669934.sh
+++ b/migrations/1787669934.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 echo "Ensure zram-generator is installed for configured zram swap"
 
 if omarchy-pkg-missing zram-generator; then

--- a/migrations/1787669934.sh
+++ b/migrations/1787669934.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Ensure zram-generator is installed for configured zram swap"
+
+if omarchy-pkg-missing zram-generator; then
+  omarchy-pkg-add zram-generator
+fi
+
+# Installing the package after boot does not run the generated unit until the
+# manager reloads. Start it now so upgraded machines get the same zram device a
+# fresh install gets on its next boot.
+sudo systemctl daemon-reload
+sudo systemctl start systemd-zram-setup@zram0.service

--- a/test/shell.d/aarch64-packages-test.sh
+++ b/test/shell.d/aarch64-packages-test.sh
@@ -7,6 +7,10 @@ source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 base_packages="$ROOT/install/omarchy-base.packages"
 unavailable="$ROOT/install/omarchy-aarch64-unavailable.packages"
 
+grep -qxF zram-generator "$base_packages" ||
+  fail "fresh installs include zram-generator in the default package set"
+pass "fresh installs include zram-generator in the default package set"
+
 mapfile -t unavailable_packages < <(grep -vE '^[[:space:]]*(#|$)' "$unavailable")
 (( ${#unavailable_packages[@]} )) || fail "the aarch64 unavailable list names at least one package"
 

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -60,3 +60,21 @@ set_call=$(grep -n '^  install_default_package_set$' "$install_script" | cut -d:
 grep -qF 'gum style' "$install_script" ||
   fail "the installer speaks through gum once it is available"
 pass "the installer styles its output with gum from the start"
+
+# A generic aarch64 base has the Asahi repo stanza but not its signing keyring.
+# Bootstrap and locally sign the documented master key before pacman refreshes,
+# or optional ARM packages fail later with a misleading missing-database error.
+grep -qF 'asahi_alarm_key=' "$install_script" ||
+  fail "the installer pins the Asahi Alarm package signing key"
+grep -qF 'pacman-key --recv-keys "$asahi_alarm_key"' "$install_script" ||
+  fail "the installer bootstraps the Asahi Alarm package signing key"
+grep -qF 'pacman-key --lsign-key "$asahi_alarm_key"' "$install_script" ||
+  fail "the installer locally trusts the Asahi Alarm package signing key"
+grep -qF 'pacman -Sy --needed --noconfirm asahi-alarm-keyring' "$install_script" ||
+  fail "the installer installs the Asahi Alarm package keyring"
+keyring_call=$(grep -n '^  ensure_asahi_alarm_keyring$' "$install_script" | cut -d: -f1)
+refresh_call=$(grep -n '^  sudo pacman -Sy --noconfirm$' "$install_script" | cut -d: -f1)
+[[ -n $keyring_call && -n $refresh_call ]] || fail "the installer bootstraps the Asahi keyring before refresh"
+(( keyring_call < refresh_call )) ||
+  fail "the Asahi keyring is installed before the package database refresh"
+pass "the installer bootstraps Asahi signing keys before refreshing ARM packages"

--- a/test/shell.d/network-manager-transition-test.sh
+++ b/test/shell.d/network-manager-transition-test.sh
@@ -34,14 +34,19 @@ grep -F 'NetworkManager.service' "$migration" >/dev/null
 grep -F '20-wlan.network' "$migration" >/dev/null
 pass "migration repairs upgraded systems with networkd still active"
 
-# enable-services.sh switches DNS to systemd-resolved, but resolv.conf still
-# names whatever resolver the machine was installed with, so a fresh install
-# reboots unable to resolve a hostname. The Quattro upgrade already links it.
+# Prefer systemd-resolved after reboot, but keep a live install online while
+# the service is only enabled and not yet started.
+grep -F '[[ -e /run/systemd/resolve/stub-resolv.conf ]]' "$ROOT/install/hardware/network.sh" >/dev/null ||
+  fail "hardware setup checks whether the systemd-resolved stub exists"
 grep -F 'ln -sfn ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf' "$ROOT/install/hardware/network.sh" >/dev/null ||
   fail "hardware setup points resolv.conf at the systemd-resolved stub"
+grep -F '[[ -e /run/NetworkManager/resolv.conf ]]' "$ROOT/install/hardware/network.sh" >/dev/null ||
+  fail "hardware setup has a live NetworkManager resolver fallback"
+grep -F 'ln -sfn ../run/NetworkManager/resolv.conf /etc/resolv.conf' "$ROOT/install/hardware/network.sh" >/dev/null ||
+  fail "hardware setup links resolv.conf to the live NetworkManager resolver"
 grep -F 'systemctl enable systemd-resolved.service' "$ROOT/install/config/enable-services.sh" >/dev/null ||
   fail "system setup enables the resolver resolv.conf now points at"
-pass "fresh installs resolve hostnames after reboot"
+pass "fresh installs keep DNS working before and after resolver startup"
 
 # Asahi Alarm configures NetworkManager to drive Wi-Fi through iwd, so disabling
 # iwd without moving the backend leaves NetworkManager with no Wi-Fi devices at

--- a/test/shell.d/zram-package-test.sh
+++ b/test/shell.d/zram-package-test.sh
@@ -37,6 +37,17 @@ STUB
 
 chmod +x "$stub_bin"/*
 
+assert_systemd_start_follows_reload() {
+  local reload_line start_line
+
+  reload_line=$(awk '$0 == "systemctl daemon-reload" { print NR; exit }' "$calls")
+  start_line=$(awk '$0 == "systemctl start systemd-zram-setup@zram0.service" { print NR; exit }' "$calls")
+  [[ -n $reload_line && -n $start_line ]] ||
+    fail "the zram migration records both systemd calls"
+  (( reload_line < start_line )) ||
+    fail "the zram migration reloads systemd before starting zram"
+}
+
 run_migration() {
   : >"$calls"
   PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
@@ -52,6 +63,7 @@ grep -Fx 'systemctl daemon-reload' "$calls" >/dev/null ||
   fail "the zram migration reloads systemd after installing zram-generator"
 grep -Fx 'systemctl start systemd-zram-setup@zram0.service' "$calls" >/dev/null ||
   fail "the zram migration starts the configured zram device"
+assert_systemd_start_follows_reload
 pass "the zram migration repairs an existing install without zram-generator"
 
 run_migration 0
@@ -59,4 +71,5 @@ run_migration 0
   fail "the zram migration does not reinstall an existing zram-generator"
 grep -Fx 'systemctl start systemd-zram-setup@zram0.service' "$calls" >/dev/null ||
   fail "the zram migration starts zram when the package is already installed"
+assert_systemd_start_follows_reload
 pass "the zram migration is idempotent"

--- a/test/shell.d/zram-package-test.sh
+++ b/test/shell.d/zram-package-test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1787669934.sh"
+[[ -f $migration ]] || fail "the zram package repair migration exists"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/omarchy-pkg-missing" <<'STUB'
+#!/bin/bash
+printf 'missing %s\n' "$*" >>"$TEST_LOG"
+(( ${OMARCHY_TEST_ZRAM_MISSING:-1} == 1 ))
+STUB
+
+cat >"$stub_bin/omarchy-pkg-add" <<'STUB'
+#!/bin/bash
+printf 'add %s\n' "$*" >>"$TEST_LOG"
+STUB
+
+cat >"$stub_bin/systemctl" <<'STUB'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$TEST_LOG"
+STUB
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+
+chmod +x "$stub_bin"/*
+
+run_migration() {
+  : >"$calls"
+  PATH="$stub_bin:$PATH" TEST_LOG="$calls" \
+    OMARCHY_TEST_ZRAM_MISSING="$1" bash -euo pipefail "$migration" >/dev/null
+}
+
+run_migration 1
+grep -Fx 'missing zram-generator' "$calls" >/dev/null ||
+  fail "the zram migration checks whether zram-generator is installed"
+grep -Fx 'add zram-generator' "$calls" >/dev/null ||
+  fail "the zram migration installs a missing zram-generator"
+grep -Fx 'systemctl daemon-reload' "$calls" >/dev/null ||
+  fail "the zram migration reloads systemd after installing zram-generator"
+grep -Fx 'systemctl start systemd-zram-setup@zram0.service' "$calls" >/dev/null ||
+  fail "the zram migration starts the configured zram device"
+pass "the zram migration repairs an existing install without zram-generator"
+
+run_migration 0
+! grep -Fx 'add zram-generator' "$calls" >/dev/null ||
+  fail "the zram migration does not reinstall an existing zram-generator"
+grep -Fx 'systemctl start systemd-zram-setup@zram0.service' "$calls" >/dev/null ||
+  fail "the zram migration starts zram when the package is already installed"
+pass "the zram migration is idempotent"


### PR DESCRIPTION
## Summary

- add `zram-generator` to the default package set consumed by the fresh Mac installer
- add a migration for existing installs that missed the package, reloads systemd, and starts the generated zram unit
- add regression coverage for both fresh-install packaging and migration idempotence

Fixes #218

## Validation

- Apple Silicon/Asahi focused tests in Apple Container: passed
- 141 Mac setup checks: passed
- Bash syntax and error-level ShellCheck: passed
- ARM64 Ubuntu container: migration repair and idempotence tests passed