### PR TITLE
fix: expand ARM mirror test paths

### DIFF
--- a/install/helpers/set-arm-mirrors.sh
+++ b/install/helpers/set-arm-mirrors.sh
@@ -109,7 +109,7 @@ auto_detect_country() {
 # Test mirror connectivity function
 test_mirror_connectivity() {
   local mirror_url="$1"
-  local test_url="${mirror_url//\$arch\$repo/aarch64/core}"
+  local test_url="${mirror_url//\$arch\/\$repo/aarch64\/core}"
 
   if [[ $VERBOSE -eq 1 ]]; then
     echo "[DEBUG] Testing connectivity to: $test_url"

--- a/test/shell.d/arm-mirrors-test.sh
+++ b/test/shell.d/arm-mirrors-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+helper="$ROOT/install/helpers/set-arm-mirrors.sh"
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+mock_bin="$test_tmp/bin"
+mkdir -p "$mock_bin"
+cat >"$mock_bin/curl" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$@" >"$ARM_MIRROR_TEST_LOG"
+SH
+chmod +x "$mock_bin/curl"
+
+export ARM_MIRROR_TEST_LOG="$test_tmp/curl-args"
+PATH="$mock_bin:$PATH"
+export PATH
+VERBOSE=0
+export VERBOSE
+
+# The helper is also an executable, so source only the connectivity function
+# instead of running its mirrorlist writes against the host.
+eval "$(awk '/^test_mirror_connectivity\(\) \{/,/^\}/' "$helper")"
+
+test_mirror_connectivity 'http://us.mirror.archlinuxarm.org/$arch/$repo'
+
+if ! grep -Fxq 'http://us.mirror.archlinuxarm.org/aarch64/core' "$ARM_MIRROR_TEST_LOG"; then
+  fail "mirror connectivity expands the ARM path" "curl args:\n$(cat "$ARM_MIRROR_TEST_LOG")"
+fi
+pass "mirror connectivity expands the ARM path"


### PR DESCRIPTION
## Bug\n`test_mirror_connectivity` tried to replace `\\`, but every configured mirror URL contains `/\/\`. With `--test`, the probe therefore sent curl or wget a URL containing literal placeholders and could reject healthy mirrors.\n\n## Fix\nExpand the complete `/\/\` path to `/aarch64/core`, with a regression test that captures the connectivity URL without touching the host mirrorlist.\n\n## Verification\n- `/opt/homebrew/bin/bash test/shell.d/arm-mirrors-test.sh`\n- `/opt/homebrew/bin/bash -n install/helpers/set-arm-mirrors.sh test/shell.d/arm-mirrors-test.sh`\n- `shellcheck -S error install/helpers/set-arm-mirrors.sh test/shell.d/arm-mirrors-test.sh`\n- `git diff --check`\n