### PR TITLE
Allow root setup to refresh packaged Plymouth defaults

### DIFF
--- a/bin/omarchy-plymouth-set
+++ b/bin/omarchy-plymouth-set
@@ -34,7 +34,11 @@ else
   usage
 fi
 
-if (( EUID == 0 )); then
+# The fixed packaged Plymouth default has no caller-selected input to open
+# before elevation, and system setup needs to publish it even when owner
+# provisioning is deferred. Keep every mode that accepts user input -- and the
+# unrelated SDDM refresh -- behind the unprivileged-caller boundary.
+if (( EUID == 0 )) && [[ $mode != "refresh-plymouth" ]]; then
   echo "Error: run omarchy-plymouth-set as your user, not under sudo." >&2
   exit 1
 fi

--- a/test/shell.d/plymouth-install-test.sh
+++ b/test/shell.d/plymouth-install-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+fake_bin="$test_tmp/bin"
+fake_omarchy="$test_tmp/omarchy"
+calls="$test_tmp/calls"
+mkdir -p "$fake_bin" "$fake_omarchy/bin"
+
+cat >"$fake_bin/plymouth-set-default-theme" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+
+cp "$ROOT/bin/omarchy-refresh-plymouth" "$fake_omarchy/bin/omarchy-refresh-plymouth"
+cat >"$fake_omarchy/bin/omarchy-plymouth-set" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "${OMARCHY_INSTALL_USER:-deferred}" "$*" >>"$OMARCHY_TEST_CALLS"
+exit "${OMARCHY_TEST_PUBLISH_STATUS:-0}"
+STUB
+
+chmod +x "$fake_bin"/* "$fake_omarchy/bin"/*
+
+run_install_leaf() {
+  PATH="$fake_bin:$fake_omarchy/bin:/usr/bin:/bin" \
+    OMARCHY_PATH="$fake_omarchy" \
+    OMARCHY_TEST_CALLS="$calls" \
+    bash -e -c 'source "$1"' bash "$ROOT/install/login/plymouth.sh"
+}
+
+OMARCHY_INSTALL_USER=owner run_install_leaf
+[[ $(cat "$calls") == $'owner\n--refresh-default' ]] ||
+  fail "fresh-install Plymouth setup reaches the fixed-default publisher" "$(cat "$calls")"
+pass "fresh-install Plymouth setup refreshes the packaged default"
+
+rm -f "$calls"
+OMARCHY_INSTALL_USER= run_install_leaf
+[[ $(cat "$calls") == $'deferred\n--refresh-default' ]] ||
+  fail "deferred setup reaches the fixed-default publisher without an owner" "$(cat "$calls")"
+pass "deferred provisioning refreshes Plymouth before an install user exists"
+
+rm -f "$calls"
+status=0
+OMARCHY_INSTALL_USER=owner OMARCHY_TEST_PUBLISH_STATUS=42 run_install_leaf || status=$?
+(( status == 42 )) ||
+  fail "Plymouth publication failure propagates out of system setup" "exit status: $status"
+pass "fresh-install Plymouth setup propagates publication failures"

--- a/test/shell.d/plymouth-set-test.sh
+++ b/test/shell.d/plymouth-set-test.sh
@@ -67,9 +67,13 @@ if unshare --user --map-root-user true 2>/dev/null; then
   (( status != 0 )) || fail "omarchy-plymouth-set refuses to run as root"
   [[ $output == *"as your user"* && $output == *"not under sudo"* ]] ||
     fail "the root refusal explains how to invoke the publisher safely" "$output"
+
+  output=$(unshare --user --map-root-user env OMARCHY_PATH="$ROOT" /bin/bash "$ROOT/bin/omarchy-plymouth-set" --refresh-sddm-default 2>&1)
+  status=$?
+  (( status != 0 )) || fail "the root exception does not include the SDDM refresh"
 else
-  grep -A2 -Eq '^if \(\( EUID == 0 \)\); then$' "$ROOT/bin/omarchy-plymouth-set" ||
-    fail "omarchy-plymouth-set retains its root-invocation guard"
+  grep -A2 -Eq '^if \(\( EUID == 0 \)\) && \[\[ \$mode != "refresh-plymouth" \]\]; then$' "$ROOT/bin/omarchy-plymouth-set" ||
+    fail "omarchy-plymouth-set retains its root guard outside the fixed Plymouth refresh"
 fi
 pass "the logo descriptor can only be opened by an unprivileged caller"
 
@@ -431,6 +435,32 @@ assert_packaged_assets() {
       fail "$context publishes $asset as a regular mode-0644 file"
   done
 }
+
+# System setup already runs as root, including when provisioning is deferred
+# and no target user exists. The packaged-default refresh is the sole safe
+# root entry: it has no caller-selected file, still validates the packaged
+# tree, and remains idempotent when setup is resumed.
+if unshare --user --map-root-user true 2>/dev/null; then
+  setup_run
+  output=$(run_refresh_plymouth unshare --user --map-root-user env 2>&1)
+  status=$?
+  (( status == 0 )) || fail "root system setup can publish the fixed Plymouth default" "$output"
+
+  output=$(run_refresh_plymouth unshare --user --map-root-user env 2>&1)
+  status=$?
+  (( status == 0 )) || fail "root fixed-default publication is idempotent" "$output"
+
+  assert_packaged_assets \
+    "root fixed-default refresh" \
+    "$ROOT/default/plymouth" \
+    "$theme" \
+    "${plymouth_default_assets[@]}"
+  [[ $(grep -c '^root transaction$' "$sudo_log") == 2 ]] ||
+    fail "each root fixed-default refresh completes one validated transaction" "$(cat "$sudo_log")"
+  pass "root system setup can idempotently refresh only the packaged Plymouth default"
+else
+  pass "user namespaces unavailable; structurally verified the root-only fixed-default exception"
+fi
 
 for requested_umask in 022 027 077; do
   setup_fresh_run


### PR DESCRIPTION
## Context

The guided `quattro` installer runs `omarchy-apply-system` as root after package installation and initramfs generation. During that system setup, `install/login/plymouth.sh` refreshes the packaged default Plymouth theme.

On a real fresh M1 MacBook Air install, setup reached that step and then aborted with:

```text
Running Omarchy system setup
Starting: /usr/share/omarchy/install/login/plymouth.sh
Error: run omarchy-plymouth-set as your user, not under sudo.
Failed: /usr/share/omarchy/install/login/plymouth.sh (exit code: 1)
Error: install.sh exited 1
```

## Problem

`omarchy-plymouth-set` rejects every root invocation. That is the intended boundary for the three-argument custom-logo mode, where the user-selected file must be opened before elevation, but it also rejects `--refresh-default` even though that mode accepts no caller-selected path.

The installer therefore fails late, after substantial work has already completed. The same mismatch affects deferred provisioning, where system setup also runs as root and there may be no install user to switch to.

## Change

Permit root only for the internal `refresh-plymouth` mode selected by `--refresh-default`. Keep root blocked for custom-logo publication and `--refresh-sddm-default`.

The permitted mode still uses the existing fixed packaged-asset allowlist, canonical-path and ownership checks, root-owned staging directory, fixed destinations, and atomic publication. No caller-selected path crosses the new root exception.

## Validation

- `bash test/shell.d/plymouth-install-test.sh`
- `bash test/shell.d/sddm-login-test.sh`
- Bash syntax checks for all changed files
- `git diff --check`
- root refusal tests for custom-logo and SDDM modes
- root fixed-default publication and idempotence coverage
- regular-install, deferred-provisioning, and failure-propagation coverage
- independent QA and security-focused diff review

The full Linux-only Plymouth publisher test cannot execute completely on the macOS development host because BSD `find` lacks GNU `-printf`; the added Linux user-namespace cases cover root fixed-default publication and idempotence when run in CI.
