### PR TITLE
fix: keep optional recorder failures nonfatal

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -228,8 +228,10 @@ install_quattro_packages() {
     fi
   done < <(grep -vE '^\s*(#|$)' "$checkout/install/omarchy-base.packages")
 
-  # Apple GPUs cannot run gpu-screen-recorder; screen recording falls back to wf-recorder.
-  yay -S --needed --noconfirm wf-recorder </dev/null
+  # Apple GPUs cannot run gpu-screen-recorder; screen recording falls back to
+  # wf-recorder. Keep this optional like the default package pass: a missing
+  # recording backend must not leave the upgrade half-complete.
+  yay -S --needed --noconfirm wf-recorder </dev/null || skipped+=("wf-recorder")
 
   if (( ${#unbuildable[@]} )); then
     log "No aarch64 build is known, so these were not attempted: ${unbuildable[*]}"

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -177,14 +177,17 @@ pass "the upgrade always ends up with Quickshell installed"
 # The default package pass records failures and continues, so the optional
 # Apple recording fallback must do the same. Otherwise a missing ARM build or a
 # transient AUR failure aborts after the checkout and system paths changed,
-# leaving the 3.x machine half-upgraded.
+# leaving the 3.x machine half-upgraded. Capture the warning rather than
+# relying on the subshell's exit status: Bash suppresses errexit in this
+# conditional context, so the old bare yay call falsely passed.
+optional_install_output=$(mktemp)
 if ! (
   checkout="$ROOT"
   unavailable_packages=()
   load_unavailable_packages() { unavailable_packages=(); }
   package_is_unavailable_here() { return 1; }
   log() { :; }
-  warn() { :; }
+  warn() { printf '%s\n' "$*" >>"$optional_install_output"; }
   yay() {
     [[ $* == *wf-recorder* ]] && return 1
     return 0
@@ -194,9 +197,15 @@ $install_body
 }"
   install_quattro_packages
 ); then
+  rm -f "$optional_install_output"
   fail "the Quattro upgrade continues when wf-recorder is unavailable"
 fi
-pass "the Quattro upgrade continues when wf-recorder is unavailable"
+grep -qF 'wf-recorder' "$optional_install_output" || {
+  rm -f "$optional_install_output"
+  fail "the Quattro upgrade reports wf-recorder when it is unavailable"
+}
+rm -f "$optional_install_output"
+pass "the Quattro upgrade continues and reports when wf-recorder is unavailable"
 
 # Every other fatal step reports through fail(); a bare set -e abort here would
 # die silently after the checkout has already been switched.

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -174,6 +174,30 @@ fi
   fail "quickshell-git is skipped and nothing installs quickshell: the upgrade leaves no shell"
 pass "the upgrade always ends up with Quickshell installed"
 
+# The default package pass records failures and continues, so the optional
+# Apple recording fallback must do the same. Otherwise a missing ARM build or a
+# transient AUR failure aborts after the checkout and system paths changed,
+# leaving the 3.x machine half-upgraded.
+if ! (
+  checkout="$ROOT"
+  unavailable_packages=()
+  load_unavailable_packages() { unavailable_packages=(); }
+  package_is_unavailable_here() { return 1; }
+  log() { :; }
+  warn() { :; }
+  yay() {
+    [[ $* == *wf-recorder* ]] && return 1
+    return 0
+  }
+  eval "install_quattro_packages() {
+$install_body
+}"
+  install_quattro_packages
+); then
+  fail "the Quattro upgrade continues when wf-recorder is unavailable"
+fi
+pass "the Quattro upgrade continues when wf-recorder is unavailable"
+
 # Every other fatal step reports through fail(); a bare set -e abort here would
 # die silently after the checkout has already been switched.
 if (( installs_quickshell )); then


### PR DESCRIPTION
## Summary
- keep `wf-recorder` failure nonfatal during the Mac Quattro upgrade
- report it with the same skipped-package warning used for the default package pass
- add a regression that simulates an unavailable recorder package

## Verification
- `test/shell.d/upgrade-to-quattro-mac-test.sh`
- `test/shell.d/aarch64-packages-test.sh`
- `test/shell.d/install-stage-wiring-test.sh`
- `bash -n` and ShellCheck on changed scripts
- `git diff --check`