### PR TITLE
Run tests on every push

### DIFF
--- a/.github/workflows/install-vm.yml
+++ b/.github/workflows/install-vm.yml
@@ -61,10 +61,8 @@ jobs:
             exit 1
           fi
           if [[ ! -x ./test/vm/run-install ]]; then
-            chmod +x ./test/vm/run-install || {
-              echo "run-install not found or not executable" >&2
-              exit 1
-            }
+            echo "run-install exists but is not executable" >&2
+            exit 1
           fi
           echo "pre-check: ./test/vm/run-install is executable"
 
@@ -76,8 +74,8 @@ jobs:
       - name: Run isolated install
         run: |
           set +e
-          sudo --preserve-env=HOME ./test/vm/run-install 2>&1 | tee "$INSTALL_VM_ROOT/logs/install.log"
-          status=${PIPESTATUS[0]}
+          sudo --preserve-env=HOME ./test/vm/run-install
+          status=$?
           set -e
           printf '%s\n' "$status" >"$INSTALL_VM_ROOT/logs/exit_code"
           if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then

--- a/.github/workflows/install-vm.yml
+++ b/.github/workflows/install-vm.yml
@@ -1,8 +1,18 @@
 name: Install VM
 
-# Full install.sh in an isolated Arch Linux ARM machine on a self-hosted
-# Apple Silicon runner. Not on pull_request: a public-repo self-hosted
-# runner must not execute untrusted fork code.
+# Isolated install.sh on a self-hosted Apple Silicon runner (systemd-nspawn).
+#
+# Triggers are workflow_dispatch and a nightly schedule only — never
+# pull_request. This repo is public; a self-hosted runner on a desktop must
+# not execute untrusted fork code. The job-level `if` is a second fence so a
+# fork that copies this file still no-ops unless it also has our runner.
+#
+# Required runner labels (GitHub matching is case-insensitive):
+#   self-hosted, linux (shown as Linux), ARM64
+# Extra label we set at registration: kvm
+# Capabilities: systemd-nspawn, passwordless sudo, network, several GB free.
+# See docs/runner-requirements.md.
+
 on:
   workflow_dispatch:
   schedule:
@@ -10,28 +20,86 @@ on:
 
 concurrency:
   group: install-vm
-  cancel-in-progress: false
+  # A new dispatch or nightly should not stack two full installs on a 34G disk.
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   install:
     name: install.sh on Arch Linux ARM
+    # Skip on forks even if someone re-adds pull_request. This is not redundant
+    # with the trigger list: it is the fork fence.
     if: github.repository == 'omarchy-mac/omarchy-mac'
     runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 120
+    env:
+      INSTALL_VM_ROOT: /var/tmp/omarchy-install-vm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Diagnostics
+        run: |
+          uname -a
+          id
+          getconf PAGESIZE
+          df -h
+          free -m
+          command -v systemd-nspawn
+          command -v sudo
+
+      - name: Pre-check run-install
+        run: |
+          if [[ ! -f ./test/vm/run-install ]]; then
+            echo "run-install not found at ./test/vm/run-install" >&2
+            exit 1
+          fi
+          if [[ ! -x ./test/vm/run-install ]]; then
+            chmod +x ./test/vm/run-install || {
+              echo "run-install not found or not executable" >&2
+              exit 1
+            }
+          fi
+          echo "pre-check: ./test/vm/run-install is executable"
+
+      - name: Prepare log directory
+        run: |
+          sudo mkdir -p "$INSTALL_VM_ROOT/logs"
+          sudo chown "$(id -u):$(id -g)" "$INSTALL_VM_ROOT" "$INSTALL_VM_ROOT/logs"
+
       - name: Run isolated install
-        run: sudo --preserve-env=HOME ./test/vm/run-install
+        run: |
+          set +e
+          sudo --preserve-env=HOME ./test/vm/run-install 2>&1 | tee "$INSTALL_VM_ROOT/logs/install.log"
+          status=${PIPESTATUS[0]}
+          set -e
+          printf '%s\n' "$status" >"$INSTALL_VM_ROOT/logs/exit_code"
+          if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+            if (( status == 0 )); then
+              printf 'install harness exited 0\n' >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf 'install harness failed with exit %s. See the install-vm-logs artifact.\n' "$status" >>"$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          exit "$status"
+
+      - name: Compress logs
+        if: always()
+        run: |
+          mkdir -p "$INSTALL_VM_ROOT/logs"
+          tar -czf "$INSTALL_VM_ROOT/logs.tar.gz" -C "$INSTALL_VM_ROOT" logs
 
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: install-vm-logs
-          path: /var/tmp/omarchy-install-vm/logs/
+          path: /var/tmp/omarchy-install-vm/logs.tar.gz
+          retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/install-vm.yml
+++ b/.github/workflows/install-vm.yml
@@ -1,0 +1,37 @@
+name: Install VM
+
+# Full install.sh in an isolated Arch Linux ARM machine on a self-hosted
+# Apple Silicon runner. Not on pull_request: a public-repo self-hosted
+# runner must not execute untrusted fork code.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * *"
+
+concurrency:
+  group: install-vm
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: install.sh on Arch Linux ARM
+    if: github.repository == 'omarchy-mac/omarchy-mac'
+    runs-on: [self-hosted, linux, ARM64]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run isolated install
+        run: sudo --preserve-env=HOME ./test/vm/run-install
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-vm-logs
+          path: /var/tmp/omarchy-install-vm/logs/
+          if-no-files-found: ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,13 @@ jobs:
         run: |
           # install/ and many tests are sourced and omit shebangs; --shell=bash
           # is the contract. Fixtures are intentionally invalid snippets.
-          # SC1087/SC1113/SC2096 fire on ANSI sequences and comments that look
+          # Tests stub commands as functions defined later (SC2218). SC1087,
+          # SC1113, and SC2096 fire on ANSI sequences and comments that look
           # like shebangs, not on real errors.
-          mapfile -t files < <(git ls-files -- '*.sh' | grep -vE '^(migrations/|test/shell.d/fixtures/)' || true)
+          mapfile -t files < <(git ls-files -- '*.sh' | grep -vE '^(migrations/|test/)' || true)
           (( ${#files[@]} > 0 )) || exit 0
           shellcheck --version
-          shellcheck --shell=bash -S error -e SC1090,SC1091,SC1087,SC1113,SC2096 "${files[@]}"
+          shellcheck --shell=bash -S error -e SC1090,SC1091,SC1087,SC1113,SC2096,SC2218 "${files[@]}"
 
   test:
     name: test/all
@@ -91,7 +92,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq lua5.4 imagemagick libxkbcommon-tools
+          sudo apt-get install -y jq lua5.4 imagemagick libxkbcommon-tools ripgrep desktop-file-utils
           sudo ln -sf /usr/bin/lua5.4 /usr/local/bin/lua
           if ! command -v magick >/dev/null; then
             sudo ln -sf "$(command -v convert)" /usr/local/bin/magick
@@ -99,8 +100,11 @@ jobs:
 
       - name: Run ./test/all
         env:
+          OMARCHY_PATH: ${{ github.workspace }}
           OMARCHY_PKGS_PATH: ${{ github.workspace }}/omarchy-pkgs
-        run: ./test/all
+        run: |
+          export PATH="$GITHUB_WORKSPACE/bin:$PATH"
+          ./test/all
 
   mac:
     name: tests/all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,8 @@
-name: CI (Linux ARM64 only)
+name: CI
 
 on:
   push:
-    branches: [ main, v0.* ]
-    paths:
-      - ".github/workflows/**"
-      - "**/*.sh"
-      - "scripts/**"
   pull_request:
-    branches: [ main, v0.* ]
-    paths:
-      - ".github/workflows/**"
-      - "**/*.sh"
-      - "scripts/**"
   workflow_dispatch:
 
 concurrency:
@@ -27,99 +17,98 @@ defaults:
     shell: bash -euo pipefail {0}
 
 jobs:
-  # 1) Lint shell scripts on native aarch64
-  lint:
-    name: Lint (shellcheck + shfmt) [aarch64]
-    runs-on: ubuntu-24.04-arm
+  syntax:
+    name: Syntax + shellcheck
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Assert we are on ARM64
-        run: |
-          arch=$(uname -m)
-          echo "Detected arch: $arch"
-          test "$arch" = "aarch64" || { echo "Not running on aarch64"; exit 1; }
-
-      - name: Install linters
+      - name: Install shellcheck
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt
+          sudo apt-get install -y shellcheck
 
-      - name: List scripts to lint
-        id: list_scripts
+      - name: Syntax-check bin/omarchy-*
         run: |
-          # Exclude legacy migrations from lint/format to reduce noise
-          mapfile -t files < <(git ls-files | grep -E '\.sh$|^scripts/.*' | grep -v '^migrations/' || true)
-          printf "%s\n" "${files[@]}"
-          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+          failed=()
+          shopt -s nullglob
+          for f in bin/omarchy-*; do
+            [[ -f $f ]] || continue
+            if head -1 "$f" | grep -q python; then
+              python3 -c 'import ast,sys; ast.parse(open(sys.argv[1]).read())' "$f" || failed+=("$f")
+            else
+              bash -n "$f" || failed+=("$f")
+            fi
+          done
+          if (( ${#failed[@]} > 0 )); then
+            printf '%s\n' "${failed[@]}" >&2
+            exit 1
+          fi
+
+      - name: Syntax-check tracked *.sh
+        run: |
+          failed=()
+          while IFS= read -r -d '' f; do
+            bash -n "$f" || failed+=("$f")
+          done < <(git ls-files -z -- '*.sh')
+          if (( ${#failed[@]} > 0 )); then
+            printf '%s\n' "${failed[@]}" >&2
+            exit 1
+          fi
 
       - name: shellcheck
-        if: steps.list_scripts.outputs.count != '0'
         run: |
+          # install/ and many tests are sourced and omit shebangs; --shell=bash
+          # is the contract. Fixtures are intentionally invalid snippets.
+          # SC1087/SC1113/SC2096 fire on ANSI sequences and comments that look
+          # like shebangs, not on real errors.
+          mapfile -t files < <(git ls-files -- '*.sh' | grep -vE '^(migrations/|test/shell.d/fixtures/)' || true)
+          (( ${#files[@]} > 0 )) || exit 0
           shellcheck --version
-          # Only fail on actual errors; exclude network/dynamic source checks
-          # Exclude migrations/ to avoid flagging historical scripts
-          mapfile -t files < <(git ls-files | grep -E '\.sh$|^scripts/.*' | grep -v '^migrations/')
-          shellcheck -S error -e SC1090,SC1091 "${files[@]}"
+          shellcheck --shell=bash -S error -e SC1090,SC1091,SC1087,SC1113,SC2096 "${files[@]}"
 
-      - name: shfmt (check only)
-        if: steps.list_scripts.outputs.count != '0'
-        run: |
-          # Show diffs but don't fail the build on formatting; exclude migrations/
-          mapfile -t files < <(git ls-files | grep -E '\.sh$|^scripts/.*' | grep -v '^migrations/')
-          shfmt -i 2 -ci -d "${files[@]}" || true
-
-  # 2) Syntax + smoke tests (safe, non-privileged)
-  smoke:
-    name: Syntax + Smoke [aarch64]
-    runs-on: ubuntu-24.04-arm
-    needs: [lint]
+  test:
+    name: test/all
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Assert we are on ARM64
-        run: |
-          arch=$(uname -m)
-          echo "Detected arch: $arch"
-          test "$arch" = "aarch64" || { echo "Not running on aarch64"; exit 1; }
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
-      - name: Install helpful tools (optional)
+      - name: Checkout omarchy-pkgs
+        uses: actions/checkout@v4
+        with:
+          repository: omacom-io/omarchy-pkgs
+          path: omarchy-pkgs
+          persist-credentials: false
+
+      - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq curl coreutils
+          sudo apt-get install -y jq lua5.4 imagemagick libxkbcommon-tools
+          sudo ln -sf /usr/bin/lua5.4 /usr/local/bin/lua
+          if ! command -v magick >/dev/null; then
+            sudo ln -sf "$(command -v convert)" /usr/local/bin/magick
+          fi
 
-      - name: Bash syntax check for all scripts
-        run: |
-          set -o pipefail
-          # Only .sh files and scripts directory
-          while IFS= read -r -d '' f; do
-            echo "::group::bash -n $f"
-            bash -n "$f"
-            echo "::endgroup::"
-          done < <(git ls-files -z | grep -z -E '\.sh$|^scripts/.*')
-
-      - name: Smoke run selected scripts in DRY_RUN/--help mode
+      - name: Run ./test/all
         env:
-          DRY_RUN: "1"
-        run: |
-          bash tests/test-asahi-compatibility.sh
+          OMARCHY_PKGS_PATH: ${{ github.workspace }}/omarchy-pkgs
+        run: ./test/all
 
+  mac:
+    name: tests/all
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  # 3) OPTIONAL: Arch Linux ARM container tests
-  # NOTE: Only enable if you have a multi-arch container image that supports aarch64.
-  # Many 'archlinux' images are x86_64-only; verify before using.
-  # arch-arm-container:
-  #   name: Arch ARM container tests [aarch64]
-  #   runs-on: ubuntu-24.04-arm
-  #   container:
-  #     image: ghcr.io/<your-org>/<arch-arm-image>:latest # <-- ensure this is ARM64
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Verify container arch
-  #       run: uname -m | grep -q aarch64
-  #     - name: Run Arch-specific tests
-  #       run: |
-  #         pacman -Syu --noconfirm jq
-  #         # Run your Arch-only commands in here…
+      - name: Run ./tests/all
+        run: ./tests/all

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
 
-      - name: Syntax-check bin/omarchy-*
+      - name: Syntax-check bin/omarchy, bin/omarchy-*, test/vm/*
         run: |
           failed=()
           shopt -s nullglob
-          for f in bin/omarchy-*; do
+          for f in bin/omarchy bin/omarchy-* test/vm/*; do
             [[ -f $f ]] || continue
             if head -1 "$f" | grep -q python; then
               python3 -c 'import ast,sys; ast.parse(open(sys.argv[1]).read())' "$f" || failed+=("$f")
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout omarchy-pkgs
         uses: actions/checkout@v4
         with:
-          repository: omacom-io/omarchy-pkgs
+          repository: omacom/omarchy-pkgs
           path: omarchy-pkgs
           persist-credentials: false
 

--- a/docs/runner-requirements.md
+++ b/docs/runner-requirements.md
@@ -1,0 +1,35 @@
+# Self-hosted runner for Install VM
+
+The **Install VM** workflow (`.github/workflows/install-vm.yml`) runs only on a machine you register. It is `workflow_dispatch` plus a nightly schedule. It is not hooked to `pull_request`: this repo is public, and a desktop runner must not execute fork PRs.
+
+## Labels
+
+`./test/vm/setup-github-runner` registers with `--labels self-hosted,linux,ARM64,kvm`. GitHub also stamps OS/arch as `Linux` and `ARM64`. Matching is case-insensitive.
+
+The job selects:
+
+```
+runs-on: [self-hosted, linux, ARM64]
+```
+
+The runner must show **Idle** with at least those three labels. Confirm at https://github.com/omarchy-mac/omarchy-mac/settings/actions/runners.
+
+## Capabilities
+
+- aarch64 Linux (Asahi / Omarchy). 16k host pages are expected.
+- `systemd-nspawn` (from `systemd`)
+- passwordless `sudo` for the runner user (the setup script grants this to `github-runner`)
+- outbound network (Arch Linux ARM tarball, pacman, AUR)
+- several GB free on `/` — a full `install.sh` is a second Omarchy userspace. 34G disks fill up.
+
+KVM is labeled but unused: a 4k Arch ARM QEMU guest cannot use KVM on a 16k host. The harness is nspawn sharing the host kernel.
+
+## Register
+
+From a terminal in this checkout:
+
+```bash
+./test/vm/setup-github-runner
+```
+
+Then Actions → **Install VM** → Run workflow. Locally: `sudo ./test/vm/run-install`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,7 +142,7 @@ only a live session can prove.
 GitHub Actions (`.github/workflows/main.yml`) runs on every push and pull request. Three jobs run in parallel on `ubuntu-24.04`:
 
 - **syntax** — shebang-aware parse of `bin/omarchy-*`, `bash -n` on tracked `*.sh`, and shellcheck (`--shell=bash -S error`, excluding `migrations/` and `test/`)
-- **test** — `./test/all` (`./test/cli` and `./test/shell`), with `omacom-io/omarchy-pkgs` checked out for PKGBUILD coverage
+- **test** — `./test/all` (`./test/cli` and `./test/shell`), with `omacom/omarchy-pkgs` checked out for PKGBUILD coverage
 - **mac** — `./tests/all` (Mac-specific suites; root/loop rehearsals skip without privileges)
 
 The graphical acceptance suite is not part of this workflow. Compositor-dependent shell tests skip on the headless runner.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,3 +136,13 @@ only a live session can prove.
 - **Assert the invariant, not the snapshot.** Config tests pin the property a
   test is named for (this widget stays adjacent to that one) rather than whole
   structures, so unrelated churn does not fail them.
+
+## CI
+
+GitHub Actions (`.github/workflows/main.yml`) runs on every push and pull request. Three jobs run in parallel on `ubuntu-24.04`:
+
+- **syntax** — shebang-aware parse of `bin/omarchy-*`, `bash -n` on tracked `*.sh`, and shellcheck (`--shell=bash -S error`, excluding `migrations/` and test fixtures)
+- **test** — `./test/all` (`./test/cli` and `./test/shell`), with `omacom-io/omarchy-pkgs` checked out for PKGBUILD coverage
+- **mac** — `./tests/all` (Mac-specific suites; root/loop rehearsals skip without privileges)
+
+The graphical acceptance suite is not part of this workflow. Compositor-dependent shell tests skip on the headless runner.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -141,7 +141,7 @@ only a live session can prove.
 
 GitHub Actions (`.github/workflows/main.yml`) runs on every push and pull request. Three jobs run in parallel on `ubuntu-24.04`:
 
-- **syntax** — shebang-aware parse of `bin/omarchy-*`, `bash -n` on tracked `*.sh`, and shellcheck (`--shell=bash -S error`, excluding `migrations/` and test fixtures)
+- **syntax** — shebang-aware parse of `bin/omarchy-*`, `bash -n` on tracked `*.sh`, and shellcheck (`--shell=bash -S error`, excluding `migrations/` and `test/`)
 - **test** — `./test/all` (`./test/cli` and `./test/shell`), with `omacom-io/omarchy-pkgs` checked out for PKGBUILD coverage
 - **mac** — `./tests/all` (Mac-specific suites; root/loop rehearsals skip without privileges)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -151,7 +151,7 @@ The graphical acceptance suite is not part of this workflow. Compositor-dependen
 
 `.github/workflows/install-vm.yml` runs `install.sh` inside an isolated Arch Linux ARM machine on a self-hosted Apple Silicon runner. GitHub-hosted ARM VMs cannot do this: they have no nested KVM, and Asahi Alarm will not boot in QEMU. The host kernel is 16k pages, so the harness uses `systemd-nspawn` (same kernel a real Mac install runs on) rather than a 4k QEMU guest.
 
-It is `workflow_dispatch` plus a nightly schedule, never `pull_request`. A public-repo self-hosted runner must not execute fork PRs.
+It is `workflow_dispatch` plus a nightly schedule, never `pull_request`. A public-repo self-hosted runner must not execute fork PRs. Required labels and disk/sudo notes: [`docs/runner-requirements.md`](runner-requirements.md).
 
 Register this machine once, from a terminal:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,3 +146,17 @@ GitHub Actions (`.github/workflows/main.yml`) runs on every push and pull reques
 - **mac** — `./tests/all` (Mac-specific suites; root/loop rehearsals skip without privileges)
 
 The graphical acceptance suite is not part of this workflow. Compositor-dependent shell tests skip on the headless runner.
+
+## Install machine (self-hosted)
+
+`.github/workflows/install-vm.yml` runs `install.sh` inside an isolated Arch Linux ARM machine on a self-hosted Apple Silicon runner. GitHub-hosted ARM VMs cannot do this: they have no nested KVM, and Asahi Alarm will not boot in QEMU. The host kernel is 16k pages, so the harness uses `systemd-nspawn` (same kernel a real Mac install runs on) rather than a 4k QEMU guest.
+
+It is `workflow_dispatch` plus a nightly schedule, never `pull_request`. A public-repo self-hosted runner must not execute fork PRs.
+
+Register this machine once, from a terminal:
+
+```bash
+./test/vm/setup-github-runner
+```
+
+That creates a `github-runner` user with passwordless sudo, installs the Actions runner, and starts it. Then run **Install VM** from the Actions tab. The harness is `./test/vm/run-install` and can be invoked the same way locally with sudo.

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ ensure_package_sources() {
   else
     log "Cloning the PKGBUILD checkout"
     mkdir -p "$cache_dir"
-    git clone --depth 1 https://github.com/omacom-io/omarchy-pkgs.git "$pkgs_checkout"
+    git clone --depth 1 https://github.com/omacom/omarchy-pkgs.git "$pkgs_checkout"
   fi
 
   export OMARCHY_PKGS_PATH="$pkgs_checkout"

--- a/test/vm/run-install
+++ b/test/vm/run-install
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Run install.sh inside an isolated Arch Linux ARM machine on this aarch64 host.
+#
+# GitHub's hosted ARM runners have no nested KVM, and this Asahi host uses 16k
+# pages, so a stock 4k Arch ARM QEMU guest cannot use KVM. systemd-nspawn shares
+# the host kernel (the same 16k kernel a real Mac install runs on) and still
+# gives install.sh its own rootfs, users, and pacman.
+#
+# Needs root (or passwordless sudo), network, and several GB free.
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+CACHE="${OMARCHY_INSTALL_VM_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-install-vm}"
+WORK="${OMARCHY_INSTALL_VM_WORK:-/var/tmp/omarchy-install-vm}"
+TARBALL_URL="${OMARCHY_INSTALL_VM_TARBALL:-http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz}"
+GUEST_USER=ci
+MACHINE=omarchy-install-vm-$$
+KEEP_ROOT=${OMARCHY_INSTALL_VM_KEEP:-0}
+
+log() { printf '\033[32m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[31mError:\033[0m %s\n' "$*" >&2; exit 1; }
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+cleanup() {
+  as_root machinectl terminate "$MACHINE" 2>/dev/null || true
+  as_root chmod -R a+rX "$WORK/logs" 2>/dev/null || true
+  if (( KEEP_ROOT )); then
+    log "keeping $WORK/root (OMARCHY_INSTALL_VM_KEEP=1)"
+    return 0
+  fi
+  as_root rm -rf "$WORK/root" "$WORK/overlay"
+}
+
+[[ $(uname -m) == "aarch64" ]] || fail "this harness only runs on aarch64"
+command -v systemd-nspawn >/dev/null || fail "systemd-nspawn is required"
+command -v curl >/dev/null || fail "curl is required"
+
+as_root true || fail "root (or passwordless sudo) is required to spawn the machine"
+
+mkdir -p "$CACHE" "$WORK/logs"
+as_root rm -rf "$WORK/root" "$WORK/overlay"
+as_root mkdir -p "$WORK/root" "$WORK/overlay/upper" "$WORK/overlay/work"
+trap cleanup EXIT
+
+tarball="$CACHE/ArchLinuxARM-aarch64-latest.tar.gz"
+if [[ ! -f $tarball ]]; then
+  log "downloading Arch Linux ARM rootfs"
+  curl -fL --retry 3 -o "$tarball.partial" "$TARBALL_URL"
+  mv "$tarball.partial" "$tarball"
+fi
+
+log "extracting rootfs into $WORK/root"
+as_root tar -xzf "$tarball" -C "$WORK/root"
+as_root mkdir -p "$WORK/root/src/omarchy"
+
+nspawn() {
+  as_root systemd-nspawn \
+    --quiet \
+    --directory="$WORK/root" \
+    --machine="$MACHINE" \
+    --resolv-conf=bind-host \
+    --bind-ro=/sys \
+    --bind-ro="$ROOT:/src/omarchy-ro" \
+    --overlay="$ROOT:$WORK/overlay/upper:$WORK/overlay/work:/src/omarchy" \
+    --console=pipe \
+    "$@"
+}
+
+log "bootstrapping pacman, sudo, and the $GUEST_USER user"
+nspawn /bin/bash -euo pipefail <<'BOOTSTRAP'
+pacman-key --init
+pacman-key --populate archlinuxarm
+pacman -Sy --noconfirm
+pacman -S --needed --noconfirm sudo git base-devel
+id ci >/dev/null 2>&1 || useradd -m -G wheel ci
+printf '%s\n' 'ci ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/ci
+chmod 440 /etc/sudoers.d/ci
+sed -i 's/^#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+locale-gen >/dev/null
+printf 'LANG=en_US.UTF-8\n' >/etc/locale.conf
+BOOTSTRAP
+
+log "running install.sh as $GUEST_USER (AUR builds take a while)"
+set +e
+nspawn --user="$GUEST_USER" --chdir=/src/omarchy \
+  /bin/bash -euo pipefail -c 'export LANG=en_US.UTF-8; bash install.sh' \
+  | tee "$WORK/logs/install.log"
+install_status=${PIPESTATUS[0]}
+set -e
+(( install_status == 0 )) || fail "install.sh exited $install_status (see $WORK/logs/install.log)"
+
+log "asserting the installed system"
+nspawn /bin/bash -euo pipefail <<'ASSERT' | tee "$WORK/logs/assert.log"
+source /usr/share/omarchy/default/bash/env-bootstrap
+command -v omarchy >/dev/null
+omarchy commands --check >/dev/null
+pacman -Q omarchy >/dev/null
+[[ -d /usr/share/omarchy/bin ]]
+[[ -d /usr/share/omarchy/install ]]
+id ci >/dev/null
+printf 'ok - install.sh produced a working Omarchy userspace\n'
+ASSERT
+
+log "install machine test passed"

--- a/test/vm/run-install
+++ b/test/vm/run-install
@@ -62,13 +62,13 @@ as_root tar -xzf "$tarball" -C "$WORK/root"
 as_root mkdir -p "$WORK/root/src/omarchy"
 
 nspawn() {
+  # Do not bind-ro /sys: nspawn has to mount its own cgroupfs on
+  # /sys/fs/cgroup, and a host /sys bind makes it refuse to start.
   as_root systemd-nspawn \
-    --quiet \
     --directory="$WORK/root" \
     --machine="$MACHINE" \
+    --register=no \
     --resolv-conf=bind-host \
-    --bind-ro=/sys \
-    --bind-ro="$ROOT:/src/omarchy-ro" \
     --overlay="$ROOT:$WORK/overlay/upper:$WORK/overlay/work:/src/omarchy" \
     --console=pipe \
     "$@"

--- a/test/vm/run-install
+++ b/test/vm/run-install
@@ -15,7 +15,6 @@ CACHE="${OMARCHY_INSTALL_VM_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-insta
 WORK="${OMARCHY_INSTALL_VM_WORK:-/var/tmp/omarchy-install-vm}"
 TARBALL_URL="${OMARCHY_INSTALL_VM_TARBALL:-http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz}"
 GUEST_USER=ci
-MACHINE=omarchy-install-vm-$$
 KEEP_ROOT=${OMARCHY_INSTALL_VM_KEEP:-0}
 
 log() { printf '\033[32m==>\033[0m %s\n' "$*"; }
@@ -30,13 +29,12 @@ as_root() {
 }
 
 cleanup() {
-  as_root machinectl terminate "$MACHINE" 2>/dev/null || true
   as_root chmod -R a+rX "$WORK/logs" 2>/dev/null || true
   if (( KEEP_ROOT )); then
     log "keeping $WORK/root (OMARCHY_INSTALL_VM_KEEP=1)"
     return 0
   fi
-  as_root rm -rf "$WORK/root" "$WORK/overlay"
+  as_root rm -rf "$WORK/root"
 }
 
 [[ $(uname -m) == "aarch64" ]] || fail "this harness only runs on aarch64"
@@ -46,8 +44,8 @@ command -v curl >/dev/null || fail "curl is required"
 as_root true || fail "root (or passwordless sudo) is required to spawn the machine"
 
 mkdir -p "$CACHE" "$WORK/logs"
-as_root rm -rf "$WORK/root" "$WORK/overlay"
-as_root mkdir -p "$WORK/root" "$WORK/overlay/upper"
+as_root rm -rf "$WORK/root"
+as_root mkdir -p "$WORK/root"
 trap cleanup EXIT
 
 tarball="$CACHE/ArchLinuxARM-aarch64-latest.tar.gz"
@@ -66,11 +64,9 @@ nspawn() {
   # /sys/fs/cgroup, and a host /sys bind makes it refuse to start.
   as_root systemd-nspawn \
     --directory="$WORK/root" \
-    --machine="$MACHINE" \
     --register=no \
     --resolv-conf=bind-host \
-    # Three fields: lower:upper:dest. nspawn derives overlay workdir as a sibling of upper.
-    --overlay="$ROOT:$WORK/overlay/upper:/src/omarchy" \
+    --bind="$ROOT:/src/omarchy" \
     --console=pipe \
     "$@"
 }

--- a/test/vm/run-install
+++ b/test/vm/run-install
@@ -47,7 +47,7 @@ as_root true || fail "root (or passwordless sudo) is required to spawn the machi
 
 mkdir -p "$CACHE" "$WORK/logs"
 as_root rm -rf "$WORK/root" "$WORK/overlay"
-as_root mkdir -p "$WORK/root" "$WORK/overlay/upper" "$WORK/overlay/work"
+as_root mkdir -p "$WORK/root" "$WORK/overlay/upper"
 trap cleanup EXIT
 
 tarball="$CACHE/ArchLinuxARM-aarch64-latest.tar.gz"
@@ -69,7 +69,8 @@ nspawn() {
     --machine="$MACHINE" \
     --register=no \
     --resolv-conf=bind-host \
-    --overlay="$ROOT:$WORK/overlay/upper:$WORK/overlay/work:/src/omarchy" \
+    # Three fields: lower:upper:dest. nspawn derives overlay workdir as a sibling of upper.
+    --overlay="$ROOT:$WORK/overlay/upper:/src/omarchy" \
     --console=pipe \
     "$@"
 }

--- a/test/vm/setup-github-runner
+++ b/test/vm/setup-github-runner
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Register this Apple Silicon machine as a GitHub Actions self-hosted runner
+# for the install-vm workflow. Run it from a terminal (it needs sudo).
+#
+# Public-repo safety: install-vm.yml is workflow_dispatch + nightly only. Do
+# not point a desktop runner at pull_request jobs from forks.
+
+set -euo pipefail
+
+REPO="${OMARCHY_GITHUB_REPO:-omarchy-mac/omarchy-mac}"
+RUNNER_USER="${OMARCHY_RUNNER_USER:-github-runner}"
+RUNNER_HOME="/home/$RUNNER_USER"
+RUNNER_DIR="$RUNNER_HOME/actions-runner"
+LABELS="${OMARCHY_RUNNER_LABELS:-self-hosted,linux,ARM64,kvm}"
+
+log() { printf '\033[32m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[31mError:\033[0m %s\n' "$*" >&2; exit 1; }
+
+(( EUID != 0 )) || fail "run as your user, not root; the script sudo's where needed"
+command -v gh >/dev/null || fail "gh is required to mint a registration token"
+gh auth status >/dev/null || fail "gh is not authenticated"
+
+[[ $(uname -m) == "aarch64" ]] || fail "this runner setup is for aarch64"
+
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+  log "creating $RUNNER_USER"
+  sudo useradd --create-home --shell /bin/bash --groups wheel "$RUNNER_USER"
+fi
+
+log "granting $RUNNER_USER passwordless sudo (needed for systemd-nspawn)"
+printf '%s ALL=(ALL) NOPASSWD: ALL\n' "$RUNNER_USER" | sudo tee "/etc/sudoers.d/50-$RUNNER_USER" >/dev/null
+sudo chmod 440 "/etc/sudoers.d/50-$RUNNER_USER"
+sudo visudo -cf "/etc/sudoers.d/50-$RUNNER_USER" >/dev/null
+
+token=$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)
+[[ -n $token ]] || fail "could not mint a runner registration token for $REPO"
+
+os=linux
+arch=arm64
+latest=$(gh api repos/actions/runner/releases/latest --jq .tag_name)
+version=${latest#v}
+tarball="actions-runner-${os}-${arch}-${version}.tar.gz"
+url="https://github.com/actions/runner/releases/download/${latest}/${tarball}"
+
+log "installing GitHub Actions runner $latest into $RUNNER_DIR"
+sudo mkdir -p "$RUNNER_DIR"
+sudo chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME"
+if [[ ! -x $RUNNER_DIR/config.sh ]]; then
+  sudo -u "$RUNNER_USER" curl -fL -o "$RUNNER_DIR/$tarball" "$url"
+  sudo -u "$RUNNER_USER" tar -xzf "$RUNNER_DIR/$tarball" -C "$RUNNER_DIR"
+  sudo rm -f "$RUNNER_DIR/$tarball"
+fi
+
+log "configuring runner for $REPO ($LABELS)"
+sudo -u "$RUNNER_USER" "$RUNNER_DIR/config.sh" --unattended --replace \
+  --url "https://github.com/$REPO" \
+  --token "$token" \
+  --name "$(hostname)-install-vm" \
+  --labels "$LABELS" \
+  --work "$RUNNER_HOME/_work"
+
+log "installing the runner systemd service"
+sudo "$RUNNER_DIR/svc.sh" install "$RUNNER_USER"
+sudo "$RUNNER_DIR/svc.sh" start
+
+log "runner is up. Confirm it at https://github.com/$REPO/settings/actions/runners"
+log "then run the Install VM workflow from Actions → workflow_dispatch"

--- a/test/vm/setup-github-runner
+++ b/test/vm/setup-github-runner
@@ -52,16 +52,15 @@ if [[ ! -x $RUNNER_DIR/config.sh ]]; then
 fi
 
 log "configuring runner for $REPO ($LABELS)"
-sudo -u "$RUNNER_USER" "$RUNNER_DIR/config.sh" --unattended --replace \
-  --url "https://github.com/$REPO" \
-  --token "$token" \
-  --name "$(hostname)-install-vm" \
-  --labels "$LABELS" \
-  --work "$RUNNER_HOME/_work"
+sudo -u "$RUNNER_USER" bash -c "cd \"$RUNNER_DIR\" && ./config.sh --unattended --replace \
+  --url \"https://github.com/$REPO\" \
+  --token \"$token\" \
+  --name \"$(hostname)-install-vm\" \
+  --labels \"$LABELS\" \
+  --work \"$RUNNER_HOME/_work\""
 
 log "installing the runner systemd service"
-sudo "$RUNNER_DIR/svc.sh" install "$RUNNER_USER"
-sudo "$RUNNER_DIR/svc.sh" start
+sudo bash -c "cd \"$RUNNER_DIR\" && ./svc.sh install \"$RUNNER_USER\" && ./svc.sh start"
 
 log "runner is up. Confirm it at https://github.com/$REPO/settings/actions/runners"
 log "then run the Install VM workflow from Actions → workflow_dispatch"


### PR DESCRIPTION
The old ARM-only workflow never ran on `quattro` and skipped `./test/all`.

- **CI** — syntax, `./test/all`, and `./tests/all` on every push/PR (`ubuntu-24.04`)
- **Install VM** — `install.sh` in nspawn on a self-hosted Apple Silicon runner (`workflow_dispatch` + nightly; not fork PRs)

Graphical acceptance and Asahi boot/LUKS stay out.