### PR TITLE
[Patch/shell] Moved calendar panel to the right

### DIFF
--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -236,8 +236,8 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    // Mac fork: moved the calendar component to the right,
-    // where the clock plugin is located in the shell.
+    // Anchor the calendar under the clock rather than the middle of the bar,
+    // so it follows wherever the widget is placed.
     centerOnBar: false
     focusTarget: keyCatcher
     contentWidth: panel.fittedContentWidth(Style.space(500))

--- a/shell/plugins/panels/clock/Panel.qml
+++ b/shell/plugins/panels/clock/Panel.qml
@@ -236,9 +236,11 @@ Panel {
     owner: root.barIdentity
     bar: root.bar
     open: root.opened
-    centerOnBar: true
+    // Mac fork: moved the calendar component to the right,
+    // where the clock plugin is located in the shell.
+    centerOnBar: false
     focusTarget: keyCatcher
-    contentWidth: panel.fittedContentWidth(Style.space(560))
+    contentWidth: panel.fittedContentWidth(Style.space(500))
     contentHeight: panel.fittedContentHeight(calendarColumn.implicitHeight)
 
     PanelKeyCatcher {


### PR DESCRIPTION
## What changed:
- Property `centerOnBar` to `false` - to align the calendar panel with clock widget in shell.
- Property `contentWidth` was reduced to fit into screen edges and not to crop the content inside.

## Why:
Current Calendar Panel is aligned with the center of bar, which makes sense if the clock widget was in the center of the bar.

## Screenshots:
<img width="520" height="481" alt="image" src="https://github.com/user-attachments/assets/e8734452-01c8-4a6c-a0ee-1dfc19ac8c16" />
<img width="864" height="583" alt="image" src="https://github.com/user-attachments/assets/dfc0e92a-897a-4d68-a783-12a9a399108f" />
