### PR TITLE
Add touchpad gestures toggle for three-finger workspace swipes

### DIFF
--- a/bin/omarchy-toggle-touchpad-gestures
+++ b/bin/omarchy-toggle-touchpad-gestures
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# omarchy:summary=Enable, disable, or toggle three-finger swipes between workspaces
+# omarchy:args=[on|off|toggle]
+
+omarchy-hyprland-toggle touchpad-gestures "${1:-toggle}" >/dev/null || exit 1
+
+if omarchy-hyprland-toggle-enabled touchpad-gestures; then
+  omarchy-notification-send -g 󰟸 "Touchpad gestures enabled"
+else
+  omarchy-notification-send -g 󰟸 "Touchpad gestures disabled"
+fi

--- a/config/hypr/input.lua
+++ b/config/hypr/input.lua
@@ -52,6 +52,7 @@
 -- o.window("com.mitchellh.ghostty", { scroll_touchpad = 0.2 })
 
 -- Enable touchpad gestures for changing workspaces.
+-- (Or flip the toggle: `omarchy toggle touchpad gestures`, also under Trigger > Hardware.)
 -- See https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/
 -- hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
 

--- a/default/hypr/toggles/touchpad-gestures.lua
+++ b/default/hypr/toggles/touchpad-gestures.lua
@@ -1,0 +1,4 @@
+-- Swipe horizontally with three fingers to move between workspaces, like
+-- swiping between full-screen apps on macOS.
+-- See https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/
+hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -75,6 +75,7 @@
   "trigger.hardware.mirror-display": {"icon":"󰍹","label":"Mirror Display","when":"omarchy-hw-laptop","action":"omarchy-hyprland-monitor-internal-mirror toggle"},
   "trigger.hardware.hybrid-gpu": {"icon":"","label":"Hybrid GPU","when":"omarchy-hw-hybrid-gpu","action":"omarchy-launch-floating-terminal-with-presentation omarchy-toggle-hybrid-gpu"},
   "trigger.hardware.touchpad": {"icon":"󰟸","label":"Touchpad","when":"omarchy-hw-touchpad","action":"omarchy-toggle-touchpad"},
+  "trigger.hardware.touchpad-gestures": {"icon":"󰟸","label":"Touchpad Gestures","when":"omarchy-hw-touchpad","checked":"omarchy-hyprland-toggle-enabled touchpad-gestures","action":"omarchy-toggle-touchpad-gestures"},
   "trigger.hardware.touchpad-haptics": {"icon":"󰌌","label":"Touchpad Haptics"},
   "trigger.hardware.touchpad-haptics.low": {"icon":"󰌌","label":"low","when":"omarchy-hw-dell-xps-haptic-touchpad && omarchy-cmd-present dell-xps-touchpad-haptics","checked":"[[ \"$(dell-xps-touchpad-haptics get)\" == \"low\" ]]","action":"dell-xps-touchpad-haptics set low"},
   "trigger.hardware.touchpad-haptics.mid": {"icon":"󰌌","label":"mid","when":"omarchy-hw-dell-xps-haptic-touchpad && omarchy-cmd-present dell-xps-touchpad-haptics","checked":"[[ \"$(dell-xps-touchpad-haptics get)\" == \"mid\" ]]","action":"dell-xps-touchpad-haptics set mid"},

--- a/manual/13-toggles-idle-screensaver.md
+++ b/manual/13-toggles-idle-screensaver.md
@@ -17,11 +17,12 @@ From the terminal, the same switches are `omarchy toggle <thing>`. Run `omarchy 
 | Screensaver | — | `omarchy toggle screensaver` |
 | Menu bar | `Super + Shift + Space` | `omarchy toggle bar` |
 | Touchpad | `XF86TouchpadToggle` | `omarchy toggle touchpad` |
+| Touchpad gestures | — | `omarchy toggle touchpad gestures` |
 | Touchscreen | — | `omarchy toggle touchscreen` |
 | Suspend | — | `omarchy toggle suspend` |
 | Hybrid GPU | — | `omarchy toggle hybrid gpu` |
 
-The touchpad, touchscreen, and hybrid GPU switches live under _Trigger > Hardware_ (`Super + Ctrl + H`) rather than under Toggle, since they only show up when you actually have that hardware. The touchpad and touchscreen ones survive a Hyprland reload — the disabled device's name is saved to a small state file that Hyprland reads on startup to disable it again.
+The touchpad, touchpad gestures, touchscreen, and hybrid GPU switches live under _Trigger > Hardware_ (`Super + Ctrl + H`) rather than under Toggle, since they only show up when you actually have that hardware. The touchpad and touchscreen ones survive a Hyprland reload — the disabled device's name is saved to a small state file that Hyprland reads on startup to disable it again.
 
 The Toggle menu also carries a few things that aren't `omarchy toggle` commands but behave the same: battery percentage in the bar, workspace layout (`Super + L`), window gaps (`Super + Shift + Backspace`), and the 1-window square aspect (`Super + Ctrl + Backspace`).
 

--- a/manual/34-keyboard-mouse-trackpad.md
+++ b/manual/34-keyboard-mouse-trackpad.md
@@ -63,10 +63,13 @@ of these in `~/.config/hypr/input.lua` using the options shown above.
 
 ### Trackpad gestures
 
-You can also turn on [touchpad gestures](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/), like swiping with three fingers to change workspaces:
+Swiping horizontally with three fingers to change workspaces — the way you swipe between full-screen apps on macOS — is a toggle. Flip it on under _Trigger > Hardware > Touchpad Gestures_ (`Super + Ctrl + H`), or with `omarchy toggle touchpad gestures`. It's off by default and survives Hyprland reloads, like the other [toggles](13-toggles-idle-screensaver.md).
+
+For other [touchpad gestures](https://wiki.hypr.land/Configuring/Advanced-and-Cool/Gestures/), such as swiping to move focus, add them to `~/.config/hypr/input.lua`:
 
 ```lua
-hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })
+hl.gesture({ fingers = 3, direction = "left", action = function() hl.dispatch(hl.dsp.focus({ direction = "l" })) end })
+hl.gesture({ fingers = 3, direction = "right", action = function() hl.dispatch(hl.dsp.focus({ direction = "r" })) end })
 ```
 
 On Dell XPS laptops with a haptic touchpad, you can also set the click strength to low, mid, or high under _Trigger > Hardware > Touchpad Haptics_.


### PR DESCRIPTION
## Summary

Apple trackpads are the natural home for the macOS-style three-finger swipe between workspaces, but turning it on meant hand-editing `~/.config/hypr/input.lua`. This ships it as a Hyprland toggle flag instead, using the existing `omarchy-hyprland-toggle` mechanism.

- `default/hypr/toggles/touchpad-gestures.lua` — the flag: `hl.gesture({ fingers = 3, direction = "horizontal", action = "workspace" })`
- `bin/omarchy-toggle-touchpad-gestures` — `omarchy toggle touchpad gestures [on|off|toggle]`, with a notification either way
- Menu: _Trigger > Hardware > Touchpad Gestures_, gated on `omarchy-hw-touchpad` like the Touchpad row, with a ✓ when on
- Manual: added to the toggles table in `13-toggles-idle-screensaver.md`, and the trackpad gestures section in `34-keyboard-mouse-trackpad.md` now points at the toggle first
- `config/hypr/input.lua`: one comment line pointing at the toggle

Off by default. Making it default-on for Macs would need the flag file created at install plus a migration for existing users, so I left that as a follow-up if maintainers want it.

## Testing

- On an M2 MacBook Pro (Hyprland 0.56.1, `apple-mtp-multi-touch`): `off` removes the flag, `toggle` re-creates it, `hyprctl configerrors` is clean, the swipe works, and a bad argument exits 1 with usage.
- `omarchy toggle touchpad gestures --help` routes to the new binary; `omarchy toggle touchpad --help` still routes to the existing one.
- `./test/all`: `test/cli` passes; `test/shell` has the same two pre-existing failures (`config-test.sh`, `unowned-system-paths-test.sh`) that need an `omarchy-pkgs` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CP9zCPpL6HL7mKmmS8NbN
