### PR TITLE
fix: restore the ARM Obsidian preinstall

### DIFF
--- a/bin/omarchy-install-preinstalls
+++ b/bin/omarchy-install-preinstalls
@@ -10,21 +10,28 @@ if gum confirm "Are you sure you want to restore all preinstalled web apps, TUI 
   # that back claude, gh, opencode, and the rest of the agents
   omarchy-refresh-applications
 
-  # Mirrors the list in omarchy-remove-preinstalls; both track omarchy-base.packages
-  if ! omarchy-pkg-add \
-    aether \
-    cliamp \
-    libreoffice-fresh \
-    xournalpp \
-    pinta \
-    obsidian \
-    obs-studio \
-    kdenlive \
-    moonlight-qt \
-    lazydocker \
-    omacut \
-    omacalc \
-    omawrite; then
+  # Mirrors the list in omarchy-remove-preinstalls. Obsidian is a pkgbase whose
+  # installable aarch64 output is obsidian-appimage, not the x86 obsidian name.
+  preinstall_packages=(
+    aether
+    cliamp
+    libreoffice-fresh
+    xournalpp
+    pinta
+    obsidian
+    obs-studio
+    kdenlive
+    moonlight-qt
+    lazydocker
+    omacut
+    omacalc
+    omawrite
+  )
+  if [[ $(uname -m) == "aarch64" ]]; then
+    preinstall_packages+=(obsidian-appimage)
+  fi
+
+  if ! omarchy-pkg-add "${preinstall_packages[@]}"; then
     echo -e "\nPreinstalls are still marked as removed. Fix the errors above and try again."
     exit 1
   fi

--- a/bin/omarchy-remove-preinstalls
+++ b/bin/omarchy-remove-preinstalls
@@ -17,18 +17,23 @@ if gum confirm "Are you sure you want to remove all preinstalled web apps, TUI w
        ~/.local/bin/gh ~/.local/bin/opencode ~/.local/bin/playwright ~/.local/bin/playwright-cli ~/.local/bin/pi \
        ~/.local/bin/omp ~/.local/bin/ori ~/.local/bin/grok ~/.local/bin/crush ~/.local/bin/ghui ~/.local/bin/hunk
 
-  omarchy-pkg-drop \
-    aether \
-    cliamp \
-    libreoffice-fresh \
-    xournalpp \
-    pinta \
-    obsidian \
-    obs-studio \
-    kdenlive \
-    moonlight-qt \
-    lazydocker \
-    omacut \
-    omacalc \
+  preinstall_packages=(
+    aether
+    cliamp
+    libreoffice-fresh
+    xournalpp
+    pinta
+    obsidian
+    obs-studio
+    kdenlive
+    moonlight-qt
+    lazydocker
+    omacut
+    omacalc
     omawrite
+  )
+  if [[ $(uname -m) == "aarch64" ]]; then
+    preinstall_packages+=(obsidian-appimage)
+  fi
+  omarchy-pkg-drop "${preinstall_packages[@]}"
 fi

--- a/test/shell.d/preinstalls-test.sh
+++ b/test/shell.d/preinstalls-test.sh
@@ -17,6 +17,11 @@ for command in omarchy-webapp-remove-all omarchy-tui-remove-all omarchy-refresh-
   printf '#!/bin/bash\nexit 0\n' >"$mock_bin/$command"
 done
 
+cat >"$mock_bin/uname" <<'SH'
+#!/bin/bash
+[[ $1 == -m ]] && echo aarch64
+SH
+
 cat >"$mock_bin/gum" <<'SH'
 #!/bin/bash
 [[ $1 == confirm ]] && exit "${OMARCHY_TEST_CONFIRM:-0}"
@@ -58,10 +63,21 @@ dropped:  ${dropped[*]}"
 pass "Install and Remove Preinstalls cover the same packages"
 
 for package in "${restored[@]}"; do
-  printf '%s\n' "${shipped[@]}" | grep -qxF "$package" ||
-    fail "every preinstall is shipped in omarchy-base.packages" "$package is not shipped"
+  if [[ $package == obsidian-appimage ]]; then
+    [[ $(uname -m) == "aarch64" ]] ||
+      fail "the ARM-only Obsidian substitute is not used on x86"
+  else
+    printf '%s\n' "${shipped[@]}" | grep -qxF "$package" ||
+      fail "every preinstall is shipped in omarchy-base.packages" "$package is not shipped"
+  fi
 done
 pass "every preinstall is shipped in omarchy-base.packages"
+
+if [[ $(uname -m) == "aarch64" ]]; then
+  printf '%s\n' "${restored[@]}" | grep -qxF obsidian-appimage ||
+    fail "ARM preinstalls restore the installable Obsidian substitute"
+  pass "ARM preinstalls restore the installable Obsidian substitute"
+fi
 
 for package in omacut omacalc omawrite; do
   printf '%s\n' "${restored[@]}" | grep -qxF "$package" ||


### PR DESCRIPTION
## What changed

- add `obsidian-appimage` to the preinstall restore list on aarch64
- remove the same ARM package when preinstalls are disabled
- keep the x86 `obsidian` package path unchanged
- extend the preinstall symmetry test to cover the ARM substitute

## Bug

Apple Silicon installs use `obsidian-appimage` because the `obsidian` pkgbase has no installable ARM output. The preinstall toggle only knew the x86 package name, so Remove Preinstalls left the ARM package behind and Install Preinstalls could not restore it.

## Verification

- `/opt/homebrew/bin/bash test/shell.d/preinstalls-test.sh`
- `/opt/homebrew/bin/bash -n bin/omarchy-install-preinstalls bin/omarchy-remove-preinstalls test/shell.d/preinstalls-test.sh`
- ShellCheck on changed files
- `git diff --check`