### PR TITLE
fix: skip timezone prompt for configured zones

### DIFF
--- a/install/user/first-run/timezone.sh
+++ b/install/user/first-run/timezone.sh
@@ -21,8 +21,8 @@ timezone_needs_setting() {
   [[ -z $timezone || $timezone == "UTC" ]]
 }
 
-timezone_needs_setting || return 0
-
-omarchy-notification-send -u critical -g 󰥔 "Set your timezone" \
-  "This machine is on $(current_timezone). Click to choose yours." \
-  --exec "omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced"
+if timezone_needs_setting; then
+  omarchy-notification-send -u critical -g 󰥔 "Set your timezone" \
+    "This machine is on $(current_timezone). Click to choose yours." \
+    --exec "omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced"
+fi

--- a/tests/test-first-run-timezone.sh
+++ b/tests/test-first-run-timezone.sh
@@ -41,11 +41,25 @@ prompts_for_timezone() {
   [[ -e $WORK/notified ]]
 }
 
+does_not_prompt_when_executed() {
+  local timezone="$1"
+  rm -rf "$WORK/bin" "$WORK/notified"
+  mkdir -p "$WORK/bin"
+  printf '#!/bin/bash\necho %s\n' "$timezone" >"$WORK/bin/timedatectl"
+  printf '#!/bin/bash\ntouch "%s/notified"\n' "$WORK" >"$WORK/bin/omarchy-notification-send"
+  chmod +x "$WORK/bin"/*
+
+  PATH="$WORK/bin:$PATH" bash "$LEAF" >/dev/null 2>&1
+  [[ ! -e $WORK/notified ]]
+}
+
 check "a machine still on UTC is prompted" prompts_for_timezone UTC
 check "a machine with a real zone is left alone" \
   not prompts_for_timezone America/New_York
 check "an unset timezone is prompted" prompts_for_timezone ""
 check "another real zone is left alone" not prompts_for_timezone Europe/London
+check "a real zone is left alone when the leaf is executed" \
+  does_not_prompt_when_executed America/Los_Angeles
 
 echo
 echo "=== $pass checks passed, $failures failed ==="


### PR DESCRIPTION
## What changed

The first-run driver executes install/user/first-run/timezone.sh with Bash. The leaf used a top-level return 0 to skip machines whose timezone was already configured. In standalone execution, Bash reports that return can only be used from a function or sourced script, then continues because the leaf does not enable set -e; the timezone notification is sent anyway.

The Omarchy Mac VM reproduced this: the system was already on America/Los_Angeles, but first run still displayed “Set your timezone”.

This replaces the top-level return with a conditional that works both when sourced and when executed, and adds a regression test for the production execution path.

## Verification

- bash tests/test-first-run-timezone.sh
- bash test/shell.d/first-run-test.sh
- bash test/shell.d/install-stage-wiring-test.sh
- bash -n install/user/first-run/timezone.sh
- git diff --check