### PR TITLE
fix: isolate Apple package build outputs

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -117,8 +117,21 @@ install_build_dependencies() {
   sudo pacman -S --needed --noconfirm "${missing[@]}"
 }
 
+remove_old_packages() {
+  local artifact
+
+  # This directory is the installer hand-off, not a package cache. A retry
+  # after PKGBUILDs changed must not mix the previous build with this one.
+  for artifact in "$output_dir"/*.pkg.tar.*; do
+    [[ -f $artifact ]] || continue
+    rm -f -- "$artifact"
+  done
+}
+
 build_package() {
   local package="$1" pkgbuild_source="$2" build_dir="$3"
+  local artifact
+  local -a built=()
 
   log "Building $package"
   rm -rf "$build_dir/$package"
@@ -139,7 +152,14 @@ build_package() {
       makepkg --force --noconfirm --nodeps --skipinteg
   )
 
-  mv "$build_dir/$package"/*.pkg.tar.* "$output_dir/"
+  # A configured makepkg signer leaves detached .sig files beside the archive;
+  # pacman -U accepts package archives, not those signatures.
+  for artifact in "$build_dir/$package"/*.pkg.tar.*; do
+    [[ -f $artifact && $artifact != *.sig ]] || continue
+    built+=("$artifact")
+  done
+  (( ${#built[@]} )) || fail "$package produced no package archive"
+  mv -- "${built[@]}" "$output_dir/"
 }
 
 main() {
@@ -164,6 +184,7 @@ main() {
   trap remove_build_dir EXIT
 
   mkdir -p "$output_dir" "$source_cache"
+  remove_old_packages
   for package in "${packages[@]}"; do
     build_package "$package" "$pkgbuild_source" "$build_dir"
   done

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,12 @@ build_omarchy_packages() {
 install_omarchy_packages() {
   log "Installing the Omarchy packages"
 
-  local built=("$package_output"/*.pkg.tar.*)
+  local artifact
+  local -a built=()
+  for artifact in "$package_output"/*.pkg.tar.*; do
+    [[ -f $artifact && $artifact != *.sig ]] || continue
+    built+=("$artifact")
+  done
   (( ${#built[@]} )) || fail "No packages were built in $package_output."
   sudo pacman -U --needed --noconfirm "${built[@]}"
 

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -68,6 +68,33 @@ grep -A2 'package == "omarchy-settings"' "$build_script" | grep -q set_pkgrel ||
   fail "the package build stamps pkgrel on omarchy and omarchy-settings"
 pass "the package build can stamp a Mac-only pkgrel on omarchy and omarchy-settings"
 
+# build-output is the hand-off directory for one install attempt. Keeping an
+# archive from an earlier retry makes pacman see two versions of the same
+# package; detached signatures are metadata, not package archives.
+grep -qF 'remove_old_packages' "$build_script" ||
+  fail "the package build clears archives from an earlier retry"
+grep -qF 'rm -f -- "$artifact"' "$build_script" ||
+  fail "the package build removes stale package archives safely"
+grep -qF '[[ -f $artifact && $artifact != *.sig ]]' "$build_script" ||
+  fail "the package build does not hand detached signatures to the installer"
+grep -qF '[[ -f $artifact && $artifact != *.sig ]]' "$install_script" ||
+  fail "the installer does not pass detached signatures to pacman"
+pass "the Apple Silicon package hand-off contains only current archives"
+
+# Clearing the hand-off directory is only useful if main calls it before the
+# package loop. Pin the ordering so a future refactor cannot leave the helper
+# covered in isolation while retries still mix old and new archives.
+main_body=$(awk '/^main\(\) \{/{inside=1} inside {print} inside && /^}/ {exit}' "$build_script")
+remove_line=$(grep -nF '  remove_old_packages' <<<"$main_body" || true)
+build_loop_line=$(grep -nF '  for package in "${packages[@]}"; do' <<<"$main_body" || true)
+[[ -n $remove_line && -n $build_loop_line ]] ||
+  fail "the package build clears old archives before its package loop"
+remove_line=${remove_line%%:*}
+build_loop_line=${build_loop_line%%:*}
+(( remove_line < build_loop_line )) ||
+  fail "the package build clears old archives before its package loop"
+pass "the package build clears old archives before its package loop"
+
 # The refresh runs from omarchy-reinstall-configs under set -e, so a machine
 # without limine must no-op rather than abort the seeding step.
 grep -F 'omarchy-cmd-missing limine' "$ROOT/bin/omarchy-refresh-limine" >/dev/null ||

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -86,12 +86,12 @@ pass "the Apple Silicon package hand-off contains only current archives"
 # covered in isolation while retries still mix old and new archives.
 main_body=$(awk '/^main\(\) \{/{inside=1} inside {print} inside && /^}/ {exit}' "$build_script")
 remove_line=$(grep -nF '  remove_old_packages' <<<"$main_body" || true)
-build_loop_line=$(grep -nF '  for package in "${packages[@]}"; do' <<<"$main_body" || true)
-[[ -n $remove_line && -n $build_loop_line ]] ||
+build_call_line=$(grep -nF '    build_package "$package"' <<<"$main_body" || true)
+[[ -n $remove_line && -n $build_call_line ]] ||
   fail "the package build clears old archives before its package loop"
 remove_line=${remove_line%%:*}
-build_loop_line=${build_loop_line%%:*}
-(( remove_line < build_loop_line )) ||
+build_call_line=${build_call_line%%:*}
+(( remove_line < build_call_line )) ||
   fail "the package build clears old archives before its package loop"
 pass "the package build clears old archives before its package loop"
 


### PR DESCRIPTION
## Summary
- clear prior package archives before a fresh Apple Silicon build
- ignore detached `.sig` files when moving and installing packages
- add regression coverage for the package hand-off

## Verification
- `test/shell.d/install-mac-test.sh`
- `test/shell.d/aarch64-packages-test.sh`
- `test/shell.d/install-stage-wiring-test.sh`
- `test/shell.d/upgrade-to-quattro-mac-test.sh`
- `bash -n` and ShellCheck on changed scripts
- `git diff --check`