### PR TITLE
Allow fresh Steam installs to bootstrap on Apple Silicon

### DIFF
--- a/bin/omarchy-install-gaming-gpu-lib32
+++ b/bin/omarchy-install-gaming-gpu-lib32
@@ -27,4 +27,8 @@ elif omarchy-hw-nvidia-without-gsp; then
   PACKAGES+=(lib32-nvidia-580xx-utils)
 fi
 
-(( ${#PACKAGES[@]} > 0 )) && omarchy-pkg-add "${PACKAGES[@]}"
+if (( ${#PACKAGES[@]} > 0 )); then
+  omarchy-pkg-add "${PACKAGES[@]}"
+else
+  echo "No supported GPU detected; skipping lib32 graphics drivers."
+fi

--- a/bin/omarchy-install-gaming-steam
+++ b/bin/omarchy-install-gaming-steam
@@ -9,6 +9,10 @@ echo "Installing Steam..."
 omarchy-pkg-add steam
 omarchy-install-gaming-gpu-lib32
 
+if [[ $(uname -m) == aarch64 ]]; then
+  omarchy-launch-steam --prepare
+fi
+
 echo ""
 echo "Steam will start automatically now. This might take a while..."
 

--- a/bin/omarchy-launch-steam
+++ b/bin/omarchy-launch-steam
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# omarchy:summary=Launch Steam, applying Asahi muvm login workarounds on Apple Silicon
+# omarchy:group=launch
+# omarchy:args=[--prepare|steam-args...]
+
+set -euo pipefail
+
+write_steam_desktop() {
+  local app_dir="$HOME/.local/share/applications"
+  mkdir -p "$app_dir"
+  cat >"$app_dir/steam.desktop" <<'EOF'
+[Desktop Entry]
+Name=Steam
+Comment=Application for managing and playing games on Steam
+Exec=omarchy-launch-steam %U
+Icon=steam
+Terminal=false
+Type=Application
+Categories=Network;FileTransfer;Game;
+MimeType=x-scheme-handler/steam;x-scheme-handler/steamlink;
+EOF
+}
+
+patch_steam_ui() {
+  local steamui="$HOME/.local/share/Steam/steamui"
+  [[ -d $steamui ]] || return 0
+
+  python3 - "$steamui" <<'PY'
+import pathlib
+import re
+import sys
+
+steamui = pathlib.Path(sys.argv[1])
+pattern = re.compile(
+    r"const t=\(0,(\w+)\.(\w+)\)\(\"System\.Network\.RegisterForDeviceChanges\"\);"
+    r"t&&SteamClient\.System\.Network\.RegisterForDeviceChanges\(this\.OnNetworkDevicesChanged\),"
+    r"\(0,\1\.\2\)\(\"System\.Network\.GetProxyInfo\"\)&&SteamClient\.System\.Network\.GetProxyInfo\(\)\.then\(e=>this\.m_proxyInfo=e\),"
+    r"\(0,\1\.\2\)\(\"System\.Network\.RegisterForConnectivityTestChanges\"\)&&SteamClient\.System\.Network\.RegisterForConnectivityTestChanges\(this\.OnConnectivityTestStateChanged\),"
+    r"t\|\|\(this\.m_bIsAwaitingInitialNetworkState=!1\)"
+)
+replacement = (
+    r'const t=(0,\1.\2)("System.Network.RegisterForDeviceChanges")'
+    r'&&!!(SteamClient.System&&SteamClient.System.Network&&"function"==typeof SteamClient.System.Network.RegisterForDeviceChanges);'
+    r'try{t&&SteamClient.System.Network.RegisterForDeviceChanges(this.OnNetworkDevicesChanged)}catch(e){}'
+    r'try{(0,\1.\2)("System.Network.GetProxyInfo")&&SteamClient.System.Network.GetProxyInfo().then(e=>this.m_proxyInfo=e)}catch(e){}'
+    r'try{(0,\1.\2)("System.Network.RegisterForConnectivityTestChanges")&&SteamClient.System.Network.RegisterForConnectivityTestChanges(this.OnConnectivityTestStateChanged)}catch(e){}'
+    r'this.m_bIsAwaitingInitialNetworkState=!1,this.m_bIsConnectedToANetwork=!0'
+)
+
+for path in sorted(steamui.glob("chunk~*.js")):
+    text = path.read_text(errors="replace")
+    if "m_bIsConnectedToANetwork=!0" in text and "RegisterForDeviceChanges" in text:
+        continue
+    updated, count = pattern.subn(replacement, text, count=1)
+    if count != 1:
+        continue
+    backup = path.with_suffix(path.suffix + ".omarchy-bak")
+    if not backup.exists():
+        backup.write_text(text)
+    path.write_text(updated)
+PY
+}
+
+prepare_asahi() {
+  [[ $(uname -m) == aarch64 ]] || return 0
+  write_steam_desktop
+  patch_steam_ui
+}
+
+if [[ ${1:-} == --prepare ]]; then
+  prepare_asahi
+  exit 0
+fi
+
+if [[ $(uname -m) == aarch64 ]] && omarchy-cmd-present muvm && omarchy-cmd-present FEXBash; then
+  prepare_asahi
+  launcher="$HOME/.local/share/fex-steam/steam-launcher/bin_steam.sh"
+  extra="-cef-force-occlusion -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles"
+
+  if [[ -f $launcher ]]; then
+    exec muvm -- FEXBash -c "$launcher $extra $*"
+  fi
+fi
+
+exec steam "$@"

--- a/bin/omarchy-launch-steam
+++ b/bin/omarchy-launch-steam
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+steam_root="$HOME/.local/share/Steam"
+
 write_steam_desktop() {
   local app_dir="$HOME/.local/share/applications"
   mkdir -p "$app_dir"
@@ -22,8 +24,19 @@ MimeType=x-scheme-handler/steam;x-scheme-handler/steamlink;
 EOF
 }
 
+steam_client_ready() {
+  [[ -f $steam_root/steamui.so && -d $steam_root/steamui ]]
+}
+
+launch_fex_steam() {
+  local launcher="$1"
+  shift
+
+  exec muvm -- FEXBash -c 'exec "$@"' omarchy-steam "$launcher" "$@"
+}
+
 patch_steam_ui() {
-  local steamui="$HOME/.local/share/Steam/steamui"
+  local steamui="$steam_root/steamui"
   [[ -d $steamui ]] || return 0
 
   python3 - "$steamui" <<'PY'
@@ -74,12 +87,23 @@ if [[ ${1:-} == --prepare ]]; then
 fi
 
 if [[ $(uname -m) == aarch64 ]] && omarchy-cmd-present muvm && omarchy-cmd-present FEXBash; then
-  prepare_asahi
   launcher="$HOME/.local/share/fex-steam/steam-launcher/bin_steam.sh"
-  extra="-cef-force-occlusion -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles"
 
   if [[ -f $launcher ]]; then
-    exec muvm -- FEXBash -c "$launcher $extra $*"
+    steam_args=(-cef-force-occlusion)
+    if steam_client_ready; then
+      prepare_asahi
+      steam_args+=(
+        -noverifyfiles
+        -nobootstrapupdate
+        -skipinitialbootstrap
+        -norepairfiles
+      )
+    else
+      write_steam_desktop
+    fi
+
+    launch_fex_steam "$launcher" "${steam_args[@]}" "$@"
   fi
 fi
 

--- a/bin/omarchy-launch-steam
+++ b/bin/omarchy-launch-steam
@@ -25,7 +25,7 @@ EOF
 }
 
 steam_client_ready() {
-  [[ -f $steam_root/steamui.so && -d $steam_root/steamui ]]
+  [[ -d $steam_root/steamui ]] && compgen -G "$steam_root/*/steamui.so" >/dev/null
 }
 
 launch_fex_steam() {

--- a/bin/omarchy-remove-gaming-steam
+++ b/bin/omarchy-remove-gaming-steam
@@ -7,9 +7,15 @@ set -e
 
 omarchy-pkg-drop steam
 
+desktop="$HOME/.local/share/applications/steam.desktop"
+if [[ -f $desktop ]] && grep -q 'omarchy-launch-steam' "$desktop"; then
+  rm -f "$desktop"
+fi
+
 rm -rf \
   "$HOME/.steam" \
   "$HOME/.local/share/Steam" \
+  "$HOME/.local/share/fex-steam" \
   "$HOME/.config/steam" \
   "$HOME/.cache/steam"
 

--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,6 +1,4 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
-o.window({ class = "^steam$", title = "Sign in to Steam" }, { center = true, size = { 1100, 700 } })
-o.window({ class = "^steam$", title = "negative:Friends List" }, { min_size = { 900, 560 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/default/hypr/apps/steam.lua
+++ b/default/hypr/apps/steam.lua
@@ -1,4 +1,6 @@
 o.window("steam", { float = true, idle_inhibit = "fullscreen" })
 o.window({ class = "steam", title = "Steam" }, { center = true, size = { 1100, 700 } })
+o.window({ class = "^steam$", title = "Sign in to Steam" }, { center = true, size = { 1100, 700 } })
+o.window({ class = "^steam$", title = "negative:Friends List" }, { min_size = { 900, 560 } })
 o.window("steam.*", { tag = "-default-opacity", opacity = "1 1" })
 o.window({ class = "steam", title = "Friends List" }, { size = { 460, 800 } })

--- a/migrations/1787606800.sh
+++ b/migrations/1787606800.sh
@@ -1,0 +1,5 @@
+echo "Work around Steam Waiting for network on Apple Silicon"
+
+[[ $(uname -m) == aarch64 ]] || exit 0
+omarchy-pkg-present steam || exit 0
+omarchy-launch-steam --prepare

--- a/test/shell.d/desktop-entry-launch-test.sh
+++ b/test/shell.d/desktop-entry-launch-test.sh
@@ -17,7 +17,7 @@ printf 'pkg:%s\n' "$*" >>"$OMARCHY_TEST_LOG"
 exit "${OMARCHY_TEST_PKG_STATUS:-0}"
 SH
 
-for command in omarchy-pkg-aur-add omarchy-install-emacs omazed omarchy-theme-set-vscode omarchy-install-gaming-gpu-lib32; do
+for command in omarchy-pkg-aur-add omarchy-install-emacs omazed omarchy-theme-set-vscode omarchy-install-gaming-gpu-lib32 omarchy-launch-steam; do
   cat >"$mock_bin/$command" <<'SH'
 #!/bin/bash
 exit 0

--- a/test/shell.d/steam-asahi-launch-test.sh
+++ b/test/shell.d/steam-asahi-launch-test.sh
@@ -59,6 +59,17 @@ pass "fresh Steam launches without bootstrap suppression flags"
 
 mkdir -p "$steam_root/steamui"
 touch "$steam_root/steamui.so"
+run_launcher --root-level-only
+
+for suppressed_flag in -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles; do
+  if grep -Fqx -- "$suppressed_flag" "$call_log"; then
+    fail "a root-level steamui.so does not falsely mark Steam as bootstrapped"
+  fi
+done
+pass "a root-level steamui.so does not falsely mark Steam as bootstrapped"
+
+mkdir -p "$steam_root/ubuntu12_32"
+touch "$steam_root/ubuntu12_32/steamui.so"
 run_launcher --existing
 
 for suppressed_flag in -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles; do

--- a/test/shell.d/steam-asahi-launch-test.sh
+++ b/test/shell.d/steam-asahi-launch-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+test_home="$test_tmp/home"
+steam_root="$test_home/.local/share/Steam"
+launcher="$test_home/.local/share/fex-steam/steam-launcher/bin_steam.sh"
+call_log="$test_tmp/muvm-calls"
+
+mkdir -p "$stub_bin" "$steam_root" "$(dirname -- "$launcher")"
+touch "$launcher"
+
+cat >"$stub_bin/uname" <<'SH'
+#!/bin/bash
+if [[ ${1:-} == -m ]]; then
+  printf 'aarch64\n'
+else
+  exec /usr/bin/uname "$@"
+fi
+SH
+
+cat >"$stub_bin/omarchy-cmd-present" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/muvm" <<'SH'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_MUVM_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_launcher() {
+  HOME="$test_home" \
+    PATH="$stub_bin:$ROOT/bin:$PATH" \
+    OMARCHY_TEST_MUVM_LOG="$call_log" \
+    bash "$ROOT/bin/omarchy-launch-steam" "$@"
+}
+
+run_launcher --first-run "steam://open test"
+
+grep -Fxq -- "-cef-force-occlusion" "$call_log" ||
+  fail "fresh Steam launch keeps the Apple Silicon occlusion workaround"
+for suppressed_flag in -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles; do
+  if grep -Fqx -- "$suppressed_flag" "$call_log"; then
+    fail "fresh Steam launch does not pass $suppressed_flag before bootstrap"
+  fi
+done
+grep -Fxq -- "steam://open test" "$call_log" ||
+  fail "fresh Steam launch preserves arguments containing spaces"
+pass "fresh Steam launches without bootstrap suppression flags"
+
+mkdir -p "$steam_root/steamui"
+touch "$steam_root/steamui.so"
+run_launcher --existing
+
+for suppressed_flag in -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles; do
+  grep -Fxq -- "$suppressed_flag" "$call_log" ||
+    fail "bootstrapped Steam launch keeps $suppressed_flag"
+done
+pass "bootstrapped Steam launches with persistent workaround flags"

--- a/test/shell.d/steam-asahi-prepare-test.sh
+++ b/test/shell.d/steam-asahi-prepare-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+export HOME="$test_tmp/home"
+mkdir -p "$HOME/.local/share/Steam/steamui" "$HOME/.local/share/applications"
+
+unpatched='prefix const t=(0,B.Dp)("System.Network.RegisterForDeviceChanges");t&&SteamClient.System.Network.RegisterForDeviceChanges(this.OnNetworkDevicesChanged),(0,B.Dp)("System.Network.GetProxyInfo")&&SteamClient.System.Network.GetProxyInfo().then(e=>this.m_proxyInfo=e),(0,B.Dp)("System.Network.RegisterForConnectivityTestChanges")&&SteamClient.System.Network.RegisterForConnectivityTestChanges(this.OnConnectivityTestStateChanged),t||(this.m_bIsAwaitingInitialNetworkState=!1) suffix'
+printf '%s' "$unpatched" >"$HOME/.local/share/Steam/steamui/chunk~deadbeef.js"
+
+PATH="$ROOT/bin:$PATH" bash "$ROOT/bin/omarchy-launch-steam" --prepare
+
+desktop="$HOME/.local/share/applications/steam.desktop"
+if [[ $(uname -m) != aarch64 ]]; then
+  [[ ! -f $desktop ]] || fail "prepare is a no-op off aarch64"
+  pass "prepare is a no-op off aarch64"
+  exit 0
+fi
+
+grep -q 'Exec=omarchy-launch-steam' "$desktop" || fail "prepare writes a Steam desktop entry"
+pass "prepare writes a Steam desktop entry"
+
+patched=$(<"$HOME/.local/share/Steam/steamui/chunk~deadbeef.js")
+[[ $patched == *'typeof SteamClient.System.Network.RegisterForDeviceChanges'* ]] || fail "prepare guards RegisterForDeviceChanges" "$patched"
+[[ $patched == *'this.m_bIsAwaitingInitialNetworkState=!1,this.m_bIsConnectedToANetwork=!0'* ]] || fail "prepare clears the waiting-for-network flag"
+[[ -f $HOME/.local/share/Steam/steamui/chunk~deadbeef.js.omarchy-bak ]] || fail "prepare backs up the original chunk"
+pass "prepare patches the Steam UI network store"
+
+PATH="$ROOT/bin:$PATH" bash "$ROOT/bin/omarchy-launch-steam" --prepare
+[[ $(<"$HOME/.local/share/Steam/steamui/chunk~deadbeef.js") == "$patched" ]] || fail "prepare is idempotent"
+pass "prepare is idempotent"

--- a/test/shell.d/steam-gpu-lib32-test.sh
+++ b/test/shell.d/steam-gpu-lib32-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/lspci" <<'SH'
+#!/bin/bash
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-hw-nvidia-gsp" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/omarchy-hw-nvidia-without-gsp" <<'SH'
+#!/bin/bash
+exit 1
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+touch "$OMARCHY_TEST_PKG_ADD_CALLED"
+exit 99
+SH
+
+chmod +x "$stub_bin"/*
+
+export OMARCHY_TEST_PKG_ADD_CALLED="$test_tmp/pkg-add-called"
+
+if ! PATH="$stub_bin:$ROOT/bin:$PATH" bash "$ROOT/bin/omarchy-install-gaming-gpu-lib32" >"$test_tmp/output" 2>&1; then
+  fail "the GPU helper succeeds when no supported GPU is detected"
+fi
+
+[[ ! -e $OMARCHY_TEST_PKG_ADD_CALLED ]] ||
+  fail "the GPU helper does not try to install an empty package list"
+grep -Fq 'No supported GPU detected' "$test_tmp/output" ||
+  fail "the GPU helper explains why it skipped lib32 drivers"
+pass "the GPU helper treats an unsupported GPU as a successful no-op"


### PR DESCRIPTION
Replacement for #226, whose head branch is in a contributor fork and cannot be updated by this account.

Fresh Apple Silicon Steam installs now launch without bootstrap-suppression flags until both steamui.so and the steamui directory exist. Existing installs keep the patched UI and persistent workaround flags. The FEXBash handoff now preserves Steam arguments as a quoted argv.

The branch also makes the lib32 GPU helper a successful no-op when no supported Intel/AMD/NVIDIA GPU is detected. Without this, set -e made the Steam installer abort on Apple/QEMU guests after Steam was installed but before first launch.

Tested:
- steam-asahi-launch-test.sh
- steam-asahi-prepare-test.sh
- steam-gpu-lib32-test.sh
- desktop-entry-launch-test.sh
- bash syntax and diff checks
- disposable UTM ARM64 guest: Steam package transaction completed and the installer returned 0 after the GPU-helper fix

The UTM guest cannot complete the FEX launch because muvm requires nested KVM, which this macOS-hosted guest does not expose: Error creating the Kvm object: Error(2). The installer and desktop-entry path are validated; actual Steam UI execution needs bare-metal Asahi or a VM with nested KVM.