### PR TITLE
fix: detect Apple Silicon lid state

### DIFF
--- a/bin/omarchy-hw-laptop
+++ b/bin/omarchy-hw-laptop
@@ -10,7 +10,9 @@ done
 # Fall back to the DMI chassis type for laptops that don't expose an ACPI lid
 # button. 8=Portable 9=Laptop 10=Notebook 14=Sub Notebook 30=Tablet
 # 31=Convertible 32=Detachable.
-case $(< /sys/class/dmi/id/chassis_type 2>/dev/null) in
+chassis_type=""
+read -r chassis_type <"${OMARCHY_DMI_CHASSIS_TYPE_PATH:-/sys/class/dmi/id/chassis_type}" 2>/dev/null || true
+case "$chassis_type" in
 8 | 9 | 10 | 14 | 30 | 31 | 32) exit 0 ;;
 esac
 

--- a/bin/omarchy-hw-laptop-closed
+++ b/bin/omarchy-hw-laptop-closed
@@ -3,7 +3,16 @@
 # omarchy:summary=Returns true when the laptop lid is closed
 # omarchy:hidden=true
 
-for state in /proc/acpi/button/lid/*/state; do
+if command -v busctl >/dev/null 2>&1; then
+  lid_state=$(busctl get-property org.freedesktop.login1 \
+    /org/freedesktop/login1 org.freedesktop.login1.Manager LidClosed 2>/dev/null || true)
+  case "$lid_state" in
+    "b true") exit 0 ;;
+    "b false") exit 1 ;;
+  esac
+fi
+
+for state in "${OMARCHY_ACPI_LID_PATH:-/proc/acpi/button/lid}"/*/state; do
   [[ -r $state ]] || continue
   [[ $(< "$state") == *"closed"* ]] && exit 0
 done

--- a/test/shell.d/hw-laptop-test.sh
+++ b/test/shell.d/hw-laptop-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+acpi_lid="$test_tmp/acpi/button/lid"
+dmi_chassis="$test_tmp/chassis_type"
+mkdir -p "$stub_bin" "$acpi_lid/macbook"
+
+cat >"$stub_bin/busctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "${OMARCHY_TEST_LID_STATE:-b false}"
+SH
+chmod +x "$stub_bin/busctl"
+
+run_laptop() {
+  OMARCHY_DMI_CHASSIS_TYPE_PATH="$dmi_chassis" \
+    OMARCHY_ACPI_LID_PATH="$acpi_lid" \
+    PATH="$stub_bin:$PATH" \
+    "$ROOT/bin/omarchy-hw-laptop"
+}
+
+run_lid_closed() {
+  local lid_state="$1"
+
+  OMARCHY_ACPI_LID_PATH="$acpi_lid" \
+    PATH="$stub_bin:$PATH" \
+    OMARCHY_TEST_LID_STATE="$lid_state" \
+    "$ROOT/bin/omarchy-hw-laptop-closed"
+}
+
+printf '9\n' >"$dmi_chassis"
+run_laptop || fail "DMI laptop chassis is recognized when ACPI is absent"
+pass "DMI laptop chassis is recognized when ACPI is absent"
+
+printf '3\n' >"$dmi_chassis"
+if run_laptop; then
+  fail "a desktop DMI chassis is not classified as a laptop"
+fi
+pass "a desktop DMI chassis is not classified as a laptop"
+
+printf 'closed\n' >"$acpi_lid/macbook/state"
+run_lid_closed not-a-property ||
+  fail "the ACPI fallback recognizes a closed lid"
+pass "the ACPI fallback recognizes a closed lid"
+
+printf 'open\n' >"$acpi_lid/macbook/state"
+if run_lid_closed not-a-property; then
+  fail "the ACPI fallback recognizes an open lid"
+fi
+pass "the ACPI fallback recognizes an open lid"
+
+run_lid_closed 'b true' ||
+  fail "logind recognizes an Apple Silicon closed lid"
+pass "logind recognizes an Apple Silicon closed lid"
+
+run_lid_closed 'b false' &&
+  fail "logind recognizes an Apple Silicon open lid"
+pass "logind recognizes an Apple Silicon open lid"
+
+rm -f "$acpi_lid/macbook/state"
+run_lid_closed 'b true' ||
+  fail "logind remains authoritative when ACPI is absent"
+pass "logind remains authoritative when ACPI is absent"


### PR DESCRIPTION
Fixes #227.

## Summary
- use systemd-logind `LidClosed` when available, with the existing ACPI state file as fallback
- read DMI chassis type with `read` so Apple Silicon laptops are recognized without ACPI
- add simulated logind, ACPI, and DMI coverage

## Verification
- `test/shell.d/hw-laptop-test.sh`
- `test/shell.d/lid-close-test.sh`
- `test/shell.d/monitor-state-test.sh`
- `test/shell.d/hw-external-monitors-test.sh`
- `bash -n` and ShellCheck on changed scripts
- `git diff --check`

Note: the existing monitor-scale test has an unrelated macOS Bash/sed portability failure in untouched monitor code.