### PR TITLE
fix(provision): seed default keyring before finalize-user check

### DIFF
--- a/bin/omarchy-provision-user
+++ b/bin/omarchy-provision-user
@@ -56,6 +56,14 @@ done
 state_dir="$HOME/.local/state/omarchy"
 mkdir -p "$state_dir"
 
+# Seed the passwordless default keyring before any other user setup. On
+# autologin images the build may have already marked finalize-user complete,
+# which would skip install/user/all.sh; run this explicitly so Chromium and
+# other apps do not prompt for a new keyring on first launch.
+if ! source "${OMARCHY_INSTALL:-/usr/share/omarchy/install}/user/default-keyring.sh"; then
+  echo "Warning: default-keyring.sh failed; continuing without passwordless keyring" >&2
+fi
+
 if omarchy-done check finalize-user && (( force == 0 )); then
   echo "User finalization already complete (rerun with --force to refresh)."
   exit 0


### PR DESCRIPTION
Fixes #252

On autologin images the build may have already marked \`finalize-user\` complete, which skips \`install/user/all.sh\` and therefore \`default-keyring.sh\`. Seed the passwordless default keyring explicitly so Chromium and other apps do not prompt for a new keyring on first launch.