### PR TITLE
Use official ARM edge for the Hyprland stack

### DIFF
--- a/.github/workflows/install-vm-selective-edge.yml
+++ b/.github/workflows/install-vm-selective-edge.yml
@@ -2,7 +2,7 @@ name: Validate selective ARM edge
 
 on:
   push:
-    branches: [selective-arm64-edge]
+    branches: [install-stack-integration]
   workflow_dispatch:
 
 permissions:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   validate:
-    if: github.repository == 'omarchy-mac/omarchy-mac' && github.actor == 'malik-na' && github.ref == 'refs/heads/selective-arm64-edge'
+    if: github.repository == 'omarchy-mac/omarchy-mac' && github.actor == 'malik-na' && (github.ref == 'refs/heads/selective-arm64-edge' || github.ref == 'refs/heads/install-stack-integration')
     runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 120
     env:

--- a/.github/workflows/install-vm-selective-edge.yml
+++ b/.github/workflows/install-vm-selective-edge.yml
@@ -1,0 +1,38 @@
+name: Validate selective ARM edge
+
+on:
+  push:
+    branches: [selective-arm64-edge]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-vm
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.repository == 'omarchy-mac/omarchy-mac' && github.actor == 'malik-na' && github.ref == 'refs/heads/selective-arm64-edge'
+    runs-on: [self-hosted, linux, ARM64]
+    timeout-minutes: 120
+    env:
+      OMARCHY_INSTALL_VM_WORK: /var/tmp/omarchy-selective-edge-${{ github.run_id }}-${{ github.run_attempt }}
+      OMARCHY_INSTALL_VM_PACKAGE_SOURCES: '1'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Validate package selection and installation
+        shell: bash
+        run: |
+          sudo --preserve-env=HOME,OMARCHY_INSTALL_VM_WORK,OMARCHY_INSTALL_VM_PACKAGE_SOURCES bash ./test/vm/run-selective-edge
+      - name: Upload validation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selective-edge-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.OMARCHY_INSTALL_VM_WORK }}/logs/
+          retention-days: 7
+          if-no-files-found: warn

--- a/bin/omarchy-refresh-pacman
+++ b/bin/omarchy-refresh-pacman
@@ -27,4 +27,11 @@ sudo cp -f "$OMARCHY_PATH/default/pacman/mirrorlist.asahi-alarm" /etc/pacman.d/m
 omarchy-hook pre-refresh-pacman
 
 # Reset all package DBs and then update
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syyuu --noconfirm
+targets=()
+if [[ $(uname -m) == "aarch64" ]]; then
+  source "$OMARCHY_PATH/install/helpers/arm-package-sources.sh"
+  # Keep the original configuration saved before the channel replacement.
+  omarchy_arm_prepare_package_sources /etc/pacman.conf preserve-backup || exit 1
+  mapfile -t targets < <(omarchy_arm_package_targets)
+fi
+sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syyuu --noconfirm "${targets[@]}"

--- a/bin/omarchy-update-keyring
+++ b/bin/omarchy-update-keyring
@@ -3,6 +3,17 @@
 # omarchy:summary=Ensure the Omarchy and Arch keyring packages are installed and populated
 # omarchy:requires-sudo=true
 
+set -e
+
+if [[ $(uname -m) == "aarch64" ]]; then
+  source "$OMARCHY_PATH/install/helpers/arm-package-sources.sh"
+  omarchy_arm_prepare_package_sources
+  # Refresh the distribution keyring before the immediately following full
+  # upgrade. The official edge repository remains explicit-target-only.
+  sudo pacman -Sy --noconfirm archlinuxarm-keyring
+  exit 0
+fi
+
 if omarchy-pkg-missing omarchy-keyring || ! sudo pacman-key --list-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 &>/dev/null; then
   sudo pacman-key --recv-keys 40DFB630FF42BCFFB047046CF0134EE680CAC571 --keyserver keys.openpgp.org
   sudo pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571

--- a/bin/omarchy-update-system-pkgs
+++ b/bin/omarchy-update-system-pkgs
@@ -5,12 +5,19 @@
 
 set -e
 
+targets=()
+if [[ $(uname -m) == "aarch64" ]]; then
+  source "$OMARCHY_PATH/install/helpers/arm-package-sources.sh"
+  omarchy_arm_prepare_package_sources
+  mapfile -t targets < <(omarchy_arm_package_targets)
+fi
+
 # The conflict handler's last resort: pacman puts its questions to the person
 # running the update instead of answering them itself. Nothing here may capture
 # a stream, because an upgrade without --noconfirm prompts on stderr. The
 # handler has already said why, so no heading here either.
 if [[ ${OMARCHY_UPDATE_CONFLICT:-} == 1 && ${OMARCHY_UPDATE_INTERACTIVE:-} == 1 ]]; then
-  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*'
+  exec sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --overwrite '/usr/share/omarchy/*' "${targets[@]}"
 fi
 
 echo -e "\e[32m\nUpdate system packages\e[0m"
@@ -24,7 +31,7 @@ trap 'rm -f "$errors"' EXIT
 # Progress bars stay on stdout. Errors are on stderr, kept for the conflict
 # handler below; LC_ALL=C is what keeps them parseable in any locale.
 if sudo env LC_ALL=C OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm \
-  --overwrite '/usr/share/omarchy/*' 2>"$errors"; then
+  --overwrite '/usr/share/omarchy/*' "${targets[@]}" 2>"$errors"; then
   cat "$errors" >&2
   exit 0
 fi

--- a/default/pacman/pacman-edge.conf
+++ b/default/pacman/pacman-edge.conf
@@ -16,9 +16,15 @@ SigLevel = Required DatabaseOptional
 LocalFileSigLevel = Optional
 
 # pacman searches repositories in the order defined here
-# Omarchy's own repo is x86_64 only, so the Apple Silicon builds live here.
+# Mac-specific packages remain in the community ARM repository.
 # Without it herdr drags in a zig0.15 build that aarch64 cannot even use,
 # costing about two hours of a fresh install before it fails.
+# Only explicitly selected Hyprland packages use official edge.
+[omarchy]
+Usage = Sync
+SigLevel = Required DatabaseOptional
+Server = https://pkgs.omarchy.org/edge/$arch
+
 [omarchy-aarch64]
 SigLevel = Optional TrustAll
 Server = https://github.com/omarchy-mac/omarchy-pkgs-aarch64/releases/download/edge

--- a/default/pacman/pacman-rc.conf
+++ b/default/pacman/pacman-rc.conf
@@ -16,9 +16,15 @@ SigLevel = Required DatabaseOptional
 LocalFileSigLevel = Optional
 
 # pacman searches repositories in the order defined here
-# Omarchy's own repo is x86_64 only, so the Apple Silicon builds live here.
+# Mac-specific packages remain in the community ARM repository.
 # Without it herdr drags in a zig0.15 build that aarch64 cannot even use,
 # costing about two hours of a fresh install before it fails.
+# Only explicitly selected Hyprland packages use official edge.
+[omarchy]
+Usage = Sync
+SigLevel = Required DatabaseOptional
+Server = https://pkgs.omarchy.org/edge/$arch
+
 [omarchy-aarch64]
 SigLevel = Optional TrustAll
 Server = https://github.com/omarchy-mac/omarchy-pkgs-aarch64/releases/download/edge

--- a/default/pacman/pacman-stable.conf
+++ b/default/pacman/pacman-stable.conf
@@ -71,9 +71,15 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
-# Omarchy's own repo is x86_64 only, so the Apple Silicon builds live here.
+# Mac-specific packages remain in the community ARM repository.
 # Without it herdr drags in a zig0.15 build that aarch64 cannot even use,
 # costing about two hours of a fresh install before it fails.
+# Only explicitly selected Hyprland packages use official edge.
+[omarchy]
+Usage = Sync
+SigLevel = Required DatabaseOptional
+Server = https://pkgs.omarchy.org/edge/$arch
+
 [omarchy-aarch64]
 SigLevel = Optional TrustAll
 Server = https://github.com/omarchy-mac/omarchy-pkgs-aarch64/releases/download/edge

--- a/default/pacman/pacman.conf
+++ b/default/pacman/pacman.conf
@@ -69,9 +69,15 @@ LocalFileSigLevel = Optional
 # repo name header and Include lines. You can add preferred servers immediately
 # after the header, and they will be used before the default mirrors.
 
-# Omarchy's own repo is x86_64 only, so the Apple Silicon builds live here.
+# Mac-specific packages remain in the community ARM repository.
 # Without it herdr drags in a zig0.15 build that aarch64 cannot even use,
 # costing about two hours of a fresh install before it fails.
+# Only explicitly selected Hyprland packages use official edge.
+[omarchy]
+Usage = Sync
+SigLevel = Required DatabaseOptional
+Server = https://pkgs.omarchy.org/edge/$arch
+
 [omarchy-aarch64]
 SigLevel = Optional TrustAll
 Server = https://github.com/omarchy-mac/omarchy-pkgs-aarch64/releases/download/edge

--- a/docs/arm-package-sources.md
+++ b/docs/arm-package-sources.md
@@ -1,0 +1,9 @@
+# ARM package sources
+
+Apple Silicon installations use the regular Arch Linux ARM, Asahi Alarm, and Mac package repositories. The official `https://pkgs.omarchy.org/edge/$arch` repository has `Usage = Sync`, so it is refreshed but excluded from automatic package selection and upgrades.
+
+The installer, system updater, and pacman channel refresh explicitly select `omarchy/hyprland`, `omarchy/hyprtoolkit`, and `omarchy/hyprland-guiutils` alongside a full system upgrade. Aquamarine and other dependencies resolve from the regular repositories. Dependency failures stop the transaction; no packages are ignored or dependencies bypassed.
+
+The shared policy lives in `install/helpers/arm-package-sources.sh`. Package signatures are required and the existing Omarchy signing key is imported by its full fingerprint. Repository configuration preserves other repositories and mirror choices, saving `/etc/pacman.conf.bak` when it changes.
+
+Use `omarchy update` for system upgrades. A bare `pacman -Syu` does not update the explicitly selected edge packages and can fail when their regular-repository dependencies change ABI. Edge is rolling; versions are resolved together at transaction time rather than pinned.

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 readonly checkout="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly package_output="$checkout/build-output"
 readonly asahi_alarm_key="12CE6799A94A3F1B5DDFFE88F576553597FB8FEB"
+source "$checkout/install/helpers/arm-package-sources.sh"
 
 # gum is how the rest of Omarchy talks to people, but it arrives with the
 # omarchy package well into this script, so every helper falls back to plain
@@ -155,8 +156,11 @@ ensure_arm_package_repo() {
   fi
 
   ensure_asahi_alarm_keyring
-  log "Refreshing package databases for ARM packages"
-  sudo pacman -Sy --noconfirm
+  omarchy_arm_prepare_package_sources
+  local -a targets
+  mapfile -t targets < <(omarchy_arm_package_targets)
+  log "Upgrading system packages and installing the compatible Hyprland stack"
+  sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm "${targets[@]}"
 }
 
 load_unavailable_packages() {
@@ -282,12 +286,12 @@ snapshot_factory_baseline() {
 main() {
   check_preconditions
   ensure_utf8_locale
+  ensure_arm_package_repo
   ensure_gum
   ensure_aur_helper
   ensure_package_sources
   build_omarchy_packages
   install_omarchy_packages
-  ensure_arm_package_repo
   install_default_package_set
   seed_user_defaults
   run_system_setup

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ ensure_asahi_alarm_keyring() {
 
   if ! sudo pacman-key --list-keys "$asahi_alarm_key" >/dev/null 2>&1; then
     log "Importing the Asahi Alarm package signing key"
-    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keys.openpgp.org
+    sudo pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keyserver.ubuntu.com
   fi
   sudo pacman-key --lsign-key "$asahi_alarm_key" >/dev/null
 

--- a/install.sh
+++ b/install.sh
@@ -263,6 +263,11 @@ run_system_setup() {
   log "Running Omarchy system setup"
   sudo omarchy-apply-system --install-user "$USER" --first-install
 
+  # System setup restores pacman.conf and can introduce repositories absent
+  # from the starting image. Trust their keys and refresh with a full upgrade
+  # before user setup installs packages, retaining the explicit edge stack.
+  ensure_arm_package_repo
+
   log "Running Omarchy user setup"
   omarchy-provision-user --first-install
 }

--- a/install.sh
+++ b/install.sh
@@ -224,6 +224,12 @@ install_default_package_set() {
 
   log "Installing the default package set (AUR builds take a while)"
   while read -r package; do
+    # Already installed in the full compatibility transaction. An unqualified
+    # yay target would select the regular repository and can downgrade it.
+    if omarchy_arm_package_is_selected "$package"; then
+      pacman -Q "$package" >/dev/null || fail "Compatible package missing after system upgrade: $package"
+      continue
+    fi
     # These compile a dependency chain for hours before failing an architecture
     # check, so do not start them unless asked to.
     if (( ! attempt_unavailable )) && package_is_unavailable_here "$package"; then

--- a/install/helpers/arm-package-sources.sh
+++ b/install/helpers/arm-package-sources.sh
@@ -5,6 +5,14 @@ omarchy_arm_package_targets() {
   printf '%s\n' omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils
 }
 
+omarchy_arm_package_is_selected() {
+  local target
+  while read -r target; do
+    [[ ${target#*/} == "$1" ]] && return 0
+  done < <(omarchy_arm_package_targets)
+  return 1
+}
+
 omarchy_arm_package_repo() {
   printf '%s\n' '[omarchy]' 'Usage = Sync' 'SigLevel = Required DatabaseOptional' 'Server = https://pkgs.omarchy.org/edge/$arch'
 }

--- a/install/helpers/arm-package-sources.sh
+++ b/install/helpers/arm-package-sources.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Shared by the standalone installer and installed package update commands.
+omarchy_arm_package_targets() {
+  printf '%s\n' omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils
+}
+
+omarchy_arm_package_repo() {
+  printf '%s\n' '[omarchy]' 'Usage = Sync' 'SigLevel = Required DatabaseOptional' 'Server = https://pkgs.omarchy.org/edge/$arch'
+}
+
+omarchy_arm_prepare_package_sources() {
+  local config="${1:-/etc/pacman.conf}" backup="${2:-backup}" updated key="40DFB630FF42BCFFB047046CF0134EE680CAC571"
+  updated=$(mktemp) || return
+  # Replace an existing unrestricted Omarchy section without changing the
+  # user's regular repositories, mirror choices, or their ordering.
+  awk '
+    /^[[:space:]]*\[/ { omit = ($0 ~ /^[[:space:]]*\[omarchy\][[:space:]]*(#.*)?$/) }
+    !omit { print }
+  ' "$config" > "$updated" || { rm -f "$updated"; return 1; }
+  omarchy_arm_package_repo >> "$updated" || { rm -f "$updated"; return 1; }
+  if ! cmp -s "$config" "$updated"; then
+    if [[ $backup != "preserve-backup" ]]; then
+      sudo cp "$config" "$config.bak" || { rm -f "$updated"; return 1; }
+    fi
+    sudo install -m 644 "$updated" "$config" || { rm -f "$updated"; return 1; }
+  fi
+  rm -f "$updated"
+
+  if ! sudo pacman-key --list-keys "$key" >/dev/null 2>&1; then
+    sudo pacman-key --recv-keys "$key" --keyserver hkps://keys.openpgp.org || return
+  fi
+  sudo pacman-key --lsign-key "$key"
+}

--- a/test/shell.d/aarch64-compat-test.sh
+++ b/test/shell.d/aarch64-compat-test.sh
@@ -17,22 +17,21 @@ for config in "$ROOT"/default/pacman/pacman*.conf; do
 done
 pass "every shipped pacman config pins aarch64"
 
-# Omarchy's own package repo is x86_64 only (docs/upgrade-to-quattro.md). Any
-# config that still points at it makes pacman fetch aarch64 packages from an
-# x86 repo and breaks every system upgrade.
-leaky=()
-while read -r config; do
-  [[ -n $config ]] || continue
-  leaky+=("$(basename "$config")")
-done < <(grep -l 'pkgs\.omarchy\.org' "$ROOT"/default/pacman/pacman*.conf 2>/dev/null || true)
-(( ${#leaky[@]} == 0 )) ||
-  fail "no shipped pacman config points at the x86 Omarchy package repo" \
-    "still x86: ${leaky[*]}"
-pass "no shipped pacman config points at the x86 Omarchy package repo"
+# Official edge serves ARM packages, but only the selected compatibility stack
+# may use it. Keep architecture, channel, and signature constraints explicit.
+for config in "$ROOT"/default/pacman/pacman*.conf; do
+  section=$(awk '/^\[/ { selected = ($0 == "[omarchy]") } selected { print }' "$config")
+  grep -qxF 'Usage = Sync' <<< "$section" || fail "official edge requires explicit targets in $config"
+  grep -qxF 'SigLevel = Required DatabaseOptional' <<< "$section" || fail "official edge requires signed packages in $config"
+  grep -qxF 'Server = https://pkgs.omarchy.org/edge/$arch' <<< "$section" || fail "official edge uses target architecture in $config"
+  if grep '^[[:space:]]*Server.*pkgs\.omarchy\.org' "$config" | grep -vxF 'Server = https://pkgs.omarchy.org/edge/$arch'; then
+    fail "no x86 or alternate-channel official repository in $config"
+  fi
+done
+pass "official edge is architecture-aware, signed, and explicit-target-only"
 
-# Same for the bundled mirrorlists: an Omarchy mirror serves x86_64 only, so a
-# mirrorlist that reaches one would leave pacman querying an x86 repo for
-# aarch64 packages.
+# The regular distribution mirrorlists must remain Arch Linux ARM sources;
+# official edge belongs only in its restricted, separate repository section.
 leaky=()
 while read -r file; do
   [[ -n $file ]] || continue

--- a/test/shell.d/aarch64-packages-test.sh
+++ b/test/shell.d/aarch64-packages-test.sh
@@ -58,8 +58,9 @@ pass "every shipped pacman config offers the Omarchy ARM repo"
 # The shipped config only reaches /etc during post-install, which runs after the
 # package set. Adding the repo any later leaves herdr building zig from source
 # for two hours, so the order in main() is the whole point of the fix.
-repo_call=$(grep -n '^  ensure_arm_package_repo$' "$ROOT/install.sh" | cut -d: -f1)
-set_call=$(grep -n '^  install_default_package_set$' "$ROOT/install.sh" | cut -d: -f1)
+install_main=$(sed -n '/^main() {/,/^}/p' "$ROOT/install.sh")
+repo_call=$(grep -n '^  ensure_arm_package_repo$' <<<"$install_main" | cut -d: -f1)
+set_call=$(grep -n '^  install_default_package_set$' <<<"$install_main" | cut -d: -f1)
 [[ -n $repo_call && -n $set_call ]] || fail "the installer adds the ARM repo and installs the set"
 (( repo_call < set_call )) ||
   fail "the ARM repo is added before the default package set is installed"

--- a/test/shell.d/arm-package-sources-test.sh
+++ b/test/shell.d/arm-package-sources-test.sh
@@ -37,6 +37,27 @@ mapfile -t targets < <(omarchy_arm_package_targets)
 [[ ${targets[*]} == "omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils" ]] || fail 'only approved packages selected'
 pass 'Aquamarine remains a regular-repository dependency'
 
+# Exercise the real default-package loop after the compatibility transaction.
+# The three selected packages must never reach yay as unqualified targets.
+eval "$(sed -n '/^install_default_package_set() {/,/^seed_user_defaults() {/p' "$ROOT/install.sh" | sed '$d')"
+checkout=$ROOT
+log() { :; }
+warn() { :; }
+load_unavailable_packages() { :; }
+should_attempt_unavailable() { return 1; }
+package_is_unavailable_here() { return 1; }
+pacman() { [[ $1 == "-Q" ]] && printf '%s\n' "$2" >> "$test_tmp/checked"; }
+yay() { printf '%s\n' "$*" >> "$test_tmp/yay"; }
+install_default_package_set
+for package in hyprland hyprtoolkit hyprland-guiutils; do
+  if grep -qxF "$package" "$ROOT/install/omarchy-base.packages"; then
+    grep -qxF "$package" "$test_tmp/checked" || fail "$package availability checked"
+  fi
+  ! grep -qE "(^| )$package( |$)" "$test_tmp/yay" || fail "$package must not be downgraded by yay"
+done
+grep -q 'wf-recorder' "$test_tmp/yay" || fail 'regular package path still runs'
+pass 'default package loop preserves the compatibility transaction selection'
+
 for config in "$ROOT"/default/pacman/pacman*.conf; do
   section=$(sed -n '/^\[omarchy\]$/,/^$/p' "$config")
   [[ $section == *"Usage = Sync"* && $section == *"SigLevel = Required DatabaseOptional"* ]] || fail "restricted signed edge in $config"

--- a/test/shell.d/arm-package-sources-test.sh
+++ b/test/shell.d/arm-package-sources-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+source "$ROOT/install/helpers/arm-package-sources.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+sudo() {
+  if [[ $1 == "pacman-key" ]]; then
+    printf '%s\n' "$*" >> "$test_tmp/keys"
+  else
+    "$@"
+  fi
+}
+
+printf '%s\n' '[options]' 'Architecture = aarch64' '[extra]' 'Server = https://regular.example/$arch' '[omarchy]' 'Usage = All' 'SigLevel = Never' 'Server = https://old.example/$arch' '[omarchy-aarch64]' 'Server = https://mac.example' > "$test_tmp/pacman.conf"
+omarchy_arm_prepare_package_sources "$test_tmp/pacman.conf"
+grep -q '^Server = https://regular.example/\$arch$' "$test_tmp/pacman.conf" || fail 'regular mirror preserved'
+grep -q '^Server = https://mac.example$' "$test_tmp/pacman.conf" || fail 'Mac repository preserved'
+! grep -q 'Usage = All\|SigLevel = Never\|old.example' "$test_tmp/pacman.conf" || fail 'unrestricted old edge section removed'
+[[ $(grep -c '^\[omarchy\]$' "$test_tmp/pacman.conf") == "1" ]] || fail 'single edge section'
+grep -q '^Usage = Sync$' "$test_tmp/pacman.conf" || fail 'edge selection restricted'
+grep -q '^SigLevel = Required DatabaseOptional$' "$test_tmp/pacman.conf" || fail 'signed packages required'
+cp "$test_tmp/pacman.conf" "$test_tmp/expected"
+omarchy_arm_prepare_package_sources "$test_tmp/pacman.conf"
+cmp -s "$test_tmp/expected" "$test_tmp/pacman.conf" || fail 'preparation idempotent'
+pass 'source preparation preserves regular repositories and restricts edge idempotently'
+
+cp "$test_tmp/pacman.conf.bak" "$test_tmp/original-backup"
+cp "$ROOT/default/pacman/pacman-stable.conf" "$test_tmp/pacman.conf"
+omarchy_arm_prepare_package_sources "$test_tmp/pacman.conf" preserve-backup
+cmp -s "$test_tmp/original-backup" "$test_tmp/pacman.conf.bak" || fail 'channel refresh original backup preserved'
+pass 'preparation after channel replacement preserves the original backup'
+
+mapfile -t targets < <(omarchy_arm_package_targets)
+[[ ${targets[*]} == "omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils" ]] || fail 'only approved packages selected'
+pass 'Aquamarine remains a regular-repository dependency'
+
+for config in "$ROOT"/default/pacman/pacman*.conf; do
+  section=$(sed -n '/^\[omarchy\]$/,/^$/p' "$config")
+  [[ $section == *"Usage = Sync"* && $section == *"SigLevel = Required DatabaseOptional"* ]] || fail "restricted signed edge in $config"
+done
+pass 'all shipped channels preserve restricted signed edge'

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -118,7 +118,7 @@ pass "the installer styles its output with gum from the start"
 # or optional ARM packages fail later with a misleading missing-database error.
 grep -qF 'asahi_alarm_key=' "$install_script" ||
   fail "the installer pins the Asahi Alarm package signing key"
-grep -qF 'pacman-key --recv-keys "$asahi_alarm_key"' "$install_script" ||
+grep -qF 'pacman-key --recv-keys "$asahi_alarm_key" --keyserver hkps://keyserver.ubuntu.com' "$install_script" ||
   fail "the installer bootstraps the Asahi Alarm package signing key"
 grep -qF 'pacman-key --lsign-key "$asahi_alarm_key"' "$install_script" ||
   fail "the installer locally trusts the Asahi Alarm package signing key"

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -125,8 +125,15 @@ grep -qF 'pacman-key --lsign-key "$asahi_alarm_key"' "$install_script" ||
 grep -qF 'pacman -Sy --needed --noconfirm asahi-alarm-keyring' "$install_script" ||
   fail "the installer installs the Asahi Alarm package keyring"
 keyring_call=$(grep -n '^  ensure_asahi_alarm_keyring$' "$install_script" | cut -d: -f1)
-refresh_call=$(grep -n '^  sudo pacman -Sy --noconfirm$' "$install_script" | cut -d: -f1)
+refresh_call=$(grep -nF '  sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed --noconfirm "${targets[@]}"' "$install_script" | cut -d: -f1)
 [[ -n $keyring_call && -n $refresh_call ]] || fail "the installer bootstraps the Asahi keyring before refresh"
 (( keyring_call < refresh_call )) ||
   fail "the Asahi keyring is installed before the package database refresh"
 pass "the installer bootstraps Asahi signing keys before refreshing ARM packages"
+
+repo_call=$(grep -n '^  ensure_arm_package_repo$' "$install_script" | cut -d: -f1)
+build_call=$(grep -n '^  build_omarchy_packages$' "$install_script" | cut -d: -f1)
+[[ -n $repo_call && -n $build_call ]] || fail "the installer prepares repositories before package builds"
+(( repo_call < build_call && repo_call < gum_call )) || fail "the compatible stack transaction precedes package operations"
+grep -qF 'source "$checkout/install/helpers/arm-package-sources.sh"' "$install_script" || fail "the installer uses shared source policy"
+pass "the installer prepares the compatible stack before package operations"

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -131,9 +131,45 @@ refresh_call=$(grep -nF '  sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --needed
   fail "the Asahi keyring is installed before the package database refresh"
 pass "the installer bootstraps Asahi signing keys before refreshing ARM packages"
 
-repo_call=$(grep -n '^  ensure_arm_package_repo$' "$install_script" | cut -d: -f1)
+repo_call=$(sed -n '/^main() {/,/^}/p' "$install_script" | grep -n '^  ensure_arm_package_repo$' | cut -d: -f1)
+main_line=$(grep -n '^main() {$' "$install_script" | cut -d: -f1)
+repo_call=$(( main_line + repo_call - 1 ))
 build_call=$(grep -n '^  build_omarchy_packages$' "$install_script" | cut -d: -f1)
 [[ -n $repo_call && -n $build_call ]] || fail "the installer prepares repositories before package builds"
 (( repo_call < build_call && repo_call < gum_call )) || fail "the compatible stack transaction precedes package operations"
 grep -qF 'source "$checkout/install/helpers/arm-package-sources.sh"' "$install_script" || fail "the installer uses shared source policy"
 pass "the installer prepares the compatible stack before package operations"
+
+# Run the real orchestration with harmless stubs. A separate bash process
+# preserves errexit even when the test captures an expected nonzero status.
+setup_body=$(sed -n '/^run_system_setup() {/,/^}/p' "$install_script")
+for failing_stage in none system repositories; do
+  setup_status=0
+  setup_output=$(SETUP_BODY="$setup_body" FAILING_STAGE="$failing_stage" bash -c '
+    set -euo pipefail
+    log() { :; }
+    sudo() {
+      [[ $* == "omarchy-apply-system --install-user $USER --first-install" ]]
+      echo system
+      [[ $FAILING_STAGE != "system" ]]
+    }
+    ensure_arm_package_repo() {
+      echo repositories
+      [[ $FAILING_STAGE != "repositories" ]]
+    }
+    omarchy-provision-user() {
+      [[ $* == "--first-install" ]]
+      echo user
+    }
+    eval "$SETUP_BODY"
+    run_system_setup
+  ') || setup_status=$?
+  case $failing_stage in
+    none) expected_output=$'system\nrepositories\nuser'; expected_status=0 ;;
+    system) expected_output=system; expected_status=1 ;;
+    repositories) expected_output=$'system\nrepositories'; expected_status=1 ;;
+  esac
+  [[ $setup_output == "$expected_output" && $setup_status == "$expected_status" ]] ||
+    fail "system setup refreshes restored repositories before user setup ($failing_stage)" "$setup_output (status $setup_status)"
+done
+pass "system setup refreshes restored repositories before user setup and stops on failure"

--- a/test/vm/run-selective-edge
+++ b/test/vm/run-selective-edge
@@ -1,10 +1,9 @@
 #!/bin/bash
 # Run install.sh inside an isolated Arch Linux ARM machine on this aarch64 host.
 #
-# GitHub's hosted ARM runners have no nested KVM, and this Asahi host uses 16k
-# pages, so a stock 4k Arch ARM QEMU guest cannot use KVM. systemd-nspawn shares
-# the host kernel (the same 16k kernel a real Mac install runs on) and still
-# gives install.sh its own rootfs, users, and pacman.
+# systemd-nspawn shares the ARM64 host kernel while giving install.sh its own
+# rootfs, users, and pacman. AWS runs a generic Linux kernel; this tests package
+# installation and userspace setup, not Asahi kernel or Apple GPU behavior.
 #
 # Needs root (or passwordless sudo), network, and several GB free.
 
@@ -152,6 +151,14 @@ nspawn() {
     "$@"
 }
 
+set_test_mirror() {
+  # Avoid the rotating HTTP mirror that timed out during package downloads.
+  # This is a guest-only fixture, not a change to users' mirror preferences.
+  nspawn /bin/bash -euo pipefail -c 'printf "%s\n" "Server = https://fl.us.mirror.archlinuxarm.org/\$arch/\$repo" > /etc/pacman.d/mirrorlist'
+}
+
+set_test_mirror
+
 if [[ ! -f $prepared ]]; then
   log "bootstrapping pacman, sudo, and the $GUEST_USER user"
   nspawn /bin/bash -euo pipefail <<'BOOTSTRAP'
@@ -178,7 +185,7 @@ BOOTSTRAP
 fi
 
 if [[ $CHECK_PACKAGE_SOURCES == "1" ]]; then
-  log "validating restricted package sources and the existing-system upgrade"
+  log "validating restricted package sources and current-stack repository remediation"
   nspawn /bin/bash -euo pipefail <<'PACKAGE_SOURCES' 2>&1 | tee "$WORK/logs/package-sources.log"
 export OMARCHY_PATH=/src/omarchy
 export PATH="$OMARCHY_PATH/bin:$PATH"
@@ -209,8 +216,19 @@ omarchy-update-system-pkgs
 [[ $(pacman-conf --repo omarchy Usage) == "Sync" ]]
 pacman -Qii aquamarine hyprtoolkit hyprland-guiutils hyprland
 pacman -Dk
-printf 'PASS: existing-system repository remediation and upgrade\n'
+printf 'PASS: current-stack repository remediation and reinstall (not an old-stack upgrade fixture)\n'
 PACKAGE_SOURCES
+
+  # The package transaction above must not preinstall the stack for install.sh.
+  # Start the full installer independently from the clean prepared base image.
+  as_root cp "$WORK/root/var/log/pacman.log" "$WORK/logs/package-phase-pacman.log"
+  [[ $WORK == /var/tmp/omarchy-* && $WORK != *".."* && ! -L $WORK/root ]] || fail "unsafe work directory"
+  as_root rm -rf -- "$WORK/root"
+  as_root mkdir -p "$WORK/root"
+  as_root tar -xzf "$prepared" -C "$WORK/root"
+  as_root mkdir -p "$WORK/root/src/omarchy"
+  set_test_mirror
+  log "restored independent clean base for the full installation"
 fi
 
 run_install() {

--- a/test/vm/run-selective-edge
+++ b/test/vm/run-selective-edge
@@ -1,0 +1,250 @@
+#!/bin/bash
+# Run install.sh inside an isolated Arch Linux ARM machine on this aarch64 host.
+#
+# GitHub's hosted ARM runners have no nested KVM, and this Asahi host uses 16k
+# pages, so a stock 4k Arch ARM QEMU guest cannot use KVM. systemd-nspawn shares
+# the host kernel (the same 16k kernel a real Mac install runs on) and still
+# gives install.sh its own rootfs, users, and pacman.
+#
+# Needs root (or passwordless sudo), network, and several GB free.
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+CACHE="${OMARCHY_INSTALL_VM_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-install-vm}"
+WORK="${OMARCHY_INSTALL_VM_WORK:-/var/tmp/omarchy-install-vm}"
+TARBALL_URL="${OMARCHY_INSTALL_VM_TARBALL:-https://fl.us.mirror.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz}"
+GUEST_USER=ci
+KEEP_ROOT=${OMARCHY_INSTALL_VM_KEEP:-0}
+CHECK_IDEMPOTENCY=${OMARCHY_INSTALL_VM_IDEMPOTENCY:-0}
+CHECK_PACKAGE_SOURCES=${OMARCHY_INSTALL_VM_PACKAGE_SOURCES:-0}
+PREPARED_CACHE_VERSION=3
+ROOTFS_SIGNING_FINGERPRINT=68B3537F39A313B3E574D06777193F152BDBE6A6
+ROOTFS_KEYSERVER=hkps://keyserver.ubuntu.com
+CALLER_UID=${SUDO_UID:-$(id -u)}
+CALLER_GID=${SUDO_GID:-$(id -g)}
+
+log() { printf '\033[32m==>\033[0m %s\n' "$*"; }
+fail() { printf '\033[31mError:\033[0m %s\n' "$*" >&2; exit 1; }
+
+as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+cleanup() {
+  for entry in omarchy-install pacman; do
+    if [[ -f $WORK/root/var/log/$entry.log ]]; then
+      if [[ $entry == "omarchy-install" ]]; then
+        as_root cp "$WORK/root/var/log/$entry.log" "$WORK/logs/system-setup.log" || true
+      else
+        as_root cp "$WORK/root/var/log/$entry.log" "$WORK/logs/$entry.log" || true
+      fi
+    fi
+  done
+  as_root chmod -R a+rX "$WORK/logs" 2>/dev/null || true
+  as_root chown "$CALLER_UID:$CALLER_GID" "$WORK/logs" 2>/dev/null || true
+  if (( KEEP_ROOT )); then
+    log "keeping $WORK/root (OMARCHY_INSTALL_VM_KEEP=1)"
+    return 0
+  fi
+  as_root rm -rf "$WORK/root"
+}
+
+[[ $(uname -m) == "aarch64" ]] || fail "this harness only runs on aarch64"
+command -v systemd-nspawn >/dev/null || fail "systemd-nspawn is required"
+command -v curl >/dev/null || fail "curl is required"
+command -v gpg >/dev/null || fail "gpg is required"
+command -v sha256sum >/dev/null || fail "sha256sum is required"
+
+as_root true || fail "root (or passwordless sudo) is required to spawn the machine"
+
+mkdir -p "$CACHE"
+as_root mkdir -p "$WORK/logs"
+as_root find "$WORK/logs" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+as_root chown "$CALLER_UID:$CALLER_GID" "$WORK/logs"
+as_root rm -rf "$WORK/root"
+as_root mkdir -p "$WORK/root"
+trap cleanup EXIT
+
+tarball="$CACHE/ArchLinuxARM-aarch64-latest.tar.gz"
+signature="$tarball.sig"
+
+verify_rootfs() {
+  local archive="$1" detached_signature="$2" keyring imported_fingerprint status signer_fingerprint result=0
+
+  keyring=$(mktemp -d "$WORK/rootfs-keyring.XXXXXX")
+  chmod 700 "$keyring"
+  if ! gpg --batch --homedir "$keyring" --keyserver "$ROOTFS_KEYSERVER" \
+    --recv-keys "$ROOTFS_SIGNING_FINGERPRINT" >/dev/null 2>&1; then
+    result=1
+  else
+    imported_fingerprint=$(gpg --batch --homedir "$keyring" --with-colons \
+      --fingerprint "$ROOTFS_SIGNING_FINGERPRINT" 2>/dev/null |
+      awk -F: '$1 == "fpr" { print $10; exit }')
+    if [[ $imported_fingerprint != "$ROOTFS_SIGNING_FINGERPRINT" ]]; then
+      result=1
+    elif ! status=$(gpg --batch --homedir "$keyring" --status-fd=1 \
+      --verify "$detached_signature" "$archive" 2>/dev/null); then
+      result=1
+    else
+      signer_fingerprint=$(awk '$1 == "[GNUPG:]" && $2 == "VALIDSIG" { print $3; exit }' <<<"$status")
+      [[ $signer_fingerprint == "$ROOTFS_SIGNING_FINGERPRINT" ]] || result=1
+    fi
+  fi
+  rm -rf "$keyring"
+  (( result == 0 ))
+}
+
+if [[ -f $tarball && -f $signature ]]; then
+  log "re-verifying cached Arch Linux ARM rootfs"
+  if ! verify_rootfs "$tarball" "$signature"; then
+    log "discarding an unverified rootfs cache"
+    rm -f "$tarball" "$signature"
+  fi
+elif [[ -f $tarball || -f $signature ]]; then
+  rm -f "$tarball" "$signature"
+fi
+
+if [[ ! -f $tarball ]]; then
+  log "downloading and verifying Arch Linux ARM rootfs"
+  download_dir=$(mktemp -d "$WORK/rootfs-download.XXXXXX")
+  curl -fL --retry 3 -o "$download_dir/rootfs.tar.gz" "$TARBALL_URL"
+  curl -fL --retry 3 -o "$download_dir/rootfs.tar.gz.sig" "$TARBALL_URL.sig"
+  if ! verify_rootfs "$download_dir/rootfs.tar.gz" "$download_dir/rootfs.tar.gz.sig"; then
+    rm -rf "$download_dir"
+    fail "Arch Linux ARM rootfs signature did not match $ROOTFS_SIGNING_FINGERPRINT"
+  fi
+  mv "$download_dir/rootfs.tar.gz" "$tarball"
+  mv "$download_dir/rootfs.tar.gz.sig" "$signature"
+  rmdir "$download_dir"
+fi
+
+rootfs_digest=$(sha256sum "$tarball" | awk '{ print $1 }')
+
+prepared="$CACHE/prepared-aarch64-v${PREPARED_CACHE_VERSION}-${rootfs_digest}.tar.gz"
+prepared_checksum="$prepared.sha256"
+
+if [[ -f $prepared && -f $prepared_checksum ]] &&
+  (cd "$CACHE" && sha256sum -c "$(basename "$prepared_checksum")" >/dev/null 2>&1); then
+  log "restoring prepared rootfs snapshot"
+  as_root tar -xzf "$prepared" -C "$WORK/root"
+else
+  rm -f "$prepared" "$prepared_checksum"
+  log "extracting rootfs into $WORK/root"
+  as_root tar -xzf "$tarball" -C "$WORK/root"
+fi
+
+as_root mkdir -p "$WORK/root/src/omarchy"
+
+nspawn() {
+  # Do not bind-ro /sys: nspawn has to mount its own cgroupfs on
+  # /sys/fs/cgroup, and a host /sys bind makes it refuse to start.
+  as_root systemd-nspawn \
+    --directory="$WORK/root" \
+    --register=no \
+    --resolv-conf=bind-host \
+    --bind="$ROOT:/src/omarchy" \
+    --console=pipe \
+    "$@"
+}
+
+if [[ ! -f $prepared ]]; then
+  log "bootstrapping pacman, sudo, and the $GUEST_USER user"
+  nspawn /bin/bash -euo pipefail <<'BOOTSTRAP'
+pacman-key --init
+pacman-key --populate archlinuxarm
+pacman -Sy --noconfirm
+pacman -S --needed --noconfirm sudo git base-devel
+id ci >/dev/null 2>&1 || useradd -m -G wheel ci
+printf '%s\n' 'ci ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/ci
+chmod 440 /etc/sudoers.d/ci
+sed -i 's/^#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+locale-gen >/dev/null
+printf 'LANG=en_US.UTF-8\n' >/etc/locale.conf
+BOOTSTRAP
+
+  log "saving prepared rootfs snapshot"
+  prepared_partial="$prepared.partial"
+  as_root rm -f "$prepared_partial"
+  as_root tar -czf "$prepared_partial" -C "$WORK/root" .
+  as_root chown "$CALLER_UID:$CALLER_GID" "$prepared_partial"
+  mv "$prepared_partial" "$prepared"
+  (cd "$CACHE" && sha256sum "$(basename "$prepared")" >"$(basename "$prepared_checksum")")
+  as_root chown "$CALLER_UID:$CALLER_GID" "$prepared_checksum"
+fi
+
+if [[ $CHECK_PACKAGE_SOURCES == "1" ]]; then
+  log "validating restricted package sources and the existing-system upgrade"
+  nspawn /bin/bash -euo pipefail <<'PACKAGE_SOURCES' 2>&1 | tee "$WORK/logs/package-sources.log"
+export OMARCHY_PATH=/src/omarchy
+export PATH="$OMARCHY_PATH/bin:$PATH"
+source "$OMARCHY_PATH/install/helpers/arm-package-sources.sh"
+omarchy_arm_prepare_package_sources
+[[ $(pacman-conf --repo omarchy Usage) == "Sync" ]]
+pacman -Sy --noconfirm
+mapfile -t targets < <(omarchy_arm_package_targets)
+pacman -Sp --print-format '%r %n %v %l' "${targets[@]}" > /tmp/package-selection
+cat /tmp/package-selection
+awk '
+  $1 == "omarchy" {
+    if ($2 != "hyprland" && $2 != "hyprtoolkit" && $2 != "hyprland-guiutils") exit 1
+    selected[$2] = 1
+  }
+  $2 == "aquamarine" { if ($1 != "extra") exit 1; aquamarine = 1 }
+  END { if (length(selected) != 3 || !aquamarine) exit 1 }
+' /tmp/package-selection
+pacman -Syu --needed --noconfirm "${targets[@]}"
+pacman -Qii aquamarine hyprtoolkit hyprland-guiutils hyprland
+pacman -Dk
+printf 'PASS: fresh restricted-source transaction\n'
+
+# Reproduce an installed system whose old configuration has no edge section.
+awk '/^\[/ { omit = ($0 == "[omarchy]") } !omit { print }' /etc/pacman.conf >/etc/pacman.conf.previous
+mv /etc/pacman.conf.previous /etc/pacman.conf
+omarchy-update-system-pkgs
+[[ $(pacman-conf --repo omarchy Usage) == "Sync" ]]
+pacman -Qii aquamarine hyprtoolkit hyprland-guiutils hyprland
+pacman -Dk
+printf 'PASS: existing-system repository remediation and upgrade\n'
+PACKAGE_SOURCES
+fi
+
+run_install() {
+  local log_file="$1"
+  nspawn --user="$GUEST_USER" --chdir=/src/omarchy \
+    /bin/bash -euo pipefail -c 'export LANG=en_US.UTF-8; bash install.sh' \
+    2>&1 | tee "$log_file"
+  local status=${PIPESTATUS[0]}
+  return "$status"
+}
+
+log "running install.sh as $GUEST_USER (AUR builds take a while)"
+run_install "$WORK/logs/install.log" || fail "install.sh exited $? (see $WORK/logs/install.log)"
+
+log "asserting the installed system"
+nspawn /bin/bash -euo pipefail <<'ASSERT' | tee "$WORK/logs/assert.log"
+source /usr/share/omarchy/default/bash/env-bootstrap
+command -v omarchy >/dev/null
+omarchy commands --check >/dev/null
+pacman -Q omarchy >/dev/null
+pacman -Q omarchy-settings >/dev/null
+[[ -d /usr/share/omarchy/bin ]]
+[[ -d /usr/share/omarchy/install ]]
+[[ -x /usr/share/omarchy/bin/omarchy ]]
+grep -q '^\[omarchy-aarch64\]' /etc/pacman.conf
+id ci >/dev/null
+su ci -c 'source /usr/share/omarchy/default/bash/env-bootstrap; command -v omarchy >/dev/null; [[ -d $HOME/.config/hypr ]]'
+printf 'ok - install.sh produced a working Omarchy userspace\n'
+ASSERT
+
+if [[ $CHECK_IDEMPOTENCY == "1" ]]; then
+  log "running install.sh again to check idempotency"
+  run_install "$WORK/logs/install-second.log" || fail "second install.sh run exited $? (see $WORK/logs/install-second.log)"
+  printf 'ok - second install.sh run completed\n' | tee "$WORK/logs/idempotency.log"
+fi
+
+log "install machine test passed"

--- a/test/vm/run-selective-edge
+++ b/test/vm/run-selective-edge
@@ -241,7 +241,27 @@ run_install() {
 }
 
 log "running install.sh as $GUEST_USER (AUR builds take a while)"
-run_install "$WORK/logs/install.log" || fail "install.sh exited $? (see $WORK/logs/install.log)"
+install_status=0
+run_install "$WORK/logs/install.log" || install_status=$?
+
+# Also run when later system setup fails: the default package loop must not
+# silently downgrade the explicit edge selection through an unqualified yay.
+if [[ $CHECK_PACKAGE_SOURCES == "1" ]]; then
+  nspawn /bin/bash -euo pipefail <<'VERIFY_FINAL' 2>&1 | tee "$WORK/logs/final-package-sources.log"
+export LC_ALL=C
+source /src/omarchy/install/helpers/arm-package-sources.sh
+while read -r target; do
+  package=${target#*/}
+  expected=$(pacman -Si "$target" | sed -n 's/^Version[[:space:]]*:[[:space:]]*//p')
+  installed=$(pacman -Q "$package" | cut -d ' ' -f2)
+  printf '%s installed=%s expected=%s\n' "$target" "$installed" "$expected"
+  [[ -n $expected && $installed == "$expected" ]]
+done < <(omarchy_arm_package_targets)
+pacman -Dk
+printf 'PASS: installer retained the explicit edge package versions\n'
+VERIFY_FINAL
+fi
+(( install_status == 0 )) || fail "install.sh exited $install_status (see $WORK/logs/install.log)"
 
 log "asserting the installed system"
 nspawn /bin/bash -euo pipefail <<'ASSERT' | tee "$WORK/logs/assert.log"


### PR DESCRIPTION
Use signed official edge only for Hyprland, Hyprtoolkit, and Hyprland-guiutils. Preserve the selection throughout installation/updates and initialize restored repositories before user setup.

Tested together with #334: CI and clean AWS ARM64 installation pass. All three versions retained, dependencies clean, Plymouth/system setup and user finalization completed.

[Passing integration run](https://github.com/omarchy-mac/omarchy-mac/actions/runs/33962771229). Awaiting confirmation before merging.