### PR TITLE
Allow a Mac-only pkgrel when building omarchy packages

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -5,6 +5,10 @@
 # omarchy, omarchy-settings, omarchy-keyring, and ttf-jetbrains-mono-nerd-basic
 # are all arch=any, so they need no architecture-specific build. The only Apple
 # Silicon delta is the limine bootloader stack, patched out below.
+#
+# OMARCHY_PKGREL bumps pkgrel on omarchy and omarchy-settings only, so a Mac
+# hotfix can ship as 4.0.1-2 without waiting for an upstream 4.0.2 tag. Leave
+# it unset to keep the PKGBUILD values.
 
 set -euo pipefail
 
@@ -59,6 +63,16 @@ find_omarchy_pkgs() {
 
 # Drop the limine entries from depends=() without forking the PKGBUILD, so it
 # keeps tracking upstream and only this delta is ours.
+set_pkgrel() {
+  local pkgbuild="$1" rel=${OMARCHY_PKGREL:-}
+
+  [[ -n $rel ]] || return 0
+  [[ $rel =~ ^[0-9]+$ ]] || fail "OMARCHY_PKGREL must be a whole number, got: $rel"
+  grep -qE '^pkgrel=' "$pkgbuild" || fail "no pkgrel= in $pkgbuild"
+  sed -i "s/^pkgrel=.*/pkgrel=$rel/" "$pkgbuild"
+  grep -qx "pkgrel=$rel" "$pkgbuild" || fail "could not set pkgrel=$rel in $pkgbuild"
+}
+
 strip_limine_dependencies() {
   local pkgbuild="$1" dependency
 
@@ -110,6 +124,9 @@ build_package() {
   if [[ $package == "omarchy" ]]; then
     strip_limine_dependencies "$build_dir/$package/PKGBUILD"
   fi
+  if [[ $package == "omarchy" || $package == "omarchy-settings" ]]; then
+    set_pkgrel "$build_dir/$package/PKGBUILD"
+  fi
 
   # SRCDEST caches downloaded sources outside the throwaway build directory, so
   # a rebuild does not re-fetch the 125 MB font archive.
@@ -152,4 +169,6 @@ main() {
   ls -1 "$output_dir"/*.pkg.tar.*
 }
 
-main "$@"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -61,18 +61,21 @@ find_omarchy_pkgs() {
   return 1
 }
 
-# Drop the limine entries from depends=() without forking the PKGBUILD, so it
-# keeps tracking upstream and only this delta is ours.
 set_pkgrel() {
   local pkgbuild="$1" rel=${OMARCHY_PKGREL:-}
 
+  # Mac hotfixes repackage the same upstream pkgver between tags, so they bump
+  # pkgrel rather than pkgver to stay upgradeable without stealing the next
+  # upstream tag. Unset OMARCHY_PKGREL to keep the PKGBUILD values.
   [[ -n $rel ]] || return 0
-  [[ $rel =~ ^[0-9]+$ ]] || fail "OMARCHY_PKGREL must be a whole number, got: $rel"
+  [[ $rel =~ ^[1-9][0-9]*$ ]] || fail "OMARCHY_PKGREL must be a positive whole number, got: $rel"
   grep -qE '^pkgrel=' "$pkgbuild" || fail "no pkgrel= in $pkgbuild"
   sed -i "s/^pkgrel=.*/pkgrel=$rel/" "$pkgbuild"
   grep -qx "pkgrel=$rel" "$pkgbuild" || fail "could not set pkgrel=$rel in $pkgbuild"
 }
 
+# Drop the limine entries from depends=() without forking the PKGBUILD, so it
+# keeps tracking upstream and only this delta is ours.
 strip_limine_dependencies() {
   local pkgbuild="$1" dependency
 

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -43,6 +43,29 @@ for limine_package in limine limine-mkinitcpio-hook limine-snapper-sync; do
 done
 pass "the package build drops the limine stack from the Apple Silicon dependencies"
 
+# The hotfix rebuild number has to land on omarchy and omarchy-settings, not
+# the keyring or the font. Run in a subshell: sourcing the builder replaces
+# fail() with one that exits without TAP.
+rel_dir=$(mktemp -d)
+printf 'pkgrel=1\n' >"$rel_dir/PKGBUILD"
+if ! (
+  source "$build_script"
+  set_pkgrel "$rel_dir/PKGBUILD"
+  [[ $(cat "$rel_dir/PKGBUILD") == "pkgrel=1" ]] || exit 1
+  OMARCHY_PKGREL=2 set_pkgrel "$rel_dir/PKGBUILD"
+  [[ $(cat "$rel_dir/PKGBUILD") == "pkgrel=2" ]] || exit 1
+  if ( OMARCHY_PKGREL=nope set_pkgrel "$rel_dir/PKGBUILD" >/dev/null 2>&1 ); then
+    exit 1
+  fi
+); then
+  rm -rf "$rel_dir"
+  fail "set_pkgrel no-ops without OMARCHY_PKGREL, writes a number, and rejects junk"
+fi
+rm -rf "$rel_dir"
+grep -A2 'package == "omarchy-settings"' "$build_script" | grep -q set_pkgrel ||
+  fail "the package build stamps pkgrel on omarchy and omarchy-settings"
+pass "the package build can stamp a Mac-only pkgrel on omarchy and omarchy-settings"
+
 # The refresh runs from omarchy-reinstall-configs under set -e, so a machine
 # without limine must no-op rather than abort the seeding step.
 grep -F 'omarchy-cmd-missing limine' "$ROOT/bin/omarchy-refresh-limine" >/dev/null ||

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -54,9 +54,11 @@ if ! (
   [[ $(cat "$rel_dir/PKGBUILD") == "pkgrel=1" ]] || exit 1
   OMARCHY_PKGREL=2 set_pkgrel "$rel_dir/PKGBUILD"
   [[ $(cat "$rel_dir/PKGBUILD") == "pkgrel=2" ]] || exit 1
-  if ( OMARCHY_PKGREL=nope set_pkgrel "$rel_dir/PKGBUILD" >/dev/null 2>&1 ); then
-    exit 1
-  fi
+  for bad in nope 0 02 -1 1.5; do
+    if ( OMARCHY_PKGREL=$bad set_pkgrel "$rel_dir/PKGBUILD" >/dev/null 2>&1 ); then
+      exit 1
+    fi
+  done
 ); then
   rm -rf "$rel_dir"
   fail "set_pkgrel no-ops without OMARCHY_PKGREL, writes a number, and rejects junk"


### PR DESCRIPTION
## Summary

Mac hotfixes on top of upstream 4.0.1 need to ship as `4.0.1-2`, not `4.0.2`. `build-packages.sh` now honors `OMARCHY_PKGREL` and stamps that rebuild number on `omarchy` and `omarchy-settings` only (not the keyring or font).

```bash
OMARCHY_PKGREL=2 ./build-packages.sh
```

That is what lets `pacman` / `omarchy update` see `4.0.1-1 → 4.0.1-2` after the packages are published to `omarchy-pkgs-aarch64` `edge`.

## Validation

- `bash -n build-packages.sh`
- `bash test/shell.d/install-mac-test.sh`