### PR TITLE
Recover Apple Silicon installs stranded before the ARM package sources policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ for the running kernel.
 
 Run `bash fix-mirrors.sh` from the repository root and retry.
 
+### The update stops on `libaquamarine.so` and cannot be repeated past it
+
+An install made before the ARM package sources policy cannot upgrade its way to
+it, because the update aborts before the package carrying it can be replaced.
+Run the recovery and log out and back in afterwards:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash
+```
+
+See [docs/arm-package-sources.md](docs/arm-package-sources.md) for what it
+changes and for `--dry-run`.
+
 ---
 
 ## Removal (uninstall)

--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ Run the recovery and log out and back in afterwards:
 curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash
 ```
 
-See [docs/arm-package-sources.md](docs/arm-package-sources.md) for what it
-changes and for `--dry-run`.
+See [docs/arm-package-sources.md](docs/arm-package-sources.md) for what it changes and how to pass `--dry-run` or `--no-snapshot` to the piped script.
 
 ---
 

--- a/docs/arm-package-sources.md
+++ b/docs/arm-package-sources.md
@@ -7,3 +7,23 @@ The installer, system updater, and pacman channel refresh explicitly select `oma
 The shared policy lives in `install/helpers/arm-package-sources.sh`. Package signatures are required and the existing Omarchy signing key is imported by its full fingerprint. Repository configuration preserves other repositories and mirror choices, saving `/etc/pacman.conf.bak` when it changes.
 
 Use `omarchy update` for system upgrades. A bare `pacman -Syu` does not update the explicitly selected edge packages and can fail when their regular-repository dependencies change ABI. Edge is rolling; versions are resolved together at transaction time rather than pinned.
+
+## Recovering an install that predates this policy
+
+The policy travels inside the `omarchy` package, and both places that apply it — the installer and the update commands — are out of reach on a machine installed before it. The installer is over, and the update aborts in dependency resolution before the package carrying the helper can be replaced, so the machine cannot upgrade its way to the fix. Such a machine reports:
+
+```
+:: unable to satisfy dependency 'libaquamarine.so=13-64' required by hyprtoolkit
+:: installing aquamarine (0.15.0-2) breaks dependency 'libaquamarine.so=13-64' required by hyprland
+error: failed to prepare transaction (could not satisfy dependencies)
+```
+
+`fix-arm-packages.sh` in the repository root applies the same preparation from outside the package and then runs the selection, which is enough for `omarchy update` to work normally afterwards. It sources `install/helpers/arm-package-sources.sh` rather than restating it, taking the copy from its own checkout, `$OMARCHY_PATH`, or `/usr/share/omarchy`, and falling back to the published copy when an installed machine has none of them:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash
+```
+
+The transaction runs as `sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu`, the same way `omarchy-update-system-pkgs` and `omarchy-refresh-pacman` do. The update guard hook aborts a `-Syu` that does not identify itself, and this is the update path arriving by another route rather than someone reaching past it.
+
+`--dry-run` reports the configuration change and the transaction without applying either, and is the only mode that runs off Apple Silicon. `--no-snapshot` skips the Snapper snapshot the script otherwise takes of the machine as found. The transaction replaces the running compositor, so log out and back in before doing anything else.

--- a/docs/arm-package-sources.md
+++ b/docs/arm-package-sources.md
@@ -24,6 +24,18 @@ error: failed to prepare transaction (could not satisfy dependencies)
 curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash
 ```
 
-The transaction runs as `sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu`, the same way `omarchy-update-system-pkgs` and `omarchy-refresh-pacman` do. The update guard hook aborts a `-Syu` that does not identify itself, and this is the update path arriving by another route rather than someone reaching past it.
+The transaction runs as `sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm`, the same way `omarchy-update-system-pkgs` and `omarchy-refresh-pacman` do. The update guard hook aborts a `-Syu` that does not identify itself, and this is the update path arriving by another route rather than someone reaching past it. The transaction is noninteractive because the recommended pipe supplies the script itself on standard input.
 
-`--dry-run` reports the configuration change and the transaction without applying either, and is the only mode that runs off Apple Silicon. `--no-snapshot` skips the Snapper snapshot the script otherwise takes of the machine as found. The transaction replaces the running compositor, so log out and back in before doing anything else.
+`--dry-run` reports the configuration change and the transaction without applying either, and is the only mode that runs off Apple Silicon. Pass options after `bash -s --` when running the script through a pipe:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash -s -- --dry-run
+```
+
+`--no-snapshot` skips the Snapper snapshot the script otherwise takes of the machine as found and can be passed the same way:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash -s -- --no-snapshot
+```
+
+The transaction replaces the running compositor, so log out and back in before doing anything else.

--- a/fix-arm-packages.sh
+++ b/fix-arm-packages.sh
@@ -21,6 +21,7 @@ readonly PACMAN_CONF="${OMARCHY_ARM_PACMAN_CONF:-/etc/pacman.conf}"
 dry_run=0
 snapshot=1
 downloaded_helper=""
+helper=""
 
 cleanup() {
   [[ -n $downloaded_helper ]] && rm -f "$downloaded_helper"
@@ -85,14 +86,14 @@ resolve_helper() {
 
   for candidate in "$script_dir" "${OMARCHY_PATH:-}" /usr/share/omarchy; do
     if [[ -n $candidate && -f "$candidate/$HELPER_RELATIVE_PATH" ]]; then
-      printf '%s\n' "$candidate/$HELPER_RELATIVE_PATH"
+      helper="$candidate/$HELPER_RELATIVE_PATH"
       return 0
     fi
   done
 
   downloaded_helper=$(mktemp)
   if curl -fsSL "$HELPER_URL" -o "$downloaded_helper"; then
-    printf '%s\n' "$downloaded_helper"
+    helper="$downloaded_helper"
     return 0
   fi
 
@@ -101,7 +102,7 @@ resolve_helper() {
   return 1
 }
 
-if ! helper=$(resolve_helper); then
+if ! resolve_helper; then
   echo "Could not find or fetch $HELPER_RELATIVE_PATH" >&2
   exit 1
 fi
@@ -126,7 +127,7 @@ if (( dry_run )); then
   echo "Configuration change for $PACMAN_CONF:"
   diff -u "$PACMAN_CONF" "$preview" || true
   rm -f "$preview" "$preview.bak"
-  echo "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu ${targets[*]}"
+  echo "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm ${targets[*]}"
   exit 0
 fi
 
@@ -150,7 +151,7 @@ fi
 # way omarchy-update-system-pkgs does. Without it the hook aborts the
 # transaction and the recovery gets no further than the machine it is fixing.
 echo "Updating the Hyprland stack together with the system"
-sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu "${targets[@]}"
+sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm "${targets[@]}"
 
 cat <<'EOF'
 

--- a/fix-arm-packages.sh
+++ b/fix-arm-packages.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# fix-arm-packages.sh
+# Recover an Apple Silicon install that cannot update because the Hyprland
+# stack in the regular repositories no longer matches the Aquamarine ABI there.
+#
+# The permanent fix ships inside the omarchy package, in
+# install/helpers/arm-package-sources.sh, and runs from the installer and the
+# update commands. A machine installed before that fix can reach neither: the
+# installer is over, and the update aborts in dependency resolution before the
+# package carrying the helper can be replaced. This script applies the same
+# preparation from outside the package so that update can start again.
+#
+# Usage: bash fix-arm-packages.sh [--dry-run] [--no-snapshot]
+
+set -euo pipefail
+
+readonly HELPER_RELATIVE_PATH="install/helpers/arm-package-sources.sh"
+readonly HELPER_URL="${OMARCHY_ARM_HELPER_URL:-https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/$HELPER_RELATIVE_PATH}"
+readonly PACMAN_CONF="${OMARCHY_ARM_PACMAN_CONF:-/etc/pacman.conf}"
+
+dry_run=0
+snapshot=1
+downloaded_helper=""
+
+cleanup() {
+  [[ -n $downloaded_helper ]] && rm -f "$downloaded_helper"
+  return 0
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<EOF
+Usage: bash $0 [--dry-run] [--no-snapshot]
+
+Options:
+  --dry-run      Report the configuration change and the transaction without applying either.
+  --no-snapshot  Skip the Snapper snapshot taken before the transaction.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --no-snapshot)
+      snapshot=0
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+# The transaction is Apple Silicon's; a dry run is a report and is allowed to
+# run anywhere, which is also what keeps this script under test off a Mac.
+if (( ! dry_run )) && [[ $(uname -m) != "aarch64" ]]; then
+  echo "This recovery is for Apple Silicon installs only (detected: $(uname -m))" >&2
+  exit 1
+fi
+
+if [[ ! -f $PACMAN_CONF ]]; then
+  echo "No pacman configuration at $PACMAN_CONF" >&2
+  exit 1
+fi
+
+# One source of truth for what the repository and key must be. A checkout has
+# the helper next to this script; an installed machine has it under the package
+# once it is new enough. Neither is guaranteed on the machines this script
+# exists for, so fall back to fetching it rather than restating its contents.
+resolve_helper() {
+  local script_dir="" candidate
+
+  if [[ -f ${BASH_SOURCE[0]} ]]; then
+    script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+  fi
+
+  for candidate in "$script_dir" "${OMARCHY_PATH:-}" /usr/share/omarchy; do
+    if [[ -n $candidate && -f "$candidate/$HELPER_RELATIVE_PATH" ]]; then
+      printf '%s\n' "$candidate/$HELPER_RELATIVE_PATH"
+      return 0
+    fi
+  done
+
+  downloaded_helper=$(mktemp)
+  if curl -fsSL "$HELPER_URL" -o "$downloaded_helper"; then
+    printf '%s\n' "$downloaded_helper"
+    return 0
+  fi
+
+  rm -f "$downloaded_helper"
+  downloaded_helper=""
+  return 1
+}
+
+if ! helper=$(resolve_helper); then
+  echo "Could not find or fetch $HELPER_RELATIVE_PATH" >&2
+  exit 1
+fi
+# shellcheck source=install/helpers/arm-package-sources.sh
+source "$helper"
+
+mapfile -t targets < <(omarchy_arm_package_targets)
+
+if (( dry_run )); then
+  preview=$(mktemp)
+  cp "$PACMAN_CONF" "$preview"
+  # Nothing leaves the temporary copy: the helper's writes land there as this
+  # user, and the key import is reported instead of performed.
+  sudo() {
+    if [[ $1 == "pacman-key" ]]; then
+      echo "would run: sudo $*"
+    else
+      command "$@"
+    fi
+  }
+  omarchy_arm_prepare_package_sources "$preview" preserve-backup
+  echo "Configuration change for $PACMAN_CONF:"
+  diff -u "$PACMAN_CONF" "$preview" || true
+  rm -f "$preview" "$preview.bak"
+  echo "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu ${targets[*]}"
+  exit 0
+fi
+
+# Before anything is written, so the snapshot is of the machine as found. 127
+# means Snapper is deliberately absent, the same reading omarchy-update takes;
+# a missing snapshot is not worth refusing the recovery over.
+if (( snapshot )) && command -v omarchy-snapshot >/dev/null; then
+  omarchy-snapshot create || (( $? == 127 )) ||
+    echo -e "\e[33mContinuing without a snapshot.\e[0m" >&2
+fi
+
+echo "Preparing package sources"
+if ! omarchy_arm_prepare_package_sources "$PACMAN_CONF"; then
+  echo "Could not prepare package sources" >&2
+  exit 1
+fi
+
+# OMARCHY_UPDATE_PACMAN=1 is what the update guard hook reads to tell an
+# Omarchy-driven transaction from someone reaching past `omarchy update`. This
+# is that path arriving by another route, not a bypass, so it says so the same
+# way omarchy-update-system-pkgs does. Without it the hook aborts the
+# transaction and the recovery gets no further than the machine it is fixing.
+echo "Updating the Hyprland stack together with the system"
+sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu "${targets[@]}"
+
+cat <<'EOF'
+
+Hyprland was replaced underneath the running session. Log out and back in
+before anything else, then run `omarchy update` normally.
+EOF

--- a/test/shell.d/arm-package-recovery-test.sh
+++ b/test/shell.d/arm-package-recovery-test.sh
@@ -29,7 +29,7 @@ pass 'dry run changes nothing on the machine'
 grep -q '^+\[omarchy\]$' <<<"$output" || fail 'dry run adds the edge section' "$output"
 grep -q '^+Usage = Sync$' <<<"$output" || fail 'dry run keeps edge out of automatic selection' "$output"
 grep -q '^+SigLevel = Required DatabaseOptional$' <<<"$output" || fail 'dry run requires signed packages' "$output"
-grep -q 'would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils' <<<"$output" ||
+grep -q 'would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils' <<<"$output" ||
   fail 'dry run reports the selected packages' "$output"
 grep -q 'would run: sudo pacman-key' <<<"$output" || fail 'dry run reports the key import' "$output"
 pass 'dry run reports the restricted signed edge section and the transaction'
@@ -42,11 +42,11 @@ guard="$ROOT/bin/omarchy-update-pacman-guard"
 if [[ -f $guard ]]; then
   grep -q 'OMARCHY_UPDATE_PACMAN' "$guard" || fail 'the guard still reads OMARCHY_UPDATE_PACMAN'
 fi
-transaction=$(grep -n 'pacman -Syu "\${targets\[@\]}"' "$recovery") || fail 'recovery runs the selection'
+transaction=$(grep -n 'pacman -Syu --noconfirm "\${targets\[@\]}"' "$recovery") || fail 'recovery runs the selection'
 [[ $transaction == *'sudo env OMARCHY_UPDATE_PACMAN=1 pacman'* ]] ||
   fail 'the transaction identifies itself to the update guard' "$transaction"
-reported=$(grep -o 'would run: sudo env [^"]*pacman -Syu' <<<"$output")
-[[ $reported == "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu" ]] ||
+reported=$(grep -o 'would run: sudo env [^"]*pacman -Syu --noconfirm' <<<"$output")
+[[ $reported == "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu --noconfirm" ]] ||
   fail 'the reported transaction matches the one that runs' "$reported"
 pass 'the transaction identifies itself to the update guard'
 
@@ -62,8 +62,11 @@ cp "$ROOT/install/helpers/arm-package-sources.sh" "$test_tmp/published-helper.sh
 mkdir -p "$test_tmp/empty"
 cp "$recovery" "$test_tmp/empty/fix-arm-packages.sh"
 cp "$test_tmp/original" "$conf"
+download_tmp="$test_tmp/downloads"
+mkdir -p "$download_tmp"
 
 output=$(
+  TMPDIR="$download_tmp" \
   OMARCHY_ARM_PACMAN_CONF="$conf" \
     OMARCHY_PATH="$test_tmp/empty" \
     OMARCHY_ARM_HELPER_URL="file://$test_tmp/published-helper.sh" \
@@ -71,8 +74,72 @@ output=$(
 ) || fail 'dry run without a local helper succeeds' "$output"
 grep -q 'omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils' <<<"$output" ||
   fail 'fetched helper supplies the selected packages' "$output"
+[[ -z $(find "$download_tmp" -mindepth 1 -print -quit) ]] ||
+  fail 'fetched helper is removed after use' "$(find "$download_tmp" -mindepth 1 -maxdepth 1 -printf '%f\n')"
 pass 'recovery falls back to the published helper when no checkout is installed'
 
+# The documented pipe puts the script itself on stdin. A pacman invocation
+# that asks questions can consume the rest of that script as answers. Run the
+# real recovery through that pipe and make the pacman stub fail after two
+# prompts unless the transaction explicitly disables prompting.
+stub_bin="$test_tmp/stub-bin"
+call_log="$test_tmp/calls"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/uname" <<'STUB'
+#!/bin/bash
+printf '%s\n' aarch64
+STUB
+cat > "$stub_bin/sudo" <<'STUB'
+#!/bin/bash
+exec "$@"
+STUB
+cat > "$stub_bin/pacman-key" <<'STUB'
+#!/bin/bash
+if [[ $1 == "--list-keys" ]]; then
+  exit 1
+fi
+exit 0
+STUB
+cat > "$stub_bin/pacman" <<'STUB'
+#!/bin/bash
+printf 'pacman' >> "$OMARCHY_TEST_CALL_LOG"
+printf '\t%s' "$@" >> "$OMARCHY_TEST_CALL_LOG"
+printf '\n' >> "$OMARCHY_TEST_CALL_LOG"
+if [[ " $* " != *" --noconfirm "* ]]; then
+  printf 'Replace package? [Y/n] ' >&2
+  IFS= read -r first_answer || true
+  printf 'Select provider? [1] ' >&2
+  IFS= read -r second_answer || true
+  printf 'answers\t%s\t%s\n' "$first_answer" "$second_answer" >> "$OMARCHY_TEST_CALL_LOG"
+  exit 42
+fi
+STUB
+chmod +x "$stub_bin/uname" "$stub_bin/sudo" "$stub_bin/pacman-key" "$stub_bin/pacman"
+
+cp "$test_tmp/original" "$conf"
+rm -f "$conf.bak" "$call_log"
+pipe_tmp="$test_tmp/pipe-downloads"
+mkdir -p "$pipe_tmp"
+output=$(
+  cat "$test_tmp/empty/fix-arm-packages.sh" | env \
+    PATH="$stub_bin:$PATH" \
+    TMPDIR="$pipe_tmp" \
+    OMARCHY_ARM_PACMAN_CONF="$conf" \
+    OMARCHY_PATH="$test_tmp/empty" \
+    OMARCHY_ARM_HELPER_URL="file://$test_tmp/published-helper.sh" \
+    OMARCHY_TEST_CALL_LOG="$call_log" \
+    bash -s -- --no-snapshot 2>&1
+) || fail 'piped recovery succeeds without reading script text as prompt answers' "$output"
+grep -q $'^pacman\t-Syu\t--noconfirm\tomarchy/hyprland\tomarchy/hyprtoolkit\tomarchy/hyprland-guiutils$' "$call_log" ||
+  fail 'piped recovery runs the noninteractive package transaction' "$(cat "$call_log")"
+! grep -q '^answers' "$call_log" || fail 'piped recovery lets pacman prompt on script input' "$(cat "$call_log")"
+grep -q '^\[omarchy\]$' "$conf" || fail 'piped recovery prepares the package source' "$(cat "$conf")"
+[[ -f "$conf.bak" ]] || fail 'piped recovery backs up the package configuration'
+[[ -z $(find "$pipe_tmp" -mindepth 1 -print -quit) ]] ||
+  fail 'piped recovery cleans its downloaded helper' "$(find "$pipe_tmp" -mindepth 1 -maxdepth 1 -printf '%f\n')"
+pass 'documented pipe runs the complete recovery without interactive package prompts'
+
+cp "$test_tmp/original" "$conf"
 output=$(run_recovery --unknown-option && echo UNEXPECTED) || true
 grep -q 'Unknown option' <<<"$output" || fail 'unknown options are rejected' "$output"
 ! grep -q UNEXPECTED <<<"$output" || fail 'unknown options do not run the recovery' "$output"

--- a/test/shell.d/arm-package-recovery-test.sh
+++ b/test/shell.d/arm-package-recovery-test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+recovery="$ROOT/fix-arm-packages.sh"
+
+[[ -x $recovery ]] || fail 'recovery script is executable'
+bash -n "$recovery" || fail 'recovery script parses'
+pass 'recovery script is present, executable, and parses'
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+conf="$test_tmp/pacman.conf"
+printf '%s\n' '[options]' 'Architecture = aarch64' '[extra]' 'Server = https://regular.example/$arch' '[omarchy-aarch64]' 'Server = https://mac.example' > "$conf"
+cp "$conf" "$test_tmp/original"
+
+run_recovery() {
+  OMARCHY_ARM_PACMAN_CONF="$conf" bash "$recovery" "$@" 2>&1
+}
+
+output=$(run_recovery --dry-run) || fail 'dry run succeeds' "$output"
+
+cmp -s "$test_tmp/original" "$conf" || fail 'dry run leaves the configuration untouched'
+[[ ! -e "$conf.bak" ]] || fail 'dry run writes no backup'
+pass 'dry run changes nothing on the machine'
+
+grep -q '^+\[omarchy\]$' <<<"$output" || fail 'dry run adds the edge section' "$output"
+grep -q '^+Usage = Sync$' <<<"$output" || fail 'dry run keeps edge out of automatic selection' "$output"
+grep -q '^+SigLevel = Required DatabaseOptional$' <<<"$output" || fail 'dry run requires signed packages' "$output"
+grep -q 'would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils' <<<"$output" ||
+  fail 'dry run reports the selected packages' "$output"
+grep -q 'would run: sudo pacman-key' <<<"$output" || fail 'dry run reports the key import' "$output"
+pass 'dry run reports the restricted signed edge section and the transaction'
+
+# The update guard hook aborts any direct -Syu that does not identify itself,
+# so a recovery that forgets this never reaches the packages it exists to
+# install. The reported command must be the one that runs, or the dry run
+# hides the failure instead of predicting it.
+guard="$ROOT/bin/omarchy-update-pacman-guard"
+if [[ -f $guard ]]; then
+  grep -q 'OMARCHY_UPDATE_PACMAN' "$guard" || fail 'the guard still reads OMARCHY_UPDATE_PACMAN'
+fi
+transaction=$(grep -n 'pacman -Syu "\${targets\[@\]}"' "$recovery") || fail 'recovery runs the selection'
+[[ $transaction == *'sudo env OMARCHY_UPDATE_PACMAN=1 pacman'* ]] ||
+  fail 'the transaction identifies itself to the update guard' "$transaction"
+reported=$(grep -o 'would run: sudo env [^"]*pacman -Syu' <<<"$output")
+[[ $reported == "would run: sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu" ]] ||
+  fail 'the reported transaction matches the one that runs' "$reported"
+pass 'the transaction identifies itself to the update guard'
+
+grep -q 'Server = https://regular.example' <<<"$(cat "$conf")" || fail 'regular mirrors kept'
+! grep -q '^-' <<<"$(grep -v '^---' <<<"$output")" || fail 'dry run removes nothing from a configuration without an edge section' "$output"
+pass 'recovery only adds to a configuration that has no edge section'
+
+# This script exists for machines whose installed package predates the helper,
+# so a checkout must never be the only place it can find one. Point every local
+# candidate at an empty directory and let it fall back to the published copy,
+# served from a file here so the test needs no network.
+cp "$ROOT/install/helpers/arm-package-sources.sh" "$test_tmp/published-helper.sh"
+mkdir -p "$test_tmp/empty"
+cp "$recovery" "$test_tmp/empty/fix-arm-packages.sh"
+cp "$test_tmp/original" "$conf"
+
+output=$(
+  OMARCHY_ARM_PACMAN_CONF="$conf" \
+    OMARCHY_PATH="$test_tmp/empty" \
+    OMARCHY_ARM_HELPER_URL="file://$test_tmp/published-helper.sh" \
+    bash "$test_tmp/empty/fix-arm-packages.sh" --dry-run 2>&1
+) || fail 'dry run without a local helper succeeds' "$output"
+grep -q 'omarchy/hyprland omarchy/hyprtoolkit omarchy/hyprland-guiutils' <<<"$output" ||
+  fail 'fetched helper supplies the selected packages' "$output"
+pass 'recovery falls back to the published helper when no checkout is installed'
+
+output=$(run_recovery --unknown-option && echo UNEXPECTED) || true
+grep -q 'Unknown option' <<<"$output" || fail 'unknown options are rejected' "$output"
+! grep -q UNEXPECTED <<<"$output" || fail 'unknown options do not run the recovery' "$output"
+cmp -s "$test_tmp/original" "$conf" || fail 'a rejected invocation changes nothing'
+pass 'unknown options are rejected before anything runs'


### PR DESCRIPTION
Closes #352.

## The problem

The ARM package sources policy from #345 travels inside the `omarchy` package, and both places that apply it are out of reach on a machine installed before it:

- the installer is over, and
- `omarchy-update-system-pkgs` sources the helper from `$OMARCHY_PATH`, so it only runs *after* the package upgrade it is meant to unblock has already succeeded.

The upgrade is the thing that aborts, so the machine cannot upgrade its way to the fix. #341 is fixed for fresh installs and unfixed for exactly the population that reported it.

## The change

`fix-arm-packages.sh` in the repository root, alongside the existing `fix-mirrors.sh`, applies the same preparation from outside the package and then runs the selection. Afterwards `omarchy update` works normally.

```bash
curl -fsSL https://raw.githubusercontent.com/omarchy-mac/omarchy-mac/quattro/fix-arm-packages.sh | bash
```

It **sources `install/helpers/arm-package-sources.sh` rather than restating it**, so the repository and key stay defined in one place. It takes that copy from its own checkout, `$OMARCHY_PATH`, or `/usr/share/omarchy`, and falls back to the published copy when an installed machine has none of them — which is the normal case for the machines this exists for.

`--dry-run` reports the configuration change and the transaction without applying either, and is the only mode that runs off Apple Silicon, which is what keeps it under test in `./test/all` on `ubuntu-24.04`. `--no-snapshot` skips the Snapper snapshot otherwise taken of the machine as found.

## The transaction has to identify itself

Found while running this on hardware. `00-omarchy-update-guard.hook` aborts any direct `-Syu`:

```
Woah partner...
This looks like a direct pacman system upgrade.
error: failed to commit transaction (failed to run transaction hooks)
```

So the recovery runs `sudo env OMARCHY_UPDATE_PACMAN=1 pacman -Syu …`, the same way `omarchy-update-system-pkgs` and `omarchy-refresh-pacman` do — this is the update path arriving by another route, not someone reaching past it. `test/shell.d/arm-package-recovery-test.sh` asserts that the command that runs carries the variable and that the dry run reports the command that actually runs, so a dry run cannot predict a transaction the guard would reject.

## Verified on hardware

MacBook Pro 14" M2 Pro (`Mac14,9`, `apple,t6020`), Asahi, stranded at `omarchy 4.0.1-2` with `hyprland 0.56.1-3` / `aquamarine 0.14.0-2`. Repository and key preparation applied; the selection resolves as intended:

```
Repository : omarchy   hyprland 0.56.2-3           libaquamarine.so=14-64
Repository : omarchy   hyprtoolkit 0.5.4-5.1       libaquamarine.so=14-64
Repository : omarchy   hyprland-guiutils 0.2.2-3
Packages (20) … aquamarine-0.15.0-2 … hyprland-0.56.2-3 hyprland-guiutils-0.2.2-3 hyprtoolkit-0.5.4-5.1
```

That transaction is what surfaced the guard, which is now handled.

## Tests

- New `test/shell.d/arm-package-recovery-test.sh`: 7 assertions — dry run mutates nothing and writes no backup, adds a restricted signed `[omarchy]` section, removes nothing from a configuration that has none, the transaction identifies itself to the guard and matches what the dry run reported, the published-helper fallback works with no local checkout, and unknown options are rejected before anything runs. Uses `OMARCHY_ARM_PACMAN_CONF` against a temporary file, so it needs no root, no pacman, and no Mac.
- `./test/shell` — 253 of 255 files pass. The two failures (`config-test.sh`, `unowned-system-paths-test.sh`) are pre-existing and environmental: both need an `omarchy-pkgs` checkout via `OMARCHY_PKGS_PATH`, which CI supplies. Confirmed identical on a pristine `quattro` clone.
- `shellcheck --shell=bash -S error -e SC1090,SC1091,SC1087,SC1113,SC2096,SC2218 fix-arm-packages.sh` clean (0.11.0).

## Not covered here

Issue #352 also notes that `omarchy-mac/omarchy-pkgs-aarch64` still ships `omarchy` / `omarchy-settings` at `4.0.1-2` (assets last updated 2026-08-27), so `[omarchy-aarch64]` never offers `4.0.2-1`. That is a release action in the other repository and cannot be fixed from here. This PR makes the stranded machines recoverable regardless of when that happens.
