### PR TITLE
Keep the Apple Silicon shell suite green

### DIFF
--- a/bin/omarchy-mac-snapshot-restore
+++ b/bin/omarchy-mac-snapshot-restore
@@ -143,7 +143,7 @@ main() {
   (( ${#paths[@]} )) || fail "no snapshots found to restore"
 
   local choice=""
-  if command -v gum >/dev/null; then
+  if omarchy-cmd-present gum; then
     choice=$(printf '%s\n' "${labels[@]}" | gum choose --header "Restore which snapshot?") || exit 1
   else
     local i

--- a/test/shell.d/bin-style-test.sh
+++ b/test/shell.d/bin-style-test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
 raw_command_checks=$(rg -l 'command -v' "$ROOT/bin" \
-  | rg -v '/omarchy-(cmd-|pkg-|upgrade-to-quattro)' || true)
+  | rg -v '/omarchy-(cmd-|pkg-|upgrade-to-quattro|mac-setup$|system-(btrfs-migrate|boot-to-esp)$)' || true)
 [[ -z $raw_command_checks ]] || fail "bin commands use command helpers" "$raw_command_checks"
 pass "bin commands use command helpers"
 

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -68,7 +68,9 @@ OMARCHY_SNAPPER_CONF_PATH="$test_tmp/etc/conf.d/snapper" \
 cmp -s "$template" "$test_tmp/etc/snapper/configs/root" || fail "snapshot configure installs the Omarchy Snapper template"
 grep -Fx 'SNAPPER_CONFIGS="root"' "$test_tmp/etc/conf.d/snapper" >/dev/null || fail "snapshot configure writes /etc/conf.d/snapper"
 grep -Fx 'systemctl disable --now snapper-timeline.timer' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure disables timeline snapshots"
-grep -Fx 'systemctl enable --now snapper-cleanup.timer limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure enables cleanup and Limine snapshot sync"
+grep -Fx 'systemctl enable --now snapper-cleanup.timer' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure enables cleanup"
+grep -Fx 'systemctl cat limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure checks for Limine snapshot sync"
+grep -Fx 'systemctl enable --now limine-snapper-sync.service' "$test_tmp/calls.log" >/dev/null || fail "snapshot configure enables Limine snapshot sync"
 pass "snapshot configure normalizes Snapper policy and services"
 
 setup_system="$ROOT/bin/omarchy-apply-system"


### PR DESCRIPTION
## Summary
- use the command helper in Mac snapshot restore
- exempt the three pre-bootstrap tools from the installed-command style guard
- update Snapper assertions for the optional Limine sync service

## Validation
- all 194 shell test files pass in an ARM64 Apple Container with the checkout bin path and omarchy-pkgs fixture mounted