### PR TITLE
fix(install): preserve NetworkManager resolver during live ARM64 install

### DIFF
--- a/install/hardware/network.sh
+++ b/install/hardware/network.sh
@@ -52,11 +52,11 @@ if systemctl is-active --quiet NetworkManager.service 2>/dev/null; then
   systemctl stop systemd-networkd.service 2>/dev/null || true
 fi
 
-# Prefer systemd-resolved's stub when it is already available. During a live
-# install enable-services.sh only enables daemons; it deliberately does not
-# start them before reboot. Do not replace a working resolver with a dangling
-# stub link in that window, or later hardware setup loses network access.
-if [[ -e /run/systemd/resolve/stub-resolv.conf ]]; then
+# Prefer systemd-resolved's stub only when systemd-resolved is already active.
+# During a live install enable-services.sh only enables daemons; it deliberately
+# does not start them before reboot. Do not replace a working resolver with a
+# dangling stub link in that window, or later hardware setup loses network access.
+if systemctl is-active --quiet systemd-resolved.service 2>/dev/null && [[ -e /run/systemd/resolve/stub-resolv.conf ]]; then
   ln -sfn ../run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
 elif [[ -e /run/NetworkManager/resolv.conf ]]; then
   ln -sfn ../run/NetworkManager/resolv.conf /etc/resolv.conf


### PR DESCRIPTION
Fixes #231

During a live install, \`enable-services.sh\` only enables \`systemd-resolved.service\` but does not start it. The previous logic saw \`/run/systemd/resolve/stub-resolv.conf\` and linked it to \`/etc/resolv.conf\`, leaving later install steps without DNS because the stub pointed at a non-running daemon.

Now the script only switches to the systemd-resolved stub when the service is already active. Otherwise it keeps NetworkManager's resolver, which is the functional path during the live install. After reboot, \`systemd-resolved\` starts normally and the expected post-install resolver behavior is unchanged.