### PR TITLE
Retire leftover Asahi alarm from wheel on existing installs

### DIFF
--- a/migrations/1787744855.sh
+++ b/migrations/1787744855.sh
@@ -1,0 +1,33 @@
+echo "Retire the Asahi bootstrap account from wheel when a different owner is already an administrator"
+
+# Asahi Alarm's image uses alarm as its bootstrap administrator. Guided setup
+# now removes it from wheel once a permanent owner has sudo, but that change
+# was force-pushed off quattro and only restored later. Installs from the gap
+# still have alarm in wheel; polkit then authenticates the bootstrap account
+# instead of the owner. Locking alarm does not help: the agent still picks it.
+
+[[ $(uname -m) == "aarch64" ]] || exit 0
+[[ $(id -un) != "alarm" ]] || exit 0
+id -u alarm >/dev/null 2>&1 || exit 0
+
+user_in_group() {
+  local user="$1" group="$2"
+  id -nG "$user" 2>/dev/null | tr ' ' '\n' | grep -qx "$group"
+}
+
+user_in_group alarm wheel || exit 0
+
+# Do not demote alarm if that would leave wheel with no other member. The
+# installer refuses the same handoff until the permanent owner is in wheel.
+other_admins=0
+wheel_members=$(getent group wheel | cut -d: -f4)
+IFS=',' read -ra members <<<"$wheel_members"
+for member in "${members[@]}"; do
+  if [[ -n $member && $member != "alarm" ]]; then
+    other_admins=1
+    break
+  fi
+done
+(( other_admins )) || exit 0
+
+sudo gpasswd -d alarm wheel >/dev/null

--- a/test/shell.d/asahi-alarm-wheel-migration-test.sh
+++ b/test/shell.d/asahi-alarm-wheel-migration-test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# The Asahi alarm-in-wheel repair must remove the bootstrap account from wheel
+# when a different owner is already an administrator, and must no-op when
+# alarm is the owner, missing, already demoted, or the only remaining admin.
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1787744855.sh"
+[[ -f $migration ]] || fail "alarm-from-wheel migration exists"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+stub_bin="$test_dir/bin"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/id" <<'STUB'
+#!/bin/bash
+case "${1:-}:${2:-}" in
+  -un:)
+    printf '%s\n' "${STUB_ME:?}"
+    ;;
+  -u:alarm)
+    [[ ${STUB_ALARM_EXISTS:-0} == 1 ]] || exit 1
+    printf '1000\n'
+    ;;
+  -nG:alarm)
+    [[ ${STUB_ALARM_EXISTS:-0} == 1 ]] || exit 1
+    printf '%s\n' "${STUB_ALARM_GROUPS:?}"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+
+cat >"$stub_bin/getent" <<'STUB'
+#!/bin/bash
+[[ $1 == group && $2 == wheel ]] || exit 1
+printf 'wheel:x:998:%s\n' "${STUB_WHEEL_MEMBERS:?}"
+STUB
+
+cat >"$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+
+cat >"$stub_bin/gpasswd" <<'STUB'
+#!/bin/bash
+echo "$@" >>"${GPASSWD_CALLS:?}"
+STUB
+
+cat >"$stub_bin/uname" <<'STUB'
+#!/bin/bash
+[[ $1 == -m ]] || exit 1
+printf '%s\n' "${STUB_ARCH:-aarch64}"
+STUB
+
+chmod +x "$stub_bin/id" "$stub_bin/getent" "$stub_bin/sudo" "$stub_bin/gpasswd" "$stub_bin/uname"
+
+gpasswd_calls="$test_dir/gpasswd-calls"
+
+run_migration() {
+  rm -f "$gpasswd_calls"
+  STUB_ME="$1" STUB_ALARM_EXISTS="$2" STUB_ALARM_GROUPS="$3" STUB_WHEEL_MEMBERS="$4" \
+    STUB_ARCH="${STUB_ARCH:-aarch64}" \
+    GPASSWD_CALLS="$gpasswd_calls" PATH="$stub_bin:$PATH" \
+    bash -euo pipefail "$migration" >/dev/null
+}
+
+# x86_64: a coincidental alarm-in-wheel must not be touched.
+STUB_ARCH=x86_64 run_migration naeem 1 "alarm wheel" "alarm,naeem" || fail "migration runs on x86_64"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not touch wheel off aarch64"
+pass "migration no-ops on x86_64"
+
+# Gap install: owner is not alarm, both are in wheel, alarm is listed first.
+run_migration naeem 1 "alarm wheel" "alarm,naeem" || fail "migration runs for a gap install"
+[[ -f $gpasswd_calls ]] || fail "migration removes alarm from wheel on a gap install"
+grep -qx -- "-d alarm wheel" "$gpasswd_calls" || fail "migration calls gpasswd -d alarm wheel"
+pass "migration removes alarm when a different owner is already in wheel"
+
+# Same repair with the owner listed first in /etc/group.
+run_migration naeem 1 "alarm wheel" "naeem,alarm" || fail "migration runs when owner is listed first"
+grep -qx -- "-d alarm wheel" "$gpasswd_calls" || fail "migration still removes alarm when owner is listed first"
+pass "migration does not depend on /etc/group member order"
+
+# The account running migrate is alarm: they chose it as the owner.
+run_migration alarm 1 "alarm wheel" "alarm" || fail "migration runs when alarm is the current user"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not demote alarm when it is the current user"
+pass "migration keeps alarm in wheel when it is the chosen owner"
+
+# No bootstrap account (or a machine that never had one).
+run_migration naeem 0 "naeem wheel" "naeem" || fail "migration runs when alarm does not exist"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not call gpasswd when alarm is missing"
+pass "migration no-ops when alarm does not exist"
+
+# Already repaired, including this machine: alarm exists but is not in wheel.
+run_migration naeem 1 "alarm" "naeem" || fail "migration runs when alarm is already out of wheel"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not call gpasswd when alarm is already out of wheel"
+pass "migration no-ops when alarm is already out of wheel"
+
+# Owner was never added to wheel: demoting alarm would leave no administrator.
+run_migration naeem 1 "alarm wheel" "alarm" || fail "migration runs when alarm is the only wheel member"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not demote alarm when it is the only administrator"
+pass "migration refuses to leave wheel with no administrator"
+
+# A uid-1001 user exists in passwd but is not in wheel. The suggested snippet
+# would still gpasswd; this migration must not.
+run_migration extra 1 "alarm wheel" "alarm" || fail "migration runs when a non-wheel extra user is current"
+[[ ! -f $gpasswd_calls ]] || fail "migration must not use a non-wheel extra user as the owner check"
+pass "migration does not demote alarm just because some other user exists"
+
+# Idempotent rerun after a successful repair.
+run_migration naeem 1 "alarm wheel" "alarm,naeem" || fail "first repair run succeeds"
+run_migration naeem 1 "alarm" "naeem" || fail "second run after repair succeeds"
+[[ ! -f $gpasswd_calls ]] || fail "second run must not call gpasswd again"
+pass "migration is a no-op on rerun after alarm has left wheel"


### PR DESCRIPTION
Fixes #257

## What was true on this machine

This host is aarch64 (`apple,j313`), owner `naeem` uid 1001, `alarm` uid 1000. It was installed **after** #205 (2026-08-25), so `getent group wheel` is already `wheel:x:998:naeem` and packaged `omarchy-mac-setup` contains `retire_asahi_admin`. The live polkit failure is **not** present here.

The gap described in the issue **is** real:

- `d3b8f9ba` (`retire_asahi_admin`) is not an ancestor of quattro at `4c7aa553` (the tip just before #205). The force-push erased #193; #205 restored it at 19:04Z.
- 125 migrations; none touch `alarm` / `wheel` (the only `alarm` hit is the Widevine “asahi-alarm repo” comment).
- `omarchy update` therefore cannot repair machines installed in that window.

Polkit on this system is `unix-group:wheel`. Omarchy's agent never sets `selectedIdentity`; Quickshell defaults to **the first identity**. Combined with `usermod -aG` appending the owner after `alarm`, PAM authenticates `alarm`. Locking `alarm` does not change that.

## Suggested snippet vs this change

The issue snippet works on the happy path (uid 1001 in wheel, `alarm` also in wheel). It is **not** safe when uid 1001 exists but is **not** in `wheel`: it still runs `gpasswd -d alarm wheel` and can leave `wheel` empty.

Reproduced on aarch64 Docker (`ubuntu:24.04`, real `useradd`/`gpasswd`/`sudo`):

```text
before: wheel:x:998:alarm,owner
after:  wheel:x:998:owner
PASS: real gpasswd removed alarm, kept owner, alarm account remains
PASS: rerun is a no-op
PASS: alarm-as-owner stays in wheel
PASS: our migration keeps the only admin
hole after: wheel:x:998:
CONFIRMED HOLE: suggested snippet removed the only wheel member
```

This migration follows `retire_asahi_admin()` instead:

- aarch64 only
- current user is not `alarm`
- `alarm` exists and is in `wheel`
- some **other** `wheel` member already exists
- then `sudo gpasswd -d alarm wheel`

No reboot: polkit re-reads NSS; the owner's session groups are unchanged.

## Validation

- `bash test/shell.d/asahi-alarm-wheel-migration-test.sh` — 9/9
- aarch64 Docker, real `gpasswd` — happy path, idempotent rerun, owner=`alarm`, only-admin, snippet hole
- `bash -n` on the migration; `bin/omarchy commands --check` (453 commands)
- `./test/all`: new file passes; 4 pre-existing failures (`omarchy-pkgs` missing, locale `C`, about-window animation) unchanged