### PR TITLE
Trust the Asahi Alarm signing key during the Quattro upgrade

### DIFF
--- a/bin/omarchy-upgrade-to-quattro-mac
+++ b/bin/omarchy-upgrade-to-quattro-mac
@@ -55,6 +55,7 @@ confirm() {
 
 checkout="$HOME/.local/share/omarchy"
 upgrade_ref="${OMARCHY_UPGRADE_REF:-quattro}"
+readonly asahi_alarm_key="12CE6799A94A3F1B5DDFFE88F576553597FB8FEB"
 yes=0
 auto_reboot=0
 
@@ -162,6 +163,28 @@ validate_quattro_tree() {
   log "The '$upgrade_ref' tree at $checkout is Quattro ($version)"
 }
 
+# The Asahi Alarm image ships this keyring already, so a Mac installed from it
+# has the master key trusted. A 3.x machine put together on a generic aarch64
+# base does not, and pacman refuses to create the asahi-alarm database until
+# that key is trusted: the refresh below fails, and the Quattro package pass
+# then reports "database file for 'asahi-alarm' does not exist" rather than the
+# signing-key problem that caused it (#235). Mirrors install.sh's
+# ensure_asahi_alarm_keyring; the upgrade is self-contained, so it carries its
+# own copy.
+ensure_asahi_alarm_keyring() {
+  grep -q '^\[asahi-alarm\]' /etc/pacman.conf || return 0
+  pacman -Q asahi-alarm-keyring >/dev/null 2>&1 && return 0
+
+  if ! sudo pacman-key --list-keys "$asahi_alarm_key" >/dev/null 2>&1; then
+    log "Importing the Asahi Alarm package signing key"
+    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keys.openpgp.org
+  fi
+  sudo pacman-key --lsign-key "$asahi_alarm_key" >/dev/null
+
+  log "Installing the Asahi Alarm package keyring"
+  sudo pacman -Sy --needed --noconfirm asahi-alarm-keyring
+}
+
 # A 3.x machine's /etc/pacman.conf predates the [omarchy-aarch64] repo. Without
 # it, every Quattro package that the ARM repo serves as a prebuilt binary
 # resolves to an hours-long AUR build instead -- quickshell-git's build even
@@ -178,6 +201,8 @@ ensure_arm_package_repo() {
 
   log "Adding the Omarchy ARM package repo"
   printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
+
+  ensure_asahi_alarm_keyring
   sudo pacman -Sy --noconfirm >/dev/null 2>&1 ||
     warn "Could not refresh package databases after adding the ARM repo."
 }

--- a/test/shell.d/upgrade-to-quattro-mac-test.sh
+++ b/test/shell.d/upgrade-to-quattro-mac-test.sh
@@ -166,3 +166,95 @@ if (( installs_quickshell )); then
     fail "a failed quickshell install reports through fail(), not a silent set -e abort"
   pass "a failed quickshell install reports through fail()"
 fi
+
+# Issue #235: a machine put together on a generic aarch64 base carries the
+# [asahi-alarm] stanza without its signing keyring, and pacman will not create
+# that database until the master key is trusted. install.sh bootstraps the key
+# before it refreshes; the upgrade refreshes the same databases, so it needs the
+# same bootstrap or the Quattro package pass fails with a missing database and
+# never names the key as the cause.
+keyring_body=$(function_body ensure_asahi_alarm_keyring)
+[[ -n $keyring_body ]] || fail "the Mac Quattro upgrade bootstraps the Asahi Alarm keyring"
+
+grep -qF 'pacman-key --recv-keys "$asahi_alarm_key"' <<<"$keyring_body" ||
+  fail "the upgrade bootstraps the Asahi Alarm package signing key"
+grep -qF 'pacman-key --lsign-key "$asahi_alarm_key"' <<<"$keyring_body" ||
+  fail "the upgrade locally trusts the Asahi Alarm package signing key"
+grep -qF 'pacman -Sy --needed --noconfirm asahi-alarm-keyring' <<<"$keyring_body" ||
+  fail "the upgrade installs the Asahi Alarm package keyring"
+
+# Trusting the key after the refresh it exists to unblock would fix nothing.
+keyring_call=$(grep -n '^  ensure_asahi_alarm_keyring$' "$upgrade_to_quattro_mac" | cut -d: -f1)
+refresh_call=$(grep -n 'pacman -Sy --noconfirm' "$upgrade_to_quattro_mac" | grep -v -- '--needed' |
+  head -1 | cut -d: -f1)
+[[ -n $keyring_call && -n $refresh_call ]] ||
+  fail "the upgrade bootstraps the Asahi keyring before refreshing package databases"
+(( keyring_call < refresh_call )) ||
+  fail "the Asahi keyring is trusted before the package database refresh"
+
+# Two copies of the same bootstrap, because the upgrade is self-contained and
+# cannot source the installer. The fingerprint is the one part that turns silent
+# if it drifts, so pin them to each other rather than to a literal here.
+install_key=$(grep -oE 'asahi_alarm_key="[0-9A-F]+"' "$ROOT/install.sh" | head -1)
+upgrade_key=$(grep -oE 'asahi_alarm_key="[0-9A-F]+"' "$upgrade_to_quattro_mac" | head -1)
+[[ -n $install_key ]] || fail "install.sh pins the Asahi Alarm signing key"
+[[ $upgrade_key == "$install_key" ]] ||
+  fail "the upgrade pins the same Asahi Alarm signing key as install.sh" "installer: $install_key
+upgrade:   $upgrade_key"
+pass "the Quattro upgrade trusts the Asahi Alarm signing key before refreshing"
+
+# Both early exits matter: a machine without the stanza has nothing to trust,
+# and one that already has the keyring must not be sent to a keyserver on every
+# upgrade. Run the function against stubs rather than read its guards.
+keyring_probe=$(mktemp -d)
+mkdir -p "$keyring_probe/bin"
+cat >"$keyring_probe/bin/grep" <<'SH'
+#!/bin/bash
+exit "${STUB_STANZA_PRESENT:-0}"
+SH
+cat >"$keyring_probe/bin/pacman" <<'SH'
+#!/bin/bash
+if [[ $1 == "-Q" ]]; then
+  exit "${STUB_KEYRING_INSTALLED:-0}"
+fi
+printf 'pacman %s\n' "$*" >>"$STUB_LOG"
+SH
+cat >"$keyring_probe/bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$STUB_LOG"
+# An untrusted key: --list-keys fails, so the import path has to run.
+[[ $1 == "pacman-key" && $2 == "--list-keys" ]] && exit 1
+exit 0
+SH
+chmod +x "$keyring_probe/bin/grep" "$keyring_probe/bin/pacman" "$keyring_probe/bin/sudo"
+
+run_keyring_bootstrap() {
+  (
+    export PATH="$keyring_probe/bin:$PATH"
+    export STUB_LOG="$keyring_probe/calls" STUB_STANZA_PRESENT="$1" STUB_KEYRING_INSTALLED="$2"
+    : >"$STUB_LOG"
+    log() { :; }
+    asahi_alarm_key="probe-key"
+    eval "$(awk '/^ensure_asahi_alarm_keyring\(\) \{/,/^\}/' "$upgrade_to_quattro_mac")"
+    ensure_asahi_alarm_keyring
+  )
+  cat "$keyring_probe/calls"
+}
+
+calls=$(run_keyring_bootstrap 1 0)
+[[ -z $calls ]] ||
+  fail "no Asahi repo stanza means nothing to bootstrap" "$calls"
+
+calls=$(run_keyring_bootstrap 0 0)
+[[ -z $calls ]] ||
+  fail "an installed asahi-alarm-keyring is left alone" "$calls"
+
+calls=$(run_keyring_bootstrap 0 1)
+grep -qF 'pacman-key --recv-keys probe-key' <<<"$calls" ||
+  fail "a missing keyring imports the signing key" "$calls"
+grep -qF 'pacman-key --lsign-key probe-key' <<<"$calls" ||
+  fail "a missing keyring locally signs the imported key" "$calls"
+grep -qF 'pacman -Sy --needed --noconfirm asahi-alarm-keyring' <<<"$calls" ||
+  fail "a missing keyring is installed from the repo" "$calls"
+rm -rf "$keyring_probe"
+pass "the keyring bootstrap runs only where it is needed"


### PR DESCRIPTION
`install.sh` learned to bootstrap the Asahi Alarm signing key before it refreshes the package databases (b3770ce, #229). The Quattro upgrade refreshes the same databases from its own copy of that code path and never got the same treatment, so a 3.x Mac that was put together on a generic aarch64 base still walks into #235 — just later, and with a worse error.

`ensure_arm_package_repo` adds the `[omarchy-aarch64]` stanza and then runs `pacman -Sy`. On a machine whose `/etc/pacman.conf` also carries `[asahi-alarm]` without `asahi-alarm-keyring` installed, pacman stops on the unknown master key:

```
error: asahi-alarm: key "12CE6799A94A3F1B5DDFFE88F576553597FB8FEB" is unknown
error: failed to synchronize all databases (unexpected error)
```

The refresh output is discarded and the failure is downgraded to a warning, so the upgrade continues and `install_quattro_packages` reports the misleading `database file for 'asahi-alarm' does not exist` instead — for a package that has nothing to do with the key.

This ports `ensure_asahi_alarm_keyring` from `install.sh` verbatim and calls it before the refresh. Both guards are kept: no `[asahi-alarm]` stanza means nothing to trust, and an already-installed keyring is left alone, so a Mac installed from the Asahi Alarm image (the common case) does not touch a keyserver on upgrade.

The upgrade script is self-contained by design — 3.x users pipe it straight from `curl` — so it carries its own copy rather than sourcing the installer. The test pins the fingerprint to `install.sh`'s, since that is the part that would go quiet if the two ever drift.

### Tests

`test/shell.d/upgrade-to-quattro-mac-test.sh` gains the wiring checks that `install-mac-test.sh` already makes for the installer, plus a stubbed run of the function itself covering all three paths (no stanza, keyring present, keyring missing).

```
bash test/shell.d/upgrade-to-quattro-mac-test.sh   # 12 ok
bin/omarchy commands --check                       # 453 commands
bash -n on both changed files
```

`./test/all` has four failures on my machine that are also present on a pristine `quattro` checkout, so they are not from this change: two want a sibling `omarchy-pkgs` checkout for PKGBUILD coverage, and two need a live session (`config-test`'s per-screen IPC count, `theme-install-guards-test`'s URL check).

Reverting the `bin/` change alone fails the new test.

### Note

Overlaps textually with #250, which restructures the same function. Whichever lands first, I'll rebase.
