### PR TITLE
Install the Apple Video Decoder stack on Apple Silicon

### DIFF
--- a/install/hardware/all.sh
+++ b/install/hardware/all.sh
@@ -43,6 +43,7 @@ run_logged "$OMARCHY_INSTALL/hardware/apple/fix-brcmfmac-supplicant.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/fix-asahi-hid-race.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/enable-notch.sh"
 run_logged "$OMARCHY_INSTALL/hardware/apple/audio.sh"
+run_logged "$OMARCHY_INSTALL/hardware/apple/video-decode.sh"
 
 run_logged "$OMARCHY_INSTALL/hardware/lenovo/fix-yoga-pro7-bass-speakers.sh"
 

--- a/install/hardware/apple/video-decode.sh
+++ b/install/hardware/apple/video-decode.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Hardware video decode on Apple Silicon needs two packages that no repository
+# outside omarchy-aarch64 carries.
+#
+# The kernel already has the driver: CONFIG_VIDEO_APPLE_AVD=m, and it autoloads
+# and autoprobes on its own. What it does not have is firmware. Asahi wrote a
+# clean MIT-licensed replacement for the Apple Video Decoder rather than
+# extracting Apple's, but nobody packaged it, so every boot on a stock install
+# ends with the driver giving up:
+#
+#   avd 269080000.avd: Direct firmware load for apple/avd-fw-v2-t0.bin failed with error -2
+#   avd 269080000.avd: probe with driver avd failed with error -2
+#
+# avd-fw supplies that blob and the decoder appears as /dev/video1.
+#
+# Firmware alone is not enough to be useful. AVD is a *stateless* decoder,
+# which almost nothing on the desktop speaks -- ffmpeg's v4l2m2m decoders are
+# stateful and will never negotiate with it. libva-v4l2_request-avd is the
+# VA-API translation layer that bridges the two, and it installs itself as
+# asahi_drv_video.so, which is the name libva derives from the DRM render node
+# here, so applications find the decoder with no environment variable set.
+#
+# What this buys: about 84% less CPU time spent decoding. The power saving is
+# real but modest -- roughly 0.2 W off a machine drawing about 7.8 W during
+# playback. mpv, ffmpeg and GStreamer benefit; Chromium on Arch Linux ARM has
+# VA-API compiled out of the build, so it cannot use this today.
+#
+# The decoder only probes at boot, so nothing here rebinds it: the reboot that
+# follows setup is what brings it up. The migration that reuses this leaf on an
+# existing install asks for that reboot, which is what the changed flag is for.
+
+compatible="${OMARCHY_APPLE_COMPATIBLE:-/proc/device-tree/compatible}"
+OMARCHY_AVD_PACKAGES_CHANGED=0
+
+# Every device-tree machine has a compatible file, so it has to name Apple --
+# otherwise a Raspberry Pi would install the Asahi video stack too.
+[[ $(uname -m) == "aarch64" ]] || return 0
+[[ -f $compatible ]] && grep -Faiq 'apple,' "$compatible" || return 0
+
+if omarchy-pkg-missing avd-fw libva-v4l2_request-avd; then
+  echo "Installing Apple Silicon hardware video decode"
+  omarchy-pkg-add avd-fw libva-v4l2_request-avd ||
+    echo "Warning: hardware video decode packages could not be installed; video decodes in software."
+
+  # A warning rather than a failure: hardware setup runs under set -e, and
+  # software decode is a working fallback, not a broken machine.
+  if omarchy-pkg-present avd-fw libva-v4l2_request-avd; then
+    OMARCHY_AVD_PACKAGES_CHANGED=1
+  else
+    echo "Warning: the hardware video decode stack is incomplete; video decodes in software." >&2
+  fi
+fi

--- a/migrations/1788044337.sh
+++ b/migrations/1788044337.sh
@@ -1,0 +1,17 @@
+echo "Enable hardware video decode on Apple Silicon"
+
+# Fresh installs run this leaf from omarchy-apply-hardware. Reuse it here so
+# existing installs get the same hardware gate and package set. The package
+# check makes this safe when another user has already set the machine up.
+video_setup="$OMARCHY_PATH/install/hardware/apple/video-decode.sh"
+[[ -f $video_setup ]] || exit 0
+
+source "$video_setup"
+
+# The apple-avd driver requests its firmware once, when it probes at boot, and
+# gives up when the file is not there. Installing the firmware under a running
+# kernel therefore changes nothing until the driver probes again, so a reboot
+# is what actually turns the decoder on.
+if (( ${OMARCHY_AVD_PACKAGES_CHANGED:-0} )); then
+  omarchy-state set reboot-required
+fi

--- a/test/shell.d/apple-video-decode-test.sh
+++ b/test/shell.d/apple-video-decode-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+leaf="$ROOT/install/hardware/apple/video-decode.sh"
+all="$ROOT/install/hardware/all.sh"
+migration=$(grep -rl 'Enable hardware video decode on Apple Silicon' "$ROOT/migrations" | head -n 1 || true)
+
+[[ -f $leaf ]] || fail "the Apple Silicon video decode setup leaf ships"
+grep -Fq 'apple/video-decode.sh' "$all" ||
+  fail "Apple Silicon video decode setup runs during hardware setup"
+[[ -n $migration ]] || fail "existing Apple Silicon installs get hardware video decode"
+pass "fresh and existing installs are wired to Apple Silicon video decode setup"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+compatible="$test_tmp/compatible"
+installed_marker="$test_tmp/avd-installed"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/uname" <<'SH'
+#!/bin/bash
+
+printf '%s\n' "$TEST_ARCH"
+SH
+
+cat >"$stub_bin/omarchy-pkg-missing" <<'SH'
+#!/bin/bash
+
+[[ ! -e $AVD_INSTALLED_MARKER ]]
+SH
+
+cat >"$stub_bin/omarchy-pkg-present" <<'SH'
+#!/bin/bash
+
+[[ -e $AVD_INSTALLED_MARKER ]]
+SH
+
+cat >"$stub_bin/omarchy-pkg-add" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-pkg-add' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+if (( ${PACKAGE_INSTALL_SUCCEEDS:-1} == 1 )); then
+  touch "$AVD_INSTALLED_MARKER"
+fi
+exit 0
+SH
+
+cat >"$stub_bin/omarchy-state" <<'SH'
+#!/bin/bash
+
+printf 'omarchy-state' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+SH
+
+chmod +x "$stub_bin"/*
+
+run_video_setup() {
+  local script="$1" arch="$2" machine="$3" install_succeeds="${4:-1}"
+  printf '%s\0' "$machine" >"$compatible"
+
+  PATH="$stub_bin:$PATH" \
+    TEST_ARCH="$arch" \
+    TEST_LOG="$calls" \
+    AVD_INSTALLED_MARKER="$installed_marker" \
+    PACKAGE_INSTALL_SUCCEEDS="$install_succeeds" \
+    OMARCHY_APPLE_COMPATIBLE="$compatible" \
+    OMARCHY_PATH="$ROOT" \
+    bash -euo pipefail -c 'source "$1"' bash "$script" >/dev/null
+}
+
+: >"$calls"
+run_video_setup "$leaf" aarch64 apple,j293
+
+expected_call=$'omarchy-pkg-add\tavd-fw\tlibva-v4l2_request-avd'
+grep -Fxq "$expected_call" "$calls" ||
+  fail "fresh Apple Silicon installs get the firmware and the VA-API driver" "$(cat "$calls")"
+pass "fresh Apple Silicon installs get the firmware and the VA-API driver"
+
+run_video_setup "$leaf" aarch64 apple,j293
+(( $(grep -Fxc "$expected_call" "$calls") == 1 )) ||
+  fail "fresh Apple Silicon video decode setup is idempotent" "$(cat "$calls")"
+pass "fresh Apple Silicon video decode setup is idempotent"
+
+rm -f "$installed_marker"
+: >"$calls"
+run_video_setup "$migration" aarch64 apple,j293
+grep -Fxq "$expected_call" "$calls" ||
+  fail "the migration enables video decode on an existing install" "$(cat "$calls")"
+expected_reboot=$'omarchy-state\tset\treboot-required'
+grep -Fxq "$expected_reboot" "$calls" ||
+  fail "the migration requests the reboot that lets the driver probe" "$(cat "$calls")"
+
+run_video_setup "$migration" aarch64 apple,j293
+(( $(grep -Fxc "$expected_call" "$calls") == 1 )) ||
+  fail "the Apple Silicon video decode migration is idempotent" "$(cat "$calls")"
+(( $(grep -Fxc "$expected_reboot" "$calls") == 1 )) ||
+  fail "an already enabled install does not request another reboot" "$(cat "$calls")"
+pass "the migration enables existing Apple Silicon installs idempotently"
+
+rm -f "$installed_marker"
+: >"$calls"
+errors="$test_tmp/errors.log"
+run_video_setup "$leaf" aarch64 apple,j293 0 2>"$errors" ||
+  fail "an incomplete install does not abort hardware setup" "$(cat "$errors")"
+grep -Fq 'hardware video decode stack is incomplete' "$errors" ||
+  fail "fresh setup explains the incomplete video decode stack" "$(cat "$errors")"
+
+: >"$calls"
+: >"$errors"
+run_video_setup "$migration" aarch64 apple,j293 0 2>"$errors" ||
+  fail "an incomplete install does not abort the migration" "$(cat "$errors")"
+! grep -Fq 'reboot-required' "$calls" ||
+  fail "an incomplete install does not ask for a pointless reboot" "$(cat "$calls")"
+pass "an incomplete package install warns instead of aborting"
+
+rm -f "$installed_marker"
+: >"$calls"
+run_video_setup "$migration" x86_64 apple,j293
+run_video_setup "$migration" aarch64 linux,dummy
+[[ ! -s $calls ]] ||
+  fail "Apple Silicon video decode setup skips unrelated hardware" "$(cat "$calls")"
+pass "Apple Silicon video decode setup skips unrelated hardware"


### PR DESCRIPTION
Adds an install leaf that pulls in the Apple Video Decoder packages on Apple
Silicon, plus a migration so existing installs get it and a shell test alongside
the asahi-audio one.

Without this the kernel's `apple-avd` driver fails to probe on every boot for
want of firmware, and video decodes in software. With it, HEVC and VP9 decode on
the hardware — including in Chromium, which reaches the decoder through V4L2 once
the firmware exists. H.264 still falls back to software; that's a Chromium
limitation I'm chasing separately.

The leaf is a no-op on non-Apple hardware and warns rather than fails if the
packages aren't available, since hardware setup runs under `set -e` and software
decode is a degradation rather than a broken install.

Depends on omarchy-mac/omarchy-pkgs-aarch64#3 — that has to land and publish
first or the leaf just warns.
