### PR TITLE
Ignore stale Chromium singleton locks during Copy URL repair

### DIFF
--- a/migrations/1786643346.sh
+++ b/migrations/1786643346.sh
@@ -124,12 +124,65 @@ unverified_repairs_exist() {
 
 # A browser only rewrites its own Preferences on exit, so a repair can only be
 # reverted by a browser attached to a profile this migration has to touch.
-# Whether a profile is open is mechanical: a running Chromium-family browser
-# holds a SingletonLock (and socket) inside its user-data-dir.
+# Chromium's POSIX SingletonLock is deliberately a symlink to a nonexistent
+# hostname-pid string, even while the browser is running. Classify that target
+# instead of treating the symlink itself as proof that a browser is attached.
 profile_open() {
-  # -L catches a SingletonLock left as a dangling symlink; -e covers a plain
-  # file, and -S the socket — any of them means a browser is attached.
-  [[ -L $1/SingletonLock || -e $1/SingletonLock || -S $1/SingletonSocket ]]
+  local profile_root="$1" lock="$1/SingletonLock" socket="$1/SingletonSocket"
+  local target host pid local_host process_name family
+
+  # Permission or metadata failures are ambiguous; defer rather than mutate a
+  # profile whose ownership cannot be inspected safely.
+  [[ -d $profile_root && -r $profile_root && -x $profile_root ]] || return 0
+  [[ -S $socket ]] && return 0
+  if [[ -e $lock && ! -L $lock ]]; then
+    # Older Chromium used a regular SingletonLock. Any present non-symlink
+    # lock remains conservative, including an unexpected object type.
+    return 0
+  fi
+  [[ -L $lock ]] || return 1
+
+  target=$(readlink "$lock") || return 0
+  host=${target%-*}
+  pid=${target##*-}
+  [[ -n $host && $host != "$target" && $pid =~ ^[0-9]+$ ]] || return 0
+  local_host=$(hostname 2>/dev/null) || return 0
+  [[ $host == "$local_host" ]] || return 0
+
+  # A missing local PID is stale. If kill -0 is inconclusive, ps distinguishes
+  # an absent PID from a live process whose signal permission is restricted.
+  command -v ps >/dev/null 2>&1 || return 0
+  if ! process_name=$(ps -p "$pid" -o comm= 2>/dev/null); then
+    kill -0 "$pid" 2>/dev/null && return 0
+    return 1
+  fi
+  if [[ -z $process_name ]]; then
+    kill -0 "$pid" 2>/dev/null && return 0
+    return 1
+  fi
+
+  process_name="${process_name#"${process_name%%[![:space:]]*}"}"
+  process_name="${process_name%"${process_name##*[![:space:]]}"}"
+  process_name=${process_name##*/}
+  case "$profile_root" in
+    */chromium) family=chromium ;;
+    */google-chrome|*/google-chrome-beta|*/google-chrome-unstable) family=google-chrome ;;
+    */BraveSoftware/Brave-Browser|*/BraveSoftware/Brave-Browser-Beta|*/BraveSoftware/Brave-Browser-Nightly) family=brave ;;
+    */microsoft-edge|*/microsoft-edge-beta|*/microsoft-edge-dev) family=edge ;;
+    */vivaldi) family=vivaldi ;;
+    */opera) family=opera ;;
+    */helium) family=helium ;;
+    *) return 0 ;;
+  esac
+
+  case "$family:$process_name" in
+    chromium:chromium|chromium:chromium-browser|chromium:chrome) return 0 ;;
+    google-chrome:google-chrome|google-chrome:chrome) return 0 ;;
+    brave:brave-browser|brave:brave) return 0 ;;
+    edge:microsoft-edge|edge:msedge) return 0 ;;
+    vivaldi:vivaldi|vivaldi:vivaldi-bin|opera:opera|helium:helium) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # Gate on a pending — or to-be-verified — profile actually being open, not on

--- a/test/shell.d/copy-url-shortcut-migration-test.sh
+++ b/test/shell.d/copy-url-shortcut-migration-test.sh
@@ -7,7 +7,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
 require_command jq
 require_command python3
 
-migration="$ROOT/migrations/1786643346.sh"
+migration="${MIGRATION_OVERRIDE:-$ROOT/migrations/1786643346.sh}"
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
@@ -30,36 +30,94 @@ mkdir -p "$stub_bin"
 
 REAL_PYTHON=$(command -v python3)
 export REAL_PYTHON
+local_host=$(hostname)
+live_pid=""
+socket_pid=""
 
 run_migration() {
   HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2>&1
 }
 
 # A running Chromium-family browser marks its profile root with a SingletonLock
-# symlink to <hostname>-<pid>, a target that never exists on disk. That lock —
-# not the mere presence of a browser process — is what the migration waits on.
+# symlink to <hostname>-<pid>, a target that never exists on disk. A dead local
+# PID is stale; a live PID is classified by its executable basename.
 open_browser() {
   mkdir -p "$profile_root"
-  ln -sfn "test-host-1234" "$profile_root/SingletonLock"
+  ln -sfn "$local_host-999999" "$profile_root/SingletonLock"
 }
 close_browser() {
-  rm -f "$profile_root/SingletonLock"
+  rm -f "$profile_root/SingletonLock" "$profile_root/SingletonSocket" "$profile_root/SingletonCookie"
+}
+open_process() {
+  open_process_at "$profile_root" "$1"
+}
+open_process_at() {
+  local process_root="$1" process_name="$2"
+  ln -s "$(command -v sleep)" "$test_dir/$process_name"
+  "$test_dir/$process_name" 30 &
+  live_pid=$!
+  for _ in {1..20}; do
+    kill -0 "$live_pid" 2>/dev/null && break
+    sleep 0.05
+  done
+  kill -0 "$live_pid" 2>/dev/null || fail "test process did not start"
+  ln -sfn "$local_host-$live_pid" "$process_root/SingletonLock"
+}
+close_process() {
+  if [[ -n $live_pid ]]; then
+    kill "$live_pid" 2>/dev/null || true
+    wait "$live_pid" 2>/dev/null || true
+    live_pid=""
+  fi
+  rm -f "$test_dir/chromium" "$test_dir/not-browser" "$test_dir/vivaldi-bin"
+}
+open_socket() {
+  SOCKET_PATH="$profile_root/SingletonSocket" "$REAL_PYTHON" -c '
+import os, socket, time
+server = socket.socket(socket.AF_UNIX)
+server.bind(os.environ["SOCKET_PATH"])
+server.listen(1)
+time.sleep(30)
+' &
+  socket_pid=$!
+  for _ in {1..20}; do
+    [[ -S $profile_root/SingletonSocket ]] && break
+    sleep 0.05
+  done
+  [[ -S $profile_root/SingletonSocket ]] || fail "test socket did not start"
+}
+close_socket() {
+  if [[ -n $socket_pid ]]; then
+    kill "$socket_pid" 2>/dev/null || true
+    wait "$socket_pid" 2>/dev/null || true
+    socket_pid=""
+  fi
+  rm -f "$profile_root/SingletonSocket"
 }
 
-# The affected profile being open prompts for the windows to be closed;
-# declining (or having no terminal to ask in) defers the repair so a
-# rewrite-on-exit cannot revert it.
+# A dead local PID is stale even though SingletonLock remains a dangling
+# symlink, so the migration repairs the profile and keeps the artifact.
 printf '#!/bin/bash\nexit 1\n' >"$stub_bin/gum"
 chmod +x "$stub_bin/gum"
 write_stale_preferences
 open_browser
 
-before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+run_migration || fail "migration repairs after a stale local SingletonLock"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+  fail "migration repairs despite a stale dangling SingletonLock"
+[[ -L $profile_root/SingletonLock ]] || fail "migration preserves the stale SingletonLock artifact"
+pass "migration classifies a dead local SingletonLock PID as stale"
+rm -f "$preferences.omarchy-copy-url-repair.bak"
 
-run_migration && fail "migration defers while the affected profile is open"
+# A regular legacy lock remains conservative and prompts before mutation.
+write_stale_preferences
+close_browser
+touch "$profile_root/SingletonLock"
+before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+run_migration && fail "migration defers while a regular SingletonLock exists"
 [[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$before_hash" ]] ||
-  fail "migration leaves preferences alone while the affected profile is open"
-pass "migration defers the repair while the affected profile is open"
+  fail "migration leaves preferences alone while a regular SingletonLock exists"
+pass "migration defers on a regular legacy SingletonLock"
 
 # gum paints its prompt on stderr, so that stream has to stay attached:
 # suppressing it leaves gum reading keys behind an unpainted screen, which
@@ -74,13 +132,14 @@ HOME="$home" PATH="$stub_bin:$PATH" bash -euo pipefail "$migration" >/dev/null 2
   fail "migration defers when the browser prompt is declined"
 grep -q "gum-prompt-painted" "$prompt_stderr" || fail "migration keeps the browser prompt visible"
 pass "migration keeps the browser prompt visible"
+rm -f "$profile_root/SingletonLock"
 
 # A browser holding a different profile root cannot revert this repair, so it
 # must not hold the update: the repair goes through without ever reaching the
 # prompt, which the still-declining gum stub would otherwise fail.
 close_browser
 mkdir -p "$home/.config/google-chrome"
-ln -sfn "test-host-1234" "$home/.config/google-chrome/SingletonLock"
+ln -sfn "foreign-host-999999" "$home/.config/google-chrome/SingletonLock"
 write_stale_preferences
 run_migration || fail "migration repairs while a different profile root is open"
 jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
@@ -88,10 +147,74 @@ jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].exten
 pass "migration ignores a browser on a different profile root"
 rm -f "$home/.config/google-chrome/SingletonLock" "$preferences.omarchy-copy-url-repair.bak"
 
+# Foreign-host and malformed targets are ambiguous and defer without changing
+# the profile. Dangling socket/cookie residue alone is not an active browser.
+for lock_target in "foreign-host-999999" "malformed-target"; do
+  write_stale_preferences
+  ln -sfn "$lock_target" "$profile_root/SingletonLock"
+  before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+  run_migration && fail "migration defers on lock target $lock_target"
+  [[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$before_hash" ]] ||
+    fail "migration leaves preferences alone for lock target $lock_target"
+  rm -f "$profile_root/SingletonLock"
+done
+ln -s "$profile_root/missing-socket" "$profile_root/SingletonSocket"
+ln -s "$profile_root/missing-cookie" "$profile_root/SingletonCookie"
+write_stale_preferences
+run_migration || fail "migration ignores dangling socket and cookie residue"
+[[ -L $profile_root/SingletonSocket && -L $profile_root/SingletonCookie ]] ||
+  fail "migration preserves dangling socket and cookie residue"
+pass "migration defers ambiguous locks and ignores dangling socket residue"
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonSocket" "$profile_root/SingletonCookie"
+
+# A real Unix SingletonSocket proves ownership even without a usable lock
+# target, while an executable-backed Chromium PID does the same through the
+# host/PID target.
+write_stale_preferences
+open_socket
+before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+run_migration && fail "migration defers while SingletonSocket is active"
+[[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$before_hash" ]] ||
+  fail "migration leaves preferences alone while SingletonSocket is active"
+close_socket
+pass "migration defers on an active SingletonSocket"
+
+write_stale_preferences
+open_process chromium
+before_hash=$(sha256sum "$preferences" | cut -d' ' -f1)
+run_migration && fail "migration defers for a live Chromium-family PID"
+[[ $(sha256sum "$preferences" | cut -d' ' -f1) == "$before_hash" ]] ||
+  fail "migration leaves preferences alone for a live Chromium-family PID"
+close_process
+rm -f "$profile_root/SingletonLock"
+pass "migration recognizes a live Chromium-family executable"
+
+vivaldi_profile_root="$home/.config/vivaldi"
+vivaldi_preferences="$vivaldi_profile_root/Default/Preferences"
+mkdir -p "$(dirname "$vivaldi_preferences")"
+jq -n --arg ghost "$ghost_id" --arg pinned "$pinned_id" '{extensions: {commands: {"linux:Alt+Shift+L": {command_name: "copy-url", extension: $ghost, global: false}}, settings: {($ghost): {commands: {"copy-url": {suggested_key: "Alt+Shift+L", was_assigned: true}}}, ($pinned): {commands: {"copy-url": {suggested_key: "Alt+Shift+L"}}}}}}' >"$vivaldi_preferences"
+open_process_at "$vivaldi_profile_root" vivaldi-bin
+before_hash=$(sha256sum "$vivaldi_preferences" | cut -d' ' -f1)
+run_migration && fail "migration defers for a live Vivaldi PID"
+[[ $(sha256sum "$vivaldi_preferences" | cut -d' ' -f1) == "$before_hash" ]] ||
+  fail "migration leaves preferences alone for a live Vivaldi PID"
+close_process
+rm -f "$vivaldi_profile_root/SingletonLock"
+pass "migration recognizes Vivaldi's vivaldi-bin executable"
+
+write_stale_preferences
+open_process not-browser
+run_migration || fail "migration treats a live non-browser PID as stale"
+jq -e --arg pinned "$pinned_id" '.extensions.commands["linux:Alt+Shift+L"].extension == $pinned' "$preferences" >/dev/null ||
+  fail "migration repairs after a non-browser PID reused the lock"
+close_process
+rm -f "$preferences.omarchy-copy-url-repair.bak" "$profile_root/SingletonLock"
+pass "migration treats a live non-browser PID as stale"
+
 # Closing the affected profile and confirming the prompt lets the repair
 # proceed.
 write_stale_preferences
-open_browser
+touch "$profile_root/SingletonLock"
 cat >"$stub_bin/gum" <<'STUB'
 #!/bin/bash
 "$CLOSE_BROWSER"
@@ -167,7 +290,7 @@ cat >"$stub_bin/python3" <<'STUB'
 # the check calls report a surviving ghost through their exit status.
 "${REAL_PYTHON}" "$@"
 status=$?
-[[ ${5:-} == "repair" ]] && ln -sfn "test-host-1234" "$HOME/.config/chromium/SingletonLock"
+[[ ${5:-} == "repair" ]] && touch "$HOME/.config/chromium/SingletonLock"
 exit $status
 STUB
 chmod +x "$stub_bin/python3"
@@ -210,7 +333,7 @@ rm -f "$preferences.omarchy-copy-url-repair.bak"
 write_stale_preferences
 run_migration || fail "repair run before the verification scenario"
 [[ -f $preferences.omarchy-copy-url-repair.bak ]] || fail "verification scenario has a repair backup"
-open_browser
+touch "$profile_root/SingletonLock"
 run_migration && fail "migration must not complete an unverified repair while a browser runs"
 pass "migration keeps an unverified repair pending while a browser runs"
 close_browser


### PR DESCRIPTION
## Summary

- classify Chromium singleton ownership from the lock host, PID, process family, and active socket
- repair profiles with stale local locks while failing closed for live, foreign, malformed, or legacy locks
- preserve singleton artifacts and cover every supported browser family, including `vivaldi-bin`

## Testing

- `bash test/shell.d/copy-url-shortcut-migration-test.sh` (19 assertions, macOS and Ubuntu 24.04)
- planted lock, family, Vivaldi, and post-repair mutations all fail the focused suite
- parser-aware syntax checks for every `bin/omarchy-*` command
- `/opt/homebrew/bin/bash bin/omarchy commands --check`
- `git diff --check`

`./test/all` was bounded at the existing `sleep-lock-test.sh` hang on macOS; the observed failures were unrelated host/tooling gaps, while the changed focused suite passed.

Fixes #312