### PR TITLE
fix: skip configured first-run timezones cleanly

### DIFF
--- a/install/user/first-run/timezone.sh
+++ b/install/user/first-run/timezone.sh
@@ -21,7 +21,7 @@ timezone_needs_setting() {
   [[ -z $timezone || $timezone == "UTC" ]]
 }
 
-timezone_needs_setting || return 0
+timezone_needs_setting || exit 0
 
 omarchy-notification-send -u critical -g 󰥔 "Set your timezone" \
   "This machine is on $(current_timezone). Click to choose yours." \

--- a/test/shell.d/first-run-test.sh
+++ b/test/shell.d/first-run-test.sh
@@ -32,4 +32,23 @@ if grep -F 'skip-first-run-update-notification' "$ROOT/install/user/first-run/wi
   fail "first-run does not track update notifications separately"
 fi
 
+cat >"$mock_bin/timedatectl" <<'SH'
+#!/bin/bash
+printf 'America/Los_Angeles\n'
+SH
+cat >"$mock_bin/omarchy-notification-send" <<'SH'
+#!/bin/bash
+touch "$OMARCHY_TEST_NOTIFICATION_SENT"
+SH
+chmod +x "$mock_bin/timedatectl" "$mock_bin/omarchy-notification-send"
+
+if ! OMARCHY_TEST_NOTIFICATION_SENT="$test_tmp/timezone-notification-sent" \
+  PATH="$mock_bin:$PATH" bash "$ROOT/install/user/first-run/timezone.sh" \
+  >"$test_tmp/timezone-output" 2>&1; then
+  fail "timezone first-run step succeeds when timezone is already configured" \
+    "$(<"$test_tmp/timezone-output")"
+fi
+[[ ! -e "$test_tmp/timezone-notification-sent" ]] || \
+  fail "timezone first-run step skips configured timezones"
+
 pass "first-run uses one lifecycle completion marker"

--- a/tests/test-first-run-timezone.sh
+++ b/tests/test-first-run-timezone.sh
@@ -27,8 +27,8 @@ not() {
   ! "$@"
 }
 
-# The leaf is sourced by the first-run driver, so it is sourced here too, with
-# the notification recorded as a file rather than sent.
+# The first-run driver invokes the leaf as a standalone Bash script, with the
+# notification recorded as a file rather than sent.
 prompts_for_timezone() {
   local timezone="$1"
   rm -rf "$WORK/bin" "$WORK/notified"
@@ -37,7 +37,7 @@ prompts_for_timezone() {
   printf '#!/bin/bash\ntouch "%s/notified"\n' "$WORK" >"$WORK/bin/omarchy-notification-send"
   chmod +x "$WORK/bin"/*
 
-  PATH="$WORK/bin:$PATH" bash -c "source '$LEAF'" >/dev/null 2>&1
+  PATH="$WORK/bin:$PATH" bash "$LEAF" >/dev/null 2>&1
   [[ -e $WORK/notified ]]
 }
 


### PR DESCRIPTION
The Mac first-run driver invokes install/user/first-run/timezone.sh as a standalone Bash script. Its already-configured branch used `return 0`, which is only valid when sourced; it could fall through to the notification command and make first-run retry if notifications were unavailable.

Change the guard to `exit 0` and update both timezone regressions to exercise the real standalone invocation.

Tests:
- /opt/homebrew/bin/bash test/shell.d/first-run-test.sh
- /opt/homebrew/bin/bash tests/test-first-run-timezone.sh
- /opt/homebrew/bin/bash -n ...
- shellcheck -S error -e SC2148 ...
- shfmt -i 2 -ci -d ...