### PR TITLE
Fix first-run timezone toast on Apple Silicon

### DIFF
--- a/install/user/first-run/timezone.sh
+++ b/install/user/first-run/timezone.sh
@@ -24,5 +24,5 @@ timezone_needs_setting() {
 if timezone_needs_setting; then
   omarchy-notification-send -u critical -g 󰥔 "Set your timezone" \
     "This machine is on $(current_timezone). Click to choose yours." \
-    --exec "omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced"
+    --exec omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced
 fi

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -38,3 +38,11 @@ grep -F 'omarchy-shell -q omarchy.clock refresh' "$timezone_menu" >/dev/null ||
   fail "timezone menu no longer refreshes the retired Clock IPC target"
 
 pass "timezone menu refreshes clock after timezone changes"
+
+first_run_tz="$ROOT/install/user/first-run/timezone.sh"
+grep -F -- '--exec omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced' \
+  "$first_run_tz" >/dev/null ||
+  fail "first-run timezone toast passes --exec as separate words"
+! grep -F -- '--exec "' "$first_run_tz" >/dev/null ||
+  fail "first-run timezone toast does not quote --exec as one string"
+pass "first-run timezone toast matches notification-send --exec argv"


### PR DESCRIPTION
The first-run timezone card never appeared on a Mac left at UTC. `omarchy-notification-send` takes `--exec` as separate words and rejects a quoted whole command, so the toast script exited 1 and first-run skipped it.

Pass the launcher the same way Wi-Fi and keybindings already do.

Closes #306