### PR TITLE
fix(migration): retire Asahi bootstrap admin on pre-fix installs

### DIFF
--- a/migrations/1787750000_retire_asahi_admin.sh
+++ b/migrations/1787750000_retire_asahi_admin.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Retire the Asahi bootstrap admin account on installs that predate setup-script fix"
+
+if ! id -u alarm >/dev/null 2>&1; then
+  exit 0
+fi
+
+owner=$(id -un 1001 2>/dev/null || true)
+if [[ ${owner:-} == alarm ]]; then
+  exit 0
+fi
+
+if ! id -nG alarm 2>/dev/null | tr ' ' '\n' | grep -qx wheel; then
+  exit 0
+fi
+
+if command -v gpasswd >/dev/null 2>&1; then
+  gpasswd -d alarm wheel || true
+fi
+
+if getent group wheel | grep -q alarm; then
+  echo "Warning: failed to remove alarm from wheel" >&2
+  exit 1
+fi
+
+echo "Removed alarm from wheel group"


### PR DESCRIPTION
Fixes #257

Installs performed during the PR #193 force-push window shipped with the \`alarm\` user still in the \`wheel\` group. Because polkit picks the lowest-UID \`wheel\` member for admin authentication, this caused every graphical prompt to fail even when the owner entered the correct password.

This migration removes \`alarm\` from \`wheel\` on installs that predate the setup-script fix, letting existing systems self-heal via \`omarchy update\`.