### PR TITLE
fix: retry first-run after user finalization failure

### DIFF
--- a/bin/omarchy-provision-first-run
+++ b/bin/omarchy-provision-first-run
@@ -43,8 +43,6 @@ if omarchy-done check "$FIRST_RUN_DONE" && (( force == 0 )); then
   exit 0
 fi
 
-omarchy-provision-user "${finalize_user_args[@]}" || true
-
 mkdir -p "$state_dir"
 
 FIRST_RUN_LOG="$state_dir/first-run.log"
@@ -53,6 +51,15 @@ first_run_failed=0
 log_first_run() {
   printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >>"$FIRST_RUN_LOG"
 }
+
+log_first_run "Starting: finalize user"
+if omarchy-provision-user "${finalize_user_args[@]}"; then
+  log_first_run "Completed: finalize user"
+else
+  finalize_user_status=$?
+  first_run_failed=1
+  log_first_run "Failed: finalize user (exit code: $finalize_user_status)"
+fi
 
 run_first_run_step() {
   local name="$1"

--- a/test/shell.d/first-run-test.sh
+++ b/test/shell.d/first-run-test.sh
@@ -33,3 +33,55 @@ if grep -F 'skip-first-run-update-notification' "$ROOT/install/user/first-run/wi
 fi
 
 pass "first-run uses one lifecycle completion marker"
+
+# A failed finalization must keep first-run retryable. The old driver discarded
+# this status with "|| true", then marked first-run complete if its later steps
+# happened to succeed; a transient setup failure could therefore permanently
+# skip the user's required finalization.
+retry_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp" "$retry_tmp"' EXIT
+retry_bin="$retry_tmp/bin"
+retry_root="$retry_tmp/omarchy"
+mkdir -p "$retry_bin" "$retry_root/install/user/first-run" "$retry_tmp/home"
+
+cat >"$retry_bin/omarchy-done" <<'SH'
+#!/bin/bash
+case "$1:$2" in
+  check:first-run-user) exit 1 ;;
+  mark:first-run-user) touch "$OMARCHY_TEST_FIRST_RUN_MARKER" ;;
+esac
+SH
+cat >"$retry_bin/omarchy-provision-user" <<'SH'
+#!/bin/bash
+touch "$OMARCHY_TEST_FINALIZE_CALLED"
+exit 42
+SH
+cat >"$retry_bin/omarchy-hook-install" <<'SH'
+#!/bin/bash
+exit 0
+SH
+cat >"$retry_bin/omarchy-notification-wait" <<'SH'
+#!/bin/bash
+exit 0
+SH
+chmod +x "$retry_bin"/*
+
+for leaf in \
+  welcome.sh timezone.sh wifi.sh enable-user-units.sh gnome-theme.sh \
+  gtk-primary-paste.sh audio-tuning.sh; do
+  printf '#!/bin/bash\nexit 0\n' >"$retry_root/install/user/first-run/$leaf"
+done
+
+retry_marker="$retry_tmp/first-run-marker"
+retry_finalize="$retry_tmp/finalize-called"
+HOME="$retry_tmp/home" PATH="$retry_bin:$PATH" OMARCHY_PATH="$retry_root" \
+  OMARCHY_TEST_FIRST_RUN_MARKER="$retry_marker" \
+  OMARCHY_TEST_FINALIZE_CALLED="$retry_finalize" \
+  bash "$ROOT/bin/omarchy-provision-first-run" >"$retry_tmp/output"
+
+[[ -e $retry_finalize ]] || fail "first-run attempts user finalization"
+[[ ! -e $retry_marker ]] || fail "failed user finalization keeps first-run retryable"
+grep -F 'Failed: finalize user (exit code: 42)' \
+  "$retry_tmp/home/.local/state/omarchy/first-run.log" >/dev/null ||
+  fail "first-run records a finalization failure"
+pass "failed user finalization keeps first-run retryable"


### PR DESCRIPTION
## What changed

- preserve the exit status from `omarchy-provision-user` in the first-run driver
- log finalization failures alongside the other first-run steps
- keep `first-run-user` unmarked so the setup is retried on the next login
- add a regression covering a failed finalization with otherwise successful first-run steps

## Bug

`omarchy-provision-first-run` previously ran `omarchy-provision-user ... || true`. If finalization failed but the later notifications and setup hooks succeeded, the driver still marked `first-run-user` complete. A transient failure could therefore permanently skip required user setup.

## Verification

- `/opt/homebrew/bin/bash test/shell.d/first-run-test.sh`
- `/opt/homebrew/bin/bash test/shell.d/install-stage-wiring-test.sh`
- `/opt/homebrew/bin/bash -n bin/omarchy-provision-first-run test/shell.d/first-run-test.sh`
- ShellCheck on changed files
- `git diff --check`