### PR TITLE
feat(keyboard-backlight): add Setup prompt gated on kbd_backlight LED

### DIFF
--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -670,6 +670,7 @@ user_form() {
   fi
 
   omarchy_prompt_password || return $?
+  omarchy_prompt_keyboard_backlight || return $?
   omarchy_prompt_identity || return $?
 
   # Hostname and timezone are deferred to first boot with the rest of the user
@@ -686,6 +687,7 @@ confirm_form() {
   echo
   echo -e "Field,Value
 Keyboard,${keyboard_label:-English (US)}
+Keyboard backlight,${keyboard_backlight:-[Skipped]}
 Username,$username
 Password,$(printf "%${#password}s" | tr ' ' '*')
 Full name,${full_name:-[Skipped]}

--- a/install/provisioning/setup-form.sh
+++ b/install/provisioning/setup-form.sh
@@ -187,3 +187,35 @@ omarchy_prompt_timezone() {
 
   [[ -n $timezone ]] || timezone="UTC"
 }
+
+# Gate keyboard-backlight setup on the presence of a *kbd_backlight* LED. The
+# M2/M3 MacBook Air has no dedicated keys, so the user cannot discover this
+# control without an entry in Setup.
+omarchy_prompt_keyboard_backlight() {
+  if ! compgen -G '/sys/class/leds/*kbd_backlight*' >/dev/null; then
+    keyboard_backlight=""
+    return 0
+  fi
+
+  local choice status
+  choice=$(printf '%s\n' \
+    "0% (off)" \
+    "25%" \
+    "50%" \
+    "75%" \
+    "100%" |
+    gum choose --height 5 --selected "50%" --header "Keyboard backlight") && status=0 || status=$?
+  ((status == 0)) || return $status
+
+  local percent
+  case "$choice" in
+    0%) percent=0 ;;
+    25%) percent=25 ;;
+    50%) percent=50 ;;
+    75%) percent=75 ;;
+    100%) percent=100 ;;
+  esac
+
+  keyboard_backlight="$percent"
+  omarchy-brightness-keyboard --no-osd set "$percent" >/dev/null 2>&1 || true
+}


### PR DESCRIPTION
Fixes #260

Add \`omarchy_prompt_keyboard_backlight()\` to setup-form.sh and call it during owner provisioning when a \`*kbd_backlight*\` LED is present.