### PR TITLE
fix: refresh ARM packages during upgrade

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -166,20 +166,24 @@ validate_quattro_tree() {
 # it, every Quattro package that the ARM repo serves as a prebuilt binary
 # resolves to an hours-long AUR build instead -- quickshell-git's build even
 # fails outright on Wayland-only systems whose GL stack predates the upgrade
-# (#208). Mirrors install.sh's ensure_arm_package_repo; must run before
+# (#208). Even when the stanza is already present, refresh it: an old sync db
+# can still point at package files the ARM mirror has removed. Must run before
 # install_quattro_packages.
 ensure_arm_package_repo() {
-  grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf && return 0
+  if ! grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf; then
+    local block
+    block=$(sed -n '/^\[omarchy-aarch64\]/,/^Server[[:space:]]*=/p' \
+      "$checkout/default/pacman/pacman-stable.conf")
+    [[ -n $block ]] || fail "default/pacman/pacman-stable.conf has no [omarchy-aarch64] section."
 
-  local block
-  block=$(sed -n '/^\[omarchy-aarch64\]/,/^Server[[:space:]]*=/p' \
-    "$checkout/default/pacman/pacman-stable.conf")
-  [[ -n $block ]] || fail "default/pacman/pacman-stable.conf has no [omarchy-aarch64] section."
+    log "Adding the Omarchy ARM package repo"
+    printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
+  fi
 
-  log "Adding the Omarchy ARM package repo"
-  printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
-  sudo pacman -Sy --noconfirm >/dev/null 2>&1 ||
-    warn "Could not refresh package databases after adding the ARM repo."
+  log "Refreshing package databases for ARM packages"
+  if ! sudo pacman -Sy --noconfirm; then
+    fail "Could not refresh package databases. Fix the network or mirror configuration and retry the Quattro upgrade."
+  fi
 }
 
 # install.sh keeps the packages with no aarch64 build out of the set rather than

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -111,6 +111,22 @@ doc_url=$(grep -oE 'https://[^ ]*omarchy-upgrade-to-quattro-mac' "$ROOT/docs/upg
 doc:    $doc_url"
 pass "the upgrade one-liner agrees between the script and the guide"
 
+# A pre-existing ARM repo stanza does not prove its sync database is current;
+# stale metadata turns the later package phase into confusing 404s. Refreshing
+# must therefore happen on both the add and already-present paths, and failure
+# must stop before package installation rather than being downgraded to a warn.
+repo_body=$(function_body ensure_arm_package_repo)
+[[ $repo_body != *'grep -q '\''^\[omarchy-aarch64\]'\'' /etc/pacman.conf && return 0'* ]] ||
+  fail "the Quattro upgrade refreshes an already-configured ARM repo"
+grep -F 'sudo pacman -Sy --noconfirm' <<<"$repo_body" >/dev/null ||
+  fail "the Quattro upgrade refreshes ARM package databases"
+grep -F 'fail "Could not refresh package databases.' <<<"$repo_body" >/dev/null ||
+  fail "the Quattro upgrade stops when the ARM package database cannot refresh"
+if grep -F 'Could not refresh package databases after adding the ARM repo' <<<"$repo_body" >/dev/null; then
+  fail "the Quattro upgrade does not continue on a failed ARM database refresh"
+fi
+pass "the Quattro upgrade refreshes and validates ARM package databases"
+
 # Issue #208: the package pass attempted every name in the default set, so a 3.x
 # machine spent hours on AUR builds install.sh deliberately skips -- and one of
 # them, quickshell-git, fails outright on the pre-upgrade GL stack.


### PR DESCRIPTION
## Summary
- refresh the ARM package databases even when the repo stanza already exists
- stop the Quattro upgrade with an actionable error when the refresh fails
- add regression coverage for stale metadata and the fatal refresh path

## Verification
- `test/shell.d/upgrade-to-quattro-mac-test.sh`
- `test/shell.d/aarch64-packages-test.sh`
- `bash -n` and ShellCheck on changed scripts
- `git diff --check`

This addresses the upgrade variant of the stale-database/404 failure reported in #211.