### PR TITLE
fix: escape guided setup resume config

### DIFF
--- a/bin/omarchy-mac-setup
+++ b/bin/omarchy-mac-setup
@@ -328,16 +328,19 @@ load_conf() {
 }
 
 save_conf() {
-  cat >"$CONF" <<EOF
-# Written by omarchy-mac-setup; delete it to stop the guided install.
-WANT_ENCRYPT=$want_encrypt
-SETUP_USER=$username
-SETUP_HOSTNAME=$hostname
-SETUP_KEYMAP=$keymap
-SETUP_REPO=$repo
-SETUP_REF=$ref
-SETUP_FORGE=$forge
-EOF
+  # This file is sourced as root on the next boot. Keep every answer shell-safe,
+  # including the repo/ref/forge flags, which are intentionally user-configurable
+  # and may contain characters that are meaningful to the shell.
+  {
+    printf '# Written by omarchy-mac-setup; delete it to stop the guided install.\n'
+    printf 'WANT_ENCRYPT=%q\n' "$want_encrypt"
+    printf 'SETUP_USER=%q\n' "$username"
+    printf 'SETUP_HOSTNAME=%q\n' "$hostname"
+    printf 'SETUP_KEYMAP=%q\n' "$keymap"
+    printf 'SETUP_REPO=%q\n' "$repo"
+    printf 'SETUP_REF=%q\n' "$ref"
+    printf 'SETUP_FORGE=%q\n' "$forge"
+  } >"$CONF"
   chmod 600 "$CONF"
 }
 

--- a/tests/test-mac-setup.sh
+++ b/tests/test-mac-setup.sh
@@ -761,6 +761,36 @@ forge_persists() {
 
 check "the forge survives a reboot in the conf file" forge_persists
 
+echo "=== saved answers are inert shell data ==="
+
+# The resume path sources /etc/omarchy-mac-setup.conf as root. An unescaped
+# --ref such as $(touch marker) used to become command substitution in that
+# file, so a value supplied to the first invocation ran on the next boot.
+conf_file=$work/setup.conf
+conf_marker=$work/conf-injected
+conf_is_safe() {
+  (
+    CONF=$conf_file
+    want_encrypt=1
+    username=owner
+    hostname=box
+    keymap=us
+    repo=owner/repo
+    ref="\$(touch \"$conf_marker\")"
+    forge=git.example.org
+
+    save_conf
+    [[ ! -e $conf_marker ]] || return 1
+
+    unset WANT_ENCRYPT SETUP_USER SETUP_HOSTNAME SETUP_KEYMAP SETUP_REPO SETUP_REF SETUP_FORGE
+    # shellcheck source=/dev/null
+    . "$CONF"
+    [[ ! -e $conf_marker && $SETUP_REF == "$ref" ]]
+  )
+}
+
+check "resume answers cannot execute shell syntax" conf_is_safe
+
 echo "=== questions and status read the machine, not the intent flag ==="
 
 # Re-running against a machine that is already encrypted -- a resumed install,

--- a/tests/test-mac-setup.sh
+++ b/tests/test-mac-setup.sh
@@ -755,7 +755,7 @@ check "no call site hardcodes a forge host" \
   [ "$(grep -c 'https://codeberg\.org' "$TOOL")" = "0" ]
 
 forge_persists() {
-  grep -qF 'SETUP_FORGE=$forge' "$TOOL" &&
+  grep -qF "printf 'SETUP_FORGE=%q\\n' \"\$forge\"" "$TOOL" &&
     grep -qF 'forge=${SETUP_FORGE:-$forge}' "$TOOL"
 }
 


### PR DESCRIPTION
### Bug
`omarchy-mac-setup` wrote the user-selected repo, ref, and forge directly into `/etc/omarchy-mac-setup.conf`, then sourced that file as root after reboot. Shell syntax supplied through `--ref` (or the other persisted options) could therefore execute during the resume boot.

### Change
Serialize every persisted answer with Bash `%q` so the resume file remains inert data while retaining the exact values.

### Verification
- `/opt/homebrew/bin/bash tests/test-mac-setup.sh` — the new resume-config regression passes; the existing harness retains four macOS pty-related failures.
- `/opt/homebrew/bin/bash -n bin/omarchy-mac-setup tests/test-mac-setup.sh`
- `shellcheck -S error bin/omarchy-mac-setup tests/test-mac-setup.sh`
- `git diff --check`