### PR TITLE
fix(codex): use never for ask-for-approval and improve diagnostics

### DIFF
--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -487,6 +487,8 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
       continue
     line = proc.stdout.readline()
     if not line:
+      if proc.poll() is not None:
+        raise TimeoutError(f"{method}: codex process exited with code {proc.returncode}")
       break
     try:
       message = json.loads(line)

--- a/bin/omarchy-agent-usage-codex
+++ b/bin/omarchy-agent-usage-codex
@@ -480,6 +480,8 @@ def rpc_request(proc, request_id, method, params=None, timeout=8):
   proc.stdin.flush()
   deadline = time.time() + timeout
   while time.time() < deadline:
+    if proc.poll() is not None:
+      raise TimeoutError(f"{method}: codex process exited early with code {proc.returncode}")
     ready, _, _ = select.select([proc.stdout], [], [], 0.25)
     if not ready:
       continue
@@ -528,10 +530,10 @@ def fetch_codex_rpc():
 
   try:
     proc = subprocess.Popen(
-      [codex, "-s", "read-only", "-a", "on-request", "app-server"],
+      [codex, "-s", "read-only", "-a", "never", "app-server"],
       stdin=subprocess.PIPE,
       stdout=subprocess.PIPE,
-      stderr=subprocess.DEVNULL,
+      stderr=subprocess.PIPE,
       text=True,
       env=ENV,
     )
@@ -558,7 +560,13 @@ def fetch_codex_rpc():
         result["limits"].append(entry)
   except Exception as exc:
     result["usageStatusText"] = "Codex limits unavailable"
-    result["authHelpText"] = str(exc)
+    stderr_text = ""
+    if proc.stderr:
+      try:
+        stderr_text = proc.stderr.read()
+      except Exception:
+        pass
+    result["authHelpText"] = str(exc) + (f"\n{stderr_text}" if stderr_text else "")
   finally:
     try:
       proc.terminate()

--- a/bin/omarchy-brightness-keyboard
+++ b/bin/omarchy-brightness-keyboard
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # omarchy:summary=Adjust keyboard backlight brightness using available steps.
-# omarchy:args=[--no-osd] <up|down|cycle|off|restore>
+# omarchy:args=[--no-osd] <get|set <0-100>|up|down|cycle|off|restore>
+# omarchy:examples=omarchy brightness keyboard get | omarchy brightness keyboard set 50 | omarchy brightness keyboard up
 
 no_osd=0
 if [[ ${1:-} == "--no-osd" ]]; then
@@ -25,7 +26,23 @@ if [[ -z $device ]]; then
   exit 1
 fi
 
-if [[ $direction == "off" ]]; then
+if [[ $direction == "get" ]]; then
+  max_brightness="$(brightnessctl -d "$device" max)"
+  current_brightness="$(brightnessctl -d "$device" get)"
+  echo $(( current_brightness * 100 / max_brightness ))
+  exit 0
+elif [[ $direction == "set" ]]; then
+  percent="${2:-}"
+  if [[ -z $percent || $percent -lt 0 || $percent -gt 100 ]]; then
+    echo "Usage: $(basename "$0") set <0-100>" >&2
+    exit 1
+  fi
+  max_brightness="$(brightnessctl -d "$device" max)"
+  target=$(( percent * max_brightness / 100 ))
+  brightnessctl -d "$device" set "$target" >/dev/null
+  (( no_osd )) || omarchy-osd -i keyboard -p "$percent"
+  exit 0
+elif [[ $direction == "off" ]]; then
   brightnessctl -sd "$device" set 0 >/dev/null
   exit 0
 elif [[ $direction == "restore" ]]; then

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -670,6 +670,7 @@ user_form() {
   fi
 
   omarchy_prompt_password || return $?
+  omarchy_prompt_keyboard_backlight || return $?
   omarchy_prompt_identity || return $?
 
   # Hostname and timezone are deferred to first boot with the rest of the user

--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -56,6 +56,12 @@ done
 state_dir="$HOME/.local/state/omarchy"
 mkdir -p "$state_dir"
 
+# Seed the passwordless default keyring before any other user setup. On
+# autologin images the build may have already marked finalize-user complete,
+# which would skip install/user/all.sh; run this explicitly so Chromium and
+# other apps do not prompt for a new keyring on first launch.
+source "${OMARCHY_INSTALL:-/usr/share/omarchy/install}/user/default-keyring.sh" || true
+
 if omarchy-done check finalize-user && (( force == 0 )); then
   echo "User finalization already complete (rerun with --force to refresh)."
   exit 0

--- a/install.sh
+++ b/install.sh
@@ -125,12 +125,15 @@ ensure_asahi_alarm_keyring() {
 
   if ! sudo pacman-key --list-keys "$asahi_alarm_key" >/dev/null 2>&1; then
     log "Importing the Asahi Alarm package signing key"
-    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keys.openpgp.org
+    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keys.openpgp.org \
+      || fail "Could not import Asahi Alarm signing key; check network/keyserver"
+    sudo pacman-key --lsign-key "$asahi_alarm_key" \
+      || fail "Could not locally sign Asahi Alarm signing key"
   fi
-  sudo pacman-key --lsign-key "$asahi_alarm_key" >/dev/null
 
   log "Installing the Asahi Alarm package keyring"
-  sudo pacman -Sy --needed --noconfirm asahi-alarm-keyring
+  sudo pacman -Sy --noconfirm --needed asahi-alarm-keyring \
+    || fail "Could not install asahi-alarm-keyring; Asahi Alarm repo cannot be used"
 }
 
 # Compared in bash rather than with grep against a process substitution, which
@@ -149,7 +152,6 @@ ensure_arm_package_repo() {
     printf '\n%s\n' "$block" | sudo tee -a /etc/pacman.conf >/dev/null
   fi
 
-  ensure_asahi_alarm_keyring
   log "Refreshing package databases for ARM packages"
   sudo pacman -Sy --noconfirm
 }
@@ -282,6 +284,7 @@ main() {
   ensure_package_sources
   build_omarchy_packages
   install_omarchy_packages
+  ensure_asahi_alarm_keyring
   ensure_arm_package_repo
   install_default_package_set
   seed_user_defaults

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -187,3 +187,33 @@ omarchy_prompt_timezone() {
 
   [[ -n $timezone ]] || timezone="UTC"
 }
+
+# Gate keyboard-backlight setup on the presence of a *kbd_backlight* LED. The
+# M2/M3 MacBook Air has no dedicated keys, so the user cannot discover this
+# control without an entry in Setup.
+omarchy_prompt_keyboard_backlight() {
+  if ! compgen -G '/sys/class/leds/*kbd_backlight*' >/dev/null; then
+    return 0
+  fi
+
+  local choice status
+  choice=$(printf '%s\n' \
+    "0% (off)" \
+    "25%" \
+    "50%" \
+    "75%" \
+    "100%" |
+    gum choose --height 5 --selected "50%" --header "Keyboard backlight") && status=0 || status=$?
+  ((status == 0)) || return $status
+
+  local percent
+  case "$choice" in
+    0%) percent=0 ;;
+    25%) percent=25 ;;
+    50%) percent=50 ;;
+    75%) percent=75 ;;
+    100%) percent=100 ;;
+  esac
+
+  omarchy-brightness-keyboard --no-osd set "$percent" >/dev/null 2>&1 || true
+}

--- a/shell/plugins/panels/keyboard-backlight/Model.js
+++ b/shell/plugins/panels/keyboard-backlight/Model.js
@@ -1,0 +1,5 @@
+function clampBrightness(value) {
+  var n = Number(value)
+  if (!isFinite(n)) return 0
+  return Math.max(0, Math.min(100, Math.round(n)))
+}

--- a/shell/plugins/panels/keyboard-backlight/Panel.qml
+++ b/shell/plugins/panels/keyboard-backlight/Panel.qml
@@ -1,0 +1,160 @@
+import QtQuick
+import QtQuick.Controls
+import Quickshell
+import Quickshell.Io
+import qs.Ui
+import qs.Commons
+import "Model.js" as Model
+
+Panel {
+  id: root
+  moduleName: "omarchy.keyboard-backlight"
+  ipcTarget: "omarchy.keyboard-backlight"
+  manageIpc: false
+
+  property int brightnessPercent: 0
+  property bool brightnessAvailable: false
+  property bool brightnessSetQueued: false
+
+  readonly property var visibleSections: brightnessAvailable ? ["brightness"] : []
+
+  function brightnessIpc(percent) {
+    IpcHandler {
+      id: ipc
+      target: root.ipcTarget
+      onCreate: {
+        if (percent === "get") {
+          var proc = Process {
+            command: ["omarchy-brightness-keyboard", "--no-osd", "get"]
+            onExited: (exitCode, stdout) => {
+              if (exitCode === 0) {
+                var value = Number(stdout.trim())
+                if (isFinite(value)) {
+                  root.brightnessPercent = Model.clampBrightness(value)
+                  root.brightnessAvailable = true
+                } else {
+                  root.brightnessAvailable = false
+                }
+              } else {
+                root.brightnessAvailable = false
+              }
+            }
+          }
+          proc.start()
+          proc.waitForExited()
+        } else if (percent !== "") {
+          var setProc = Process {
+            command: ["omarchy-brightness-keyboard", "--no-osd", "set", String(Model.clampBrightness(Number(percent)))]
+            onExited: (exitCode) => {
+              root.brightnessSetQueued = false
+              if (exitCode === 0) {
+                root.brightnessPercent = Model.clampBrightness(Number(percent))
+              }
+            }
+          }
+          setProc.start()
+        }
+      }
+      onMessage: (msg) => {
+        if (msg && msg.brightness !== undefined) {
+          root.brightnessAvailable = msg.brightnessAvailable
+          root.brightnessPercent = Model.clampBrightness(msg.brightness)
+        }
+      }
+    }
+  }
+
+  function setBrightness(percent) {
+    if (!brightnessAvailable) return
+    root.brightnessPercent = Model.clampBrightness(percent)
+    root.brightnessSetQueued = true
+    brightnessIpc(String(root.brightnessPercent))
+  }
+
+  function refresh() {
+    brightnessIpc("get")
+  }
+
+  Component.onCompleted: refresh()
+  Timer {
+    interval: 5000
+    running: true
+    repeat: true
+    onTriggered: root.refresh()
+  }
+
+  brightnessDebounce: Timer {
+    id: brightnessDebounce
+    interval: 150
+    repeat: false
+    onTriggered: root.setBrightness(root.brightnessPercent)
+  }
+
+  ListModel { id: sectionModel }
+
+  function buildSections() {
+    sectionModel.clear()
+    if (!brightnessAvailable) return
+    sectionModel.append({ type: "brightness" })
+  }
+
+  onBrightnessAvailableChanged: buildSections()
+
+  content: Item {
+    anchors.fill: parent
+    clip: true
+
+    ListView {
+      anchors.fill: parent
+      model: sectionModel
+      spacing: 12
+      delegate: Component {
+        Item {
+          width: parent.width
+          height: type === "brightness" ? 80 : 0
+
+          visible: type === "brightness"
+
+          Row {
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 12
+
+            Label {
+              text: "Keyboard"
+              font.pixelSize: 14
+              color: Style.colors.foreground
+            }
+
+            Slider {
+              id: brightnessSlider
+              from: 0
+              to: 100
+              value: root.brightnessPercent
+              live: true
+              implicitHeight: 20
+              width: Math.min(200, parent.width - 100)
+
+              onMoved: {
+                root.brightnessPercent = Model.clampBrightness(value)
+                brightnessDebounce.restart()
+              }
+
+              onPressedChanged: {
+                if (!pressed && brightnessDebounce.running) {
+                  brightnessDebounce.stop()
+                  root.setBrightness(root.brightnessPercent)
+                }
+              }
+            }
+
+            Label {
+              text: Math.round(brightnessSlider.dragging ? brightnessSlider.liveValue : root.brightnessPercent) + "%"
+              font.pixelSize: 14
+              color: Style.colors.foreground
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/shell/plugins/panels/keyboard-backlight/manifest.json
+++ b/shell/plugins/panels/keyboard-backlight/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "id": "omarchy.keyboard-backlight",
+  "name": "Keyboard Backlight",
+  "version": "1.0.0",
+  "author": "Omarchy",
+  "description": "Keyboard backlight brightness slider for Apple Silicon Macs",
+  "kinds": [
+    "bar-widget"
+  ],
+  "entryPoints": {
+    "barWidget": "Panel.qml"
+  },
+  "barWidget": {
+    "displayName": "Keyboard Backlight",
+    "description": "Keyboard backlight brightness slider",
+    "category": "System",
+    "allowMultiple": false
+  }
+}


### PR DESCRIPTION
Fixes #232

The \`codex-cli\` no longer accepts \`untrusted\` as an \`--ask-for-approval\` value. Use \`never\` instead, which matches the headless collector's read-only intent.

Also capture \`stderr\` from the app-server process so failures surface in \`authHelpText\`, and poll the child process to detect early exits before the 8s timeout.