### PR TITLE
Keep the asahi mkinitcpio hook in the aarch64 package

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -90,6 +90,36 @@ strip_limine_dependencies() {
   done
 }
 
+# Upstream's package() deletes /etc/mkinitcpio.conf.d wholesale on aarch64,
+# reasoning that omarchy_hooks.conf is the x86 file that would inject the
+# Limine hooks into an Asahi initramfs. That is true of upstream's copy and
+# false of ours: this fork rewrote the same file to insert the asahi hook --
+# which stages the Apple Silicon display, Wi-Fi and neural-engine firmware
+# into early boot -- and to drop btrfs-overlayfs when limine-snapper-sync is
+# absent. Ship without it and the next mkinitcpio writes an image that cannot
+# drive the hardware: the boot wedges in the initramfs, keyboard and all, with
+# `avd: failed to load firmware` and apple-dcp errors as the only clue.
+#
+# Narrow the deletion to the Limine entry-tool config, which really is x86
+# only, rather than forking the PKGBUILD, so it keeps tracking upstream.
+keep_apple_silicon_mkinitcpio_drop_ins() {
+  local pkgbuild="$1"
+  local upstream_line='rm -rf "$pkgdir/etc/limine-entry-tool.d" "$pkgdir/etc/mkinitcpio.conf.d"'
+
+  # Fail loudly if upstream restructures this. Silently not matching would
+  # ship a package missing the asahi hook, which is the failure this exists
+  # to prevent and the one nobody notices until the next kernel update.
+  grep -qF "$upstream_line" "$pkgbuild" ||
+    fail "omarchy-settings PKGBUILD no longer deletes /etc/mkinitcpio.conf.d as expected; re-check it against $pkgbuild"
+
+  sed -i 's| "\$pkgdir/etc/mkinitcpio\.conf\.d"||' "$pkgbuild"
+
+  ! grep -q 'pkgdir/etc/mkinitcpio\.conf\.d' "$pkgbuild" ||
+    fail "could not keep /etc/mkinitcpio.conf.d in $pkgbuild"
+  grep -qF 'rm -rf "$pkgdir/etc/limine-entry-tool.d"' "$pkgbuild" ||
+    fail "lost the limine-entry-tool.d cleanup in $pkgbuild"
+}
+
 # makepkg runs with --nodeps because the runtime dependencies include packages
 # built here, so pacman cannot resolve them yet. That skips makedepends too,
 # leaving the build tools to be installed up front.
@@ -139,6 +169,9 @@ build_package() {
 
   if [[ $package == "omarchy" ]]; then
     strip_limine_dependencies "$build_dir/$package/PKGBUILD"
+  fi
+  if [[ $package == "omarchy-settings" ]]; then
+    keep_apple_silicon_mkinitcpio_drop_ins "$build_dir/$package/PKGBUILD"
   fi
   if [[ $package == "omarchy" || $package == "omarchy-settings" ]]; then
     set_pkgrel "$build_dir/$package/PKGBUILD"


### PR DESCRIPTION
Building `omarchy-settings` as a real `aarch64` package drops `etc/mkinitcpio.conf.d/`, and the machine stops booting at the next kernel update.

Upstream's `package()` does this:

```bash
if [[ $CARCH == aarch64 ]]; then
  # ... omarchy_hooks.conf would inject the Limine hooks into the Asahi
  # kernel's initramfs ...
  rm -rf "$pkgdir/etc/limine-entry-tool.d" "$pkgdir/etc/mkinitcpio.conf.d"
```

Correct for **upstream's** `omarchy_hooks.conf`. Not for ours — this fork rewrote the same path for Apple Silicon, and `build-packages.sh` never put it back (it only set `pkgrel` and stripped limine *dependencies*).

## Measured on a booting M-series machine

Effective `HOOKS`, resolved with and without the drop-in:

```
WITH:    base udev plymouth keyboard autodetect microcode modconf kms keymap consolefont block encrypt filesystems fsck
WITHOUT: base udev plymouth keyboard keymap block encrypt filesystems

lost: autodetect, microcode, modconf, kms, consolefont, fsck
```

**`kms` is the one that bites.** Without early mode-setting there is no display driver in the initramfs, and these machines boot to a LUKS passphrase prompt — you can't see it or type into it. The file also re-inserts the `asahi` hook where `/usr/lib/initcpio/install/asahi` exists, and drops `btrfs-overlayfs` when `limine-snapper-sync` isn't installed.

## Why nobody has hit this

The published packages are `arch=any`, built by hand, so `CARCH == aarch64` never matched and the deletion never ran. Confirmed on a booting M-series machine: `/etc/mkinitcpio.conf.d/omarchy_hooks.conf` is owned by `omarchy-settings 4.0.1-2`. omarchy-pkgs-aarch64's new pipeline builds these as `aarch64`, which switches the deletion on.

It also wouldn't fail loudly — the package installs fine, and the breakage lands at the next `mkinitcpio` run.

## The change

Narrows the deletion to `limine-entry-tool.d`, keeping upstream's intent for the part that genuinely is x86-only, and follows the existing `strip_limine_dependencies` approach of patching rather than forking so the PKGBUILD keeps tracking upstream.

**It refuses to build if upstream restructures that line.** Silently failing to match would ship exactly the package this prevents.

## Verification

Built all four packages in the CI container on real aarch64 hardware with this change applied. The resulting `omarchy-settings-4.0.2-2-aarch64` keeps `omarchy_hooks.conf` and `thunderbolt_module.conf`, and the hook file is **byte-identical** to the one in the shipping `4.0.1-2` package (md5 `9e2de865`) — users get exactly the file they already have.

Full file-list diff against the shipping package: every removal is either an audited x86-only strip or 4.0.2 upstream drift. I compared git blob SHAs for all eight paths upstream strips on aarch64; only `omarchy_hooks.conf` and `thunderbolt_module.conf` are fork-modified, and both are covered here.

Also verified the narrowing applies cleanly to the current upstream PKGBUILD, that `limine-entry-tool.d` is still removed, and that a simulated upstream restructure is refused.

Pairs with omarchy-pkgs-aarch64#9, which flips `verify()` from asserting this directory is absent to requiring the hook.