### PR TITLE
Harden the install-vm workflow

### DIFF
--- a/.github/workflows/install-vm.yml
+++ b/.github/workflows/install-vm.yml
@@ -1,8 +1,18 @@
 name: Install VM
 
-# Full install.sh in an isolated Arch Linux ARM machine on a self-hosted
-# Apple Silicon runner. Not on pull_request: a public-repo self-hosted
-# runner must not execute untrusted fork code.
+# Isolated install.sh on a self-hosted Apple Silicon runner (systemd-nspawn).
+#
+# Triggers are workflow_dispatch and a nightly schedule only — never
+# pull_request. This repo is public; a self-hosted runner on a desktop must
+# not execute untrusted fork code. The job-level `if` is a second fence so a
+# fork that copies this file still no-ops unless it also has our runner.
+#
+# Required runner labels (GitHub matching is case-insensitive):
+#   self-hosted, linux (shown as Linux), ARM64
+# Extra label we set at registration: kvm
+# Capabilities: systemd-nspawn, passwordless sudo, network, several GB free.
+# See docs/runner-requirements.md.
+
 on:
   workflow_dispatch:
   schedule:
@@ -10,28 +20,86 @@ on:
 
 concurrency:
   group: install-vm
-  cancel-in-progress: false
+  # A new dispatch or nightly should not stack two full installs on a 34G disk.
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   install:
     name: install.sh on Arch Linux ARM
+    # Skip on forks even if someone re-adds pull_request. This is not redundant
+    # with the trigger list: it is the fork fence.
     if: github.repository == 'omarchy-mac/omarchy-mac'
     runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 120
+    env:
+      INSTALL_VM_ROOT: /var/tmp/omarchy-install-vm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Diagnostics
+        run: |
+          uname -a
+          id
+          getconf PAGESIZE
+          df -h
+          free -m
+          command -v systemd-nspawn
+          command -v sudo
+
+      - name: Pre-check run-install
+        run: |
+          if [[ ! -f ./test/vm/run-install ]]; then
+            echo "run-install not found at ./test/vm/run-install" >&2
+            exit 1
+          fi
+          if [[ ! -x ./test/vm/run-install ]]; then
+            chmod +x ./test/vm/run-install || {
+              echo "run-install not found or not executable" >&2
+              exit 1
+            }
+          fi
+          echo "pre-check: ./test/vm/run-install is executable"
+
+      - name: Prepare log directory
+        run: |
+          sudo mkdir -p "$INSTALL_VM_ROOT/logs"
+          sudo chown "$(id -u):$(id -g)" "$INSTALL_VM_ROOT" "$INSTALL_VM_ROOT/logs"
+
       - name: Run isolated install
-        run: sudo --preserve-env=HOME ./test/vm/run-install
+        run: |
+          set +e
+          sudo --preserve-env=HOME ./test/vm/run-install 2>&1 | tee "$INSTALL_VM_ROOT/logs/install.log"
+          status=${PIPESTATUS[0]}
+          set -e
+          printf '%s\n' "$status" >"$INSTALL_VM_ROOT/logs/exit_code"
+          if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+            if (( status == 0 )); then
+              printf 'install harness exited 0\n' >>"$GITHUB_STEP_SUMMARY"
+            else
+              printf 'install harness failed with exit %s. See the install-vm-logs artifact.\n' "$status" >>"$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          exit "$status"
+
+      - name: Compress logs
+        if: always()
+        run: |
+          mkdir -p "$INSTALL_VM_ROOT/logs"
+          tar -czf "$INSTALL_VM_ROOT/logs.tar.gz" -C "$INSTALL_VM_ROOT" logs
 
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: install-vm-logs
-          path: /var/tmp/omarchy-install-vm/logs/
+          path: /var/tmp/omarchy-install-vm/logs.tar.gz
+          retention-days: 7
           if-no-files-found: ignore

--- a/docs/runner-requirements.md
+++ b/docs/runner-requirements.md
@@ -1,0 +1,35 @@
+# Self-hosted runner for Install VM
+
+The **Install VM** workflow (`.github/workflows/install-vm.yml`) runs only on a machine you register. It is `workflow_dispatch` plus a nightly schedule. It is not hooked to `pull_request`: this repo is public, and a desktop runner must not execute fork PRs.
+
+## Labels
+
+`./test/vm/setup-github-runner` registers with `--labels self-hosted,linux,ARM64,kvm`. GitHub also stamps OS/arch as `Linux` and `ARM64`. Matching is case-insensitive.
+
+The job selects:
+
+```
+runs-on: [self-hosted, linux, ARM64]
+```
+
+The runner must show **Idle** with at least those three labels. Confirm at https://github.com/omarchy-mac/omarchy-mac/settings/actions/runners.
+
+## Capabilities
+
+- aarch64 Linux (Asahi / Omarchy). 16k host pages are expected.
+- `systemd-nspawn` (from `systemd`)
+- passwordless `sudo` for the runner user (the setup script grants this to `github-runner`)
+- outbound network (Arch Linux ARM tarball, pacman, AUR)
+- several GB free on `/` — a full `install.sh` is a second Omarchy userspace. 34G disks fill up.
+
+KVM is labeled but unused: a 4k Arch ARM QEMU guest cannot use KVM on a 16k host. The harness is nspawn sharing the host kernel.
+
+## Register
+
+From a terminal in this checkout:
+
+```bash
+./test/vm/setup-github-runner
+```
+
+Then Actions → **Install VM** → Run workflow. Locally: `sudo ./test/vm/run-install`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -151,7 +151,7 @@ The graphical acceptance suite is not part of this workflow. Compositor-dependen
 
 `.github/workflows/install-vm.yml` runs `install.sh` inside an isolated Arch Linux ARM machine on a self-hosted Apple Silicon runner. GitHub-hosted ARM VMs cannot do this: they have no nested KVM, and Asahi Alarm will not boot in QEMU. The host kernel is 16k pages, so the harness uses `systemd-nspawn` (same kernel a real Mac install runs on) rather than a 4k QEMU guest.
 
-It is `workflow_dispatch` plus a nightly schedule, never `pull_request`. A public-repo self-hosted runner must not execute fork PRs.
+It is `workflow_dispatch` plus a nightly schedule, never `pull_request`. A public-repo self-hosted runner must not execute fork PRs. Required labels and disk/sudo notes: [`docs/runner-requirements.md`](runner-requirements.md).
 
 Register this machine once, from a terminal:
 


### PR DESCRIPTION
Follow-up to #332. Makes the self-hosted install job fail clearly and leave logs you can actually fetch.

- Pre-check `./test/vm/run-install` exists and is executable
- Create/chown `/var/tmp/omarchy-install-vm/logs`, tee the run, write `exit_code`, put a line on the step summary
- Upload `logs.tar.gz` with 7-day retention
- Diagnostics (`uname`, `df`, `free`, `id`) before the install
- `docs/runner-requirements.md` for labels (`self-hosted`, `linux`/`Linux`, `ARM64`) and sudo/nspawn/disk
- Comment on the repo `if` (fork fence) and `cancel-in-progress: true` so a new dispatch does not stack two installs

Verify: dispatch **Install VM** from this branch, confirm it hits `omarchymac-install-vm`, artifact contains `install.log` + `exit_code`.