### PR TITLE
Fix first-run login loop caused by unpackaged user units

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -120,6 +120,30 @@ keep_apple_silicon_mkinitcpio_drop_ins() {
     fail "lost the limine-entry-tool.d cleanup in $pkgbuild"
 }
 
+# omarchy-settings installs runtime user units from a hand-maintained list in
+# package(), so a unit added under default/systemd/user/ looks shipped in
+# /usr/share/omarchy while never reaching /usr/lib/systemd/user/. That gap is
+# how 4.0.2 wedged first-run into replaying every login: enable-user-units.sh
+# asked for a unit the package never installed. Append a glob install after
+# the existing list rather than forking the PKGBUILD, so upstream keeps
+# tracking and every shipped unit — current and future — lands in the package.
+install_all_user_units() {
+  local pkgbuild="$1"
+  local anchor='install -Dm644 default/systemd/user/bt-agent.service'
+  local glob_loop='for omarchy_user_unit in default/systemd/user/*.service; do install -Dm644 "$omarchy_user_unit" "$pkgdir/usr/lib/systemd/user/${omarchy_user_unit##*/}"; done'
+
+  # Fail loudly if upstream restructures the unit installs. Silently not
+  # matching would ship a package missing every user unit.
+  grep -qF "$anchor" "$pkgbuild" ||
+    fail "omarchy-settings PKGBUILD no longer installs default/systemd/user units as expected; re-check it against $pkgbuild"
+
+  sed -i "\\%$anchor%a\\
+$glob_loop" "$pkgbuild"
+
+  grep -qF 'for omarchy_user_unit in default/systemd/user/*.service' "$pkgbuild" ||
+    fail "could not add the default/systemd/user glob install to $pkgbuild"
+}
+
 # makepkg runs with --nodeps because the runtime dependencies include packages
 # built here, so pacman cannot resolve them yet. That skips makedepends too,
 # leaving the build tools to be installed up front.
@@ -172,6 +196,7 @@ build_package() {
   fi
   if [[ $package == "omarchy-settings" ]]; then
     keep_apple_silicon_mkinitcpio_drop_ins "$build_dir/$package/PKGBUILD"
+    install_all_user_units "$build_dir/$package/PKGBUILD"
   fi
   if [[ $package == "omarchy" || $package == "omarchy-settings" ]]; then
     set_pkgrel "$build_dir/$package/PKGBUILD"

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -8,15 +8,31 @@
 # first session has bluetooth pairing, sleep lock, etc. live immediately
 # instead of waiting for the next login. ConditionPath* in the unit files
 # keep the enabled units inert on hardware they don't apply to.
+#
+# Units are enabled one at a time, and a per-unit failure is reported but
+# does not fail this step. Failing the step would keep omarchy-provision-
+# first-run from marking first-run done, replaying the whole first-run
+# notification stack at every login — the 4.0.2 loop caused by a unit that
+# shipped in /usr/share/omarchy but was never packaged into
+# /usr/lib/systemd/user/. A unit systemd cannot enable is a packaging bug
+# that a login-retry loop cannot fix.
 
 set -euo pipefail
 
-systemctl --user daemon-reload
-systemctl --user enable --now \
-  bt-agent.service \
-  omarchy-recover-internal-monitor.service \
-  omarchy-sleep-lock.service \
-  omarchy-migrate-notify.service \
-  omarchy-fcitx5.service \
-  omarchy-crash-watch.service \
+units=(
+  bt-agent.service
+  omarchy-recover-internal-monitor.service
+  omarchy-sleep-lock.service
+  omarchy-migrate-notify.service
+  omarchy-fcitx5.service
+  omarchy-crash-watch.service
   omarchy-brightness-keyboard-auto.service
+)
+
+systemctl --user daemon-reload
+
+for unit in "${units[@]}"; do
+  if ! systemctl --user enable --now "$unit"; then
+    echo "Warning: could not enable $unit" >&2
+  fi
+done

--- a/install/user/first-run/enable-user-units.sh
+++ b/install/user/first-run/enable-user-units.sh
@@ -9,13 +9,19 @@
 # instead of waiting for the next login. ConditionPath* in the unit files
 # keep the enabled units inert on hardware they don't apply to.
 #
-# Units are enabled one at a time, and a per-unit failure is reported but
-# does not fail this step. Failing the step would keep omarchy-provision-
-# first-run from marking first-run done, replaying the whole first-run
-# notification stack at every login — the 4.0.2 loop caused by a unit that
-# shipped in /usr/share/omarchy but was never packaged into
-# /usr/lib/systemd/user/. A unit systemd cannot enable is a packaging bug
-# that a login-retry loop cannot fix.
+# Units are enabled one at a time so one bad unit cannot stop the rest, but
+# an unexpected failure still fails this step: omarchy-provision-first-run
+# must not mark first-run done while a required unit such as sleep-lock or
+# migrate-notify is missing from the session, since nothing else retries it.
+#
+# The single exception is omarchy-brightness-keyboard-auto.service when
+# systemd reports it as not-found. That is the 4.0.2 packaging omission — a
+# unit that shipped in /usr/share/omarchy but was never installed into
+# /usr/lib/systemd/user/ — which no login-retry loop can fix, and which
+# replayed the whole first-run notification stack at every login. Anything
+# else (a transient failure of that same unit, a masked or bad-setting
+# state, or an unreadable state query) is treated as a real failure so
+# first-run retries.
 
 set -euo pipefail
 
@@ -31,8 +37,23 @@ units=(
 
 systemctl --user daemon-reload
 
+failed=0
 for unit in "${units[@]}"; do
-  if ! systemctl --user enable --now "$unit"; then
-    echo "Warning: could not enable $unit" >&2
+  if systemctl --user enable --now "$unit"; then
+    continue
   fi
+
+  if [[ $unit == "omarchy-brightness-keyboard-auto.service" ]]; then
+    if load_state=$(systemctl --user show --property=LoadState --value "$unit"); then
+      if [[ $load_state == "not-found" ]]; then
+        echo "Warning: skipping known missing unit $unit; install the repaired package" >&2
+        continue
+      fi
+    fi
+  fi
+
+  echo "Error: could not enable $unit; setup must retry" >&2
+  failed=1
 done
+
+exit "$failed"

--- a/migrations/1788782695.sh
+++ b/migrations/1788782695.sh
@@ -1,0 +1,29 @@
+echo "Repair first-run wedged by unpackaged user units"
+
+# 4.0.2 shipped omarchy-brightness-keyboard-auto.service and
+# omarchy-speaker-tuning.service under /usr/share/omarchy without installing
+# them to /usr/lib/systemd/user/, so first-run's enable step failed at every
+# login and never marked itself done, and migration 1788139121's fallback
+# wrote a dangling graphical-session.target.wants symlink. The package now
+# installs every default/systemd/user unit; drop any dangling wants symlink
+# and re-run the (now per-unit, non-wedging) enable so the units come up
+# without waiting for another login.
+
+# The repair needs a live user manager. From a TTY or SSH update there is
+# nothing to enable against, so stay pending and let the login notifier
+# bring the user back to omarchy-migrate inside a graphical session.
+if ! systemctl --user daemon-reload >/dev/null 2>&1; then
+  echo "No user systemd manager available; run omarchy-migrate again from a graphical session" >&2
+  exit 1
+fi
+
+wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
+if [[ -d $wants_dir ]]; then
+  for wants_link in "$wants_dir"/*.service; do
+    if [[ -L $wants_link && ! -e $wants_link ]]; then
+      rm -f "$wants_link"
+    fi
+  done
+fi
+
+bash "$OMARCHY_PATH/install/user/first-run/enable-user-units.sh"

--- a/migrations/1788782695.sh
+++ b/migrations/1788782695.sh
@@ -5,9 +5,15 @@ echo "Repair first-run wedged by unpackaged user units"
 # them to /usr/lib/systemd/user/, so first-run's enable step failed at every
 # login and never marked itself done, and migration 1788139121's fallback
 # wrote a dangling graphical-session.target.wants symlink. The package now
-# installs every default/systemd/user unit; drop any dangling wants symlink
-# and re-run the (now per-unit, non-wedging) enable so the units come up
-# without waiting for another login.
+# installs every default/systemd/user unit; drop that one link when it still
+# points at the target 1788139121 wrote and nothing is there, then re-run the
+# per-unit enable so the units come up without waiting for another login.
+#
+# Only that exact link and target are removed: other dangling links in the
+# same directory belong to the user, and a link of the same name pointing
+# somewhere else is the user's own choice. The enable helper's status is
+# propagated, so a required unit that cannot be enabled leaves this
+# migration pending and it is retried.
 
 # The repair needs a live user manager. From a TTY or SSH update there is
 # nothing to enable against, so stay pending and let the login notifier
@@ -17,13 +23,12 @@ if ! systemctl --user daemon-reload >/dev/null 2>&1; then
   exit 1
 fi
 
-wants_dir="$HOME/.config/systemd/user/graphical-session.target.wants"
-if [[ -d $wants_dir ]]; then
-  for wants_link in "$wants_dir"/*.service; do
-    if [[ -L $wants_link && ! -e $wants_link ]]; then
-      rm -f "$wants_link"
-    fi
-  done
+wants_link="$HOME/.config/systemd/user/graphical-session.target.wants/omarchy-brightness-keyboard-auto.service"
+legacy_target="/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service"
+if [[ -L $wants_link && ! -e $wants_link ]]; then
+  if [[ $(readlink "$wants_link") == "$legacy_target" ]]; then
+    rm -- "$wants_link"
+  fi
 fi
 
 bash "$OMARCHY_PATH/install/user/first-run/enable-user-units.sh"

--- a/test/shell.d/brightness-keyboard-auto-test.sh
+++ b/test/shell.d/brightness-keyboard-auto-test.sh
@@ -84,10 +84,9 @@ grep -F 'Automatic control pauses while the screen is locked or the lid is close
   fail "manual does not describe lock and lid-close as a pause"
 pass "manual describes lock and lid-close as pausing automatic control"
 
-migration=$(ls "$ROOT"/migrations/*keyboard*als* "$ROOT"/migrations/*als*keyboard* 2>/dev/null | tail -n 1 || true)
-if [[ -z $migration ]]; then
-  migration=$(grep -l omarchy-brightness-keyboard-auto.service "$ROOT"/migrations/*.sh | tail -n 1 || true)
-fi
+# Pinned: later migrations (1788782695 repairs the unpackaged-unit loop) also
+# name this unit, so discovery by grep would find the wrong file.
+migration="$ROOT/migrations/1788139121.sh"
 [[ -n $migration ]] || fail "a migration enables the ALS keyboard backlight unit"
 grep -F 'omarchy-brightness-keyboard-auto.service' "$migration" >/dev/null
 grep -F 'systemctl --user enable' "$migration" >/dev/null

--- a/test/shell.d/enable-user-units-test.sh
+++ b/test/shell.d/enable-user-units-test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+script="$ROOT/install/user/first-run/enable-user-units.sh"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+mock_bin="$TMPDIR/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+echo "$*" >>"$SYSTEMCTL_LOG"
+for failing_unit in ${SYSTEMCTL_FAIL_UNITS:-}; do
+  if [[ $* == *"$failing_unit"* ]]; then
+    echo "Failed to enable unit: Unit $failing_unit does not exist." >&2
+    exit 1
+  fi
+done
+exit 0
+SH
+chmod +x "$mock_bin/systemctl"
+
+log="$TMPDIR/calls"
+
+# Happy path: reload once, then one enable call per unit.
+: >"$log"
+SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" bash "$script" ||
+  fail "enable-user-units exits 0 when every unit enables"
+grep -Fqx -- '--user daemon-reload' "$log" || fail "the script reloads the user manager first"
+(( $(grep -c -- '--user enable --now' "$log") >= 7 )) ||
+  fail "the script enables each shipped unit with its own systemctl call" "$(cat "$log")"
+while read -r enable_call; do
+  unit_count=$(grep -oE '[A-Za-z0-9@_-]+\.service' <<<"$enable_call" | wc -l)
+  (( unit_count == 1 )) ||
+    fail "each enable call names exactly one unit" "$enable_call"
+done < <(grep -- '--user enable --now' "$log")
+pass "enable-user-units enables units one at a time after a daemon reload"
+
+# One missing unit must not block the others or fail the first-run step:
+# a non-zero exit here is what kept first-run replaying at every login on
+# 4.0.2 when omarchy-brightness-keyboard-auto.service was never packaged.
+: >"$log"
+stderr_file="$TMPDIR/stderr"
+SYSTEMCTL_LOG="$log" SYSTEMCTL_FAIL_UNITS=omarchy-brightness-keyboard-auto.service \
+  PATH="$mock_bin:$PATH" bash "$script" 2>"$stderr_file" ||
+  fail "one missing unit does not fail the first-run step" "$(cat "$stderr_file")"
+grep -Fq 'could not enable omarchy-brightness-keyboard-auto.service' "$stderr_file" ||
+  fail "the failing unit is reported by name" "$(cat "$stderr_file")"
+grep -Fq 'bt-agent.service' "$log" || fail "units before the failing one are still enabled"
+grep -Fq 'omarchy-crash-watch.service' "$log" ||
+  fail "units after the failing one are still enabled" "$(cat "$log")"
+pass "a missing unit is reported per unit and never wedges first-run"
+
+# A dead user manager is a different failure: nothing can be enabled at all,
+# so the step must fail and let first-run retry at the next login.
+: >"$log"
+if SYSTEMCTL_LOG="$log" SYSTEMCTL_FAIL_UNITS="daemon-reload" \
+  PATH="$mock_bin:$PATH" bash "$script" 2>/dev/null; then
+  fail "a failed daemon-reload still fails the step"
+fi
+pass "a dead user manager still fails the step so first-run retries"

--- a/test/shell.d/enable-user-units-test.sh
+++ b/test/shell.d/enable-user-units-test.sh
@@ -8,58 +8,69 @@ script="$ROOT/install/user/first-run/enable-user-units.sh"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
-mock_bin="$TMPDIR/bin"
-mkdir -p "$mock_bin"
+mkdir -p "$TMPDIR/bin"
 
-cat >"$mock_bin/systemctl" <<'SH'
+# The mock reports the enable status and the LoadState separately so a
+# transient failure of a unit that is installed is distinguishable from the
+# packaging omission the helper is allowed to tolerate.
+cat >"$TMPDIR/bin/systemctl" <<'SH'
 #!/bin/bash
-echo "$*" >>"$SYSTEMCTL_LOG"
-for failing_unit in ${SYSTEMCTL_FAIL_UNITS:-}; do
-  if [[ $* == *"$failing_unit"* ]]; then
-    echo "Failed to enable unit: Unit $failing_unit does not exist." >&2
-    exit 1
-  fi
-done
-exit 0
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+case "$2" in
+  daemon-reload) exit "${RELOAD_STATUS:-0}" ;;
+  enable)
+    if [[ $4 == "${FAIL_UNIT:-}" ]]; then
+      echo "Synthetic enable failure: $4" >&2
+      exit 42
+    fi
+    ;;
+  show)
+    # ${LOAD_STATE-loaded}, not :-, so an explicitly empty state stays empty
+    # and the empty-query case is not silently a duplicate of the transient one.
+    printf '%s\n' "${LOAD_STATE-loaded}"
+    exit "${SHOW_STATUS:-0}"
+    ;;
+  *) exit 99 ;;
+esac
 SH
-chmod +x "$mock_bin/systemctl"
+chmod +x "$TMPDIR/bin/systemctl"
 
-log="$TMPDIR/calls"
+run_case() {
+  local name="$1" expected="$2" failed="$3" state="$4" show="$5" reload="$6"
+  local status=0
+  : >"$TMPDIR/calls"
+  SYSTEMCTL_LOG="$TMPDIR/calls" FAIL_UNIT="$failed" LOAD_STATE="$state" \
+    SHOW_STATUS="$show" RELOAD_STATUS="$reload" PATH="$TMPDIR/bin:$PATH" \
+    bash "$script" >"$TMPDIR/out" 2>"$TMPDIR/err" || status=$?
+  if [[ $expected == "success" ]]; then
+    (( status == 0 )) || fail "$name" "$(cat "$TMPDIR/err")"
+  else
+    (( status != 0 )) || fail "$name must fail"
+  fi
+  if (( reload == 0 )); then
+    (( $(grep -c -- '^--user enable --now ' "$TMPDIR/calls") == 7 )) ||
+      fail "$name must attempt all seven units"
+    grep -Fxq -- '--user enable --now omarchy-brightness-keyboard-auto.service' "$TMPDIR/calls" ||
+      fail "$name must reach the final unit"
+  else
+    if grep -q -- 'enable --now' "$TMPDIR/calls"; then
+      fail "reload failure must stop before enables"
+    fi
+  fi
+  if [[ -n $failed ]] && (( reload == 0 )); then
+    grep -Fq "$failed" "$TMPDIR/err" || fail "$name must identify the failure"
+  fi
+  pass "$name"
+}
 
-# Happy path: reload once, then one enable call per unit.
-: >"$log"
-SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" bash "$script" ||
-  fail "enable-user-units exits 0 when every unit enables"
-grep -Fqx -- '--user daemon-reload' "$log" || fail "the script reloads the user manager first"
-(( $(grep -c -- '--user enable --now' "$log") >= 7 )) ||
-  fail "the script enables each shipped unit with its own systemctl call" "$(cat "$log")"
-while read -r enable_call; do
-  unit_count=$(grep -oE '[A-Za-z0-9@_-]+\.service' <<<"$enable_call" | wc -l)
-  (( unit_count == 1 )) ||
-    fail "each enable call names exactly one unit" "$enable_call"
-done < <(grep -- '--user enable --now' "$log")
-pass "enable-user-units enables units one at a time after a daemon reload"
-
-# One missing unit must not block the others or fail the first-run step:
-# a non-zero exit here is what kept first-run replaying at every login on
-# 4.0.2 when omarchy-brightness-keyboard-auto.service was never packaged.
-: >"$log"
-stderr_file="$TMPDIR/stderr"
-SYSTEMCTL_LOG="$log" SYSTEMCTL_FAIL_UNITS=omarchy-brightness-keyboard-auto.service \
-  PATH="$mock_bin:$PATH" bash "$script" 2>"$stderr_file" ||
-  fail "one missing unit does not fail the first-run step" "$(cat "$stderr_file")"
-grep -Fq 'could not enable omarchy-brightness-keyboard-auto.service' "$stderr_file" ||
-  fail "the failing unit is reported by name" "$(cat "$stderr_file")"
-grep -Fq 'bt-agent.service' "$log" || fail "units before the failing one are still enabled"
-grep -Fq 'omarchy-crash-watch.service' "$log" ||
-  fail "units after the failing one are still enabled" "$(cat "$log")"
-pass "a missing unit is reported per unit and never wedges first-run"
-
-# A dead user manager is a different failure: nothing can be enabled at all,
-# so the step must fail and let first-run retry at the next login.
-: >"$log"
-if SYSTEMCTL_LOG="$log" SYSTEMCTL_FAIL_UNITS="daemon-reload" \
-  PATH="$mock_bin:$PATH" bash "$script" 2>/dev/null; then
-  fail "a failed daemon-reload still fails the step"
-fi
-pass "a dead user manager still fails the step so first-run retries"
+run_case happy success '' loaded 0 0
+run_case known-missing success omarchy-brightness-keyboard-auto.service not-found 0 0
+run_case brightness-transient failure omarchy-brightness-keyboard-auto.service loaded 0 0
+run_case brightness-masked failure omarchy-brightness-keyboard-auto.service masked 0 0
+run_case brightness-bad-setting failure omarchy-brightness-keyboard-auto.service bad-setting 0 0
+run_case brightness-query-failed failure omarchy-brightness-keyboard-auto.service not-found 1 0
+run_case brightness-query-empty failure omarchy-brightness-keyboard-auto.service '' 0 0
+run_case sleep-transient failure omarchy-sleep-lock.service loaded 0 0
+run_case notify-transient failure omarchy-migrate-notify.service loaded 0 0
+run_case unrelated-missing failure omarchy-sleep-lock.service not-found 0 0
+run_case reload-failed failure '' loaded 0 1

--- a/test/shell.d/first-run-test.sh
+++ b/test/shell.d/first-run-test.sh
@@ -85,3 +85,48 @@ grep -F 'Failed: finalize user (exit code: 42)' \
   "$retry_tmp/home/.local/state/omarchy/first-run.log" >/dev/null ||
   fail "first-run records a finalization failure"
 pass "failed user finalization keeps first-run retryable"
+
+# The same contract has to hold for the real enable-user-units leaf: a unit
+# that is installed but fails to enable must keep first-run pending, while the
+# historical missing brightness unit alone may still complete. The systemctl
+# stub represents a loaded service failing to start, not a missing file.
+printf '#!/bin/bash\nexit 0\n' >"$retry_bin/omarchy-provision-user"
+cp "$ROOT/install/user/first-run/enable-user-units.sh" "$retry_root/install/user/first-run/enable-user-units.sh"
+cat >"$retry_bin/systemctl" <<'SH'
+#!/bin/bash
+case "$2" in
+  enable)
+    if [[ $4 == "${FAIL_UNIT:-}" ]]; then
+      exit 42
+    fi
+    ;;
+  show) printf '%s\n' "${LOAD_STATE:-loaded}" ;;
+esac
+SH
+chmod +x "$retry_bin/systemctl"
+
+run_unit_first_run() {
+  HOME="$retry_tmp/home" PATH="$retry_bin:$PATH" OMARCHY_PATH="$retry_root" \
+    OMARCHY_TEST_FIRST_RUN_MARKER="$retry_marker" \
+    OMARCHY_TEST_FINALIZE_CALLED="$retry_finalize" \
+    bash "$ROOT/bin/omarchy-provision-first-run" >"$retry_tmp/output"
+}
+
+first_run_log="$retry_tmp/home/.local/state/omarchy/first-run.log"
+for unit in omarchy-sleep-lock.service omarchy-migrate-notify.service; do
+  rm -f "$retry_marker"
+  # The log is appended across runs, so an earlier iteration's failure line
+  # would satisfy this run's assertion.
+  : >"$first_run_log"
+  FAIL_UNIT="$unit" LOAD_STATE=loaded run_unit_first_run
+  [[ ! -e $retry_marker ]] || fail "$unit failure must not mark first-run complete"
+  grep -Fq 'Failed: enable user systemd units' "$first_run_log" ||
+    fail "enable failure is logged"
+  FAIL_UNIT='' run_unit_first_run
+  [[ -e $retry_marker ]] || fail "successful retry must mark first-run complete"
+done
+
+rm -f "$retry_marker"
+FAIL_UNIT=omarchy-brightness-keyboard-auto.service LOAD_STATE=not-found run_unit_first_run
+[[ -e $retry_marker ]] || fail "known missing brightness alone may complete first-run"
+pass "real unit failures preserve the first-run retry contract"

--- a/test/shell.d/first-run-units-migration-test.sh
+++ b/test/shell.d/first-run-units-migration-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+migration="$ROOT/migrations/1788782695.sh"
+
+[[ -f $migration ]] || fail "the unpackaged-units repair migration ships"
+[[ ! -x $migration ]] || fail "migration files are 0644, not executable"
+head -1 "$migration" | grep -q '^echo ' || fail "the migration starts with an echo description"
+pass "the unpackaged-units repair migration ships in migration format"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+fake_home="$TMPDIR/home"
+wants_dir="$fake_home/.config/systemd/user/graphical-session.target.wants"
+mkdir -p "$wants_dir"
+
+# The 1788139121 fallback wrote this link before the unit was packaged; on a
+# wedged machine it dangles. A link to a unit that ships must survive.
+ln -s "$TMPDIR/nowhere/omarchy-brightness-keyboard-auto.service" \
+  "$wants_dir/omarchy-brightness-keyboard-auto.service"
+touch "$TMPDIR/omarchy-sleep-lock.service"
+ln -s "$TMPDIR/omarchy-sleep-lock.service" "$wants_dir/omarchy-sleep-lock.service"
+
+mock_bin="$TMPDIR/bin"
+mkdir -p "$mock_bin"
+cat >"$mock_bin/systemctl" <<'SH'
+#!/bin/bash
+echo "$*" >>"$SYSTEMCTL_LOG"
+[[ ${SYSTEMCTL_NO_USER_MANAGER:-0} == 1 ]] && exit 1
+exit 0
+SH
+chmod +x "$mock_bin/systemctl"
+log="$TMPDIR/calls"
+
+: >"$log"
+HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null ||
+  fail "the migration completes against a wedged home"
+[[ ! -e "$wants_dir/omarchy-brightness-keyboard-auto.service" &&
+   ! -L "$wants_dir/omarchy-brightness-keyboard-auto.service" ]] ||
+  fail "the dangling wants symlink is removed"
+[[ -L "$wants_dir/omarchy-sleep-lock.service" ]] || fail "valid wants symlinks are kept"
+grep -Fq 'omarchy-brightness-keyboard-auto.service' "$log" ||
+  fail "the migration re-runs the first-run unit enable" "$(cat "$log")"
+grep -Fq -- '--user enable --now' "$log" ||
+  fail "units are enabled through enable-user-units.sh" "$(cat "$log")"
+pass "the migration drops dangling wants symlinks and re-enables the shipped units"
+
+: >"$log"
+HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null ||
+  fail "the migration is idempotent on an already-repaired home"
+[[ -L "$wants_dir/omarchy-sleep-lock.service" ]] ||
+  fail "a second run leaves valid symlinks alone"
+pass "the migration is idempotent"
+
+# No user manager (TTY/SSH update): the repair cannot happen, so the
+# migration must stay pending instead of marking itself complete.
+: >"$log"
+if HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" \
+  SYSTEMCTL_NO_USER_MANAGER=1 PATH="$mock_bin:$PATH" \
+  bash -euo pipefail "$migration" >/dev/null 2>&1; then
+  fail "the migration exits non-zero without a live user manager"
+fi
+pass "the migration stays pending without a live user manager"

--- a/test/shell.d/first-run-units-migration-test.sh
+++ b/test/shell.d/first-run-units-migration-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
 
+require_command python3
+
 migration="$ROOT/migrations/1788782695.sh"
 
 [[ -f $migration ]] || fail "the unpackaged-units repair migration ships"
@@ -11,16 +13,41 @@ migration="$ROOT/migrations/1788782695.sh"
 head -1 "$migration" | grep -q '^echo ' || fail "the migration starts with an echo description"
 pass "the unpackaged-units repair migration ships in migration format"
 
+# The production literals: migration 1788139121 wrote exactly this link name
+# pointing at exactly this absolute target, and only that pair may be removed.
+grep -Fq 'graphical-session.target.wants/omarchy-brightness-keyboard-auto.service' "$migration" ||
+  fail "the migration names the exact historical link path"
+grep -Fq '/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service' "$migration" ||
+  fail "the migration names the exact historical link target"
+pass "the migration names the exact legacy link and target"
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 fake_home="$TMPDIR/home"
 wants_dir="$fake_home/.config/systemd/user/graphical-session.target.wants"
 mkdir -p "$wants_dir"
 
+# Whether this host installed the real unit must not decide the outcome, so
+# behavior runs against a sandboxed copy whose historical target is redirected
+# to a guaranteed-missing path. The production literal itself is asserted above
+# and by the single-occurrence check below.
+legacy_target=/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service
+fixture_target="$TMPDIR/missing/omarchy-brightness-keyboard-auto.service"
+fixture_migration="$TMPDIR/repair.sh"
+# Single exact replacement: no dependence on whether the host installed the unit.
+python3 - "$migration" "$fixture_migration" "$legacy_target" "$fixture_target" <<'PY'
+import pathlib, sys
+source, destination, old, new = sys.argv[1:]
+text = pathlib.Path(source).read_text()
+assert text.count(old) == 1, "migration must name the exact historical target once"
+pathlib.Path(destination).write_text(text.replace(old, new))
+PY
+
 # The 1788139121 fallback wrote this link before the unit was packaged; on a
-# wedged machine it dangles. A link to a unit that ships must survive.
-ln -s "$TMPDIR/nowhere/omarchy-brightness-keyboard-auto.service" \
-  "$wants_dir/omarchy-brightness-keyboard-auto.service"
+# wedged machine it dangles. Everything else in the directory must survive.
+ln -s "$fixture_target" "$wants_dir/omarchy-brightness-keyboard-auto.service"
+ln -s "$TMPDIR/missing/custom.service" "$wants_dir/custom.service"
+printf 'keep\n' >"$wants_dir/personal.service"
 touch "$TMPDIR/omarchy-sleep-lock.service"
 ln -s "$TMPDIR/omarchy-sleep-lock.service" "$wants_dir/omarchy-sleep-lock.service"
 
@@ -30,31 +57,61 @@ cat >"$mock_bin/systemctl" <<'SH'
 #!/bin/bash
 echo "$*" >>"$SYSTEMCTL_LOG"
 [[ ${SYSTEMCTL_NO_USER_MANAGER:-0} == 1 ]] && exit 1
+if [[ $2 == "enable" && $4 == "omarchy-sleep-lock.service" && ${SYSTEMCTL_FAIL_SLEEP:-0} == "1" ]]; then
+  exit 42
+fi
 exit 0
 SH
 chmod +x "$mock_bin/systemctl"
 log="$TMPDIR/calls"
 
+run_repair() {
+  HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" \
+    bash -euo pipefail "$fixture_migration" >/dev/null
+}
+
 : >"$log"
-HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" \
-  bash -euo pipefail "$migration" >/dev/null ||
-  fail "the migration completes against a wedged home"
+run_repair || fail "the migration completes against a wedged home"
 [[ ! -e "$wants_dir/omarchy-brightness-keyboard-auto.service" &&
    ! -L "$wants_dir/omarchy-brightness-keyboard-auto.service" ]] ||
-  fail "the dangling wants symlink is removed"
+  fail "the dangling legacy wants symlink is removed"
 [[ -L "$wants_dir/omarchy-sleep-lock.service" ]] || fail "valid wants symlinks are kept"
 grep -Fq 'omarchy-brightness-keyboard-auto.service' "$log" ||
   fail "the migration re-runs the first-run unit enable" "$(cat "$log")"
 grep -Fq -- '--user enable --now' "$log" ||
   fail "units are enabled through enable-user-units.sh" "$(cat "$log")"
-pass "the migration drops dangling wants symlinks and re-enables the shipped units"
+pass "the migration drops the legacy dangling symlink and re-enables the shipped units"
 
-: >"$log"
-HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" PATH="$mock_bin:$PATH" \
-  bash -euo pipefail "$migration" >/dev/null ||
-  fail "the migration is idempotent on an already-repaired home"
+[[ -L "$wants_dir/custom.service" ]] || fail "unrelated dangling link is preserved"
+[[ $(readlink "$wants_dir/custom.service") == "$TMPDIR/missing/custom.service" ]] ||
+  fail "custom target is unchanged"
+[[ $(<"$wants_dir/personal.service") == "keep" ]] || fail "regular file is preserved"
+brightness_link="$wants_dir/omarchy-brightness-keyboard-auto.service"
+ln -s "$TMPDIR/missing/user-choice.service" "$brightness_link"
+run_repair || fail "custom same-name link does not fail cleanup"
+[[ $(readlink "$brightness_link") == "$TMPDIR/missing/user-choice.service" ]] ||
+  fail "same-name custom dangling link is preserved"
+rm "$brightness_link"
+mkdir -p "$(dirname "$fixture_target")"
+touch "$fixture_target"
+ln -s "$fixture_target" "$brightness_link"
+run_repair || fail "valid legacy target is harmless"
+[[ -L $brightness_link && -e $brightness_link ]] || fail "valid legacy link is preserved"
+rm "$brightness_link"
+printf 'user unit\n' >"$brightness_link"
+run_repair || fail "same-name regular file is harmless"
+[[ -f $brightness_link && ! -L $brightness_link ]] || fail "same-name regular file survives"
+rm "$brightness_link"
+mkdir "$brightness_link"
+run_repair || fail "same-name directory is harmless"
+[[ -d $brightness_link && ! -L $brightness_link ]] || fail "same-name directory survives"
+rmdir "$brightness_link"
+rm "$fixture_target"
+ln -s "$fixture_target" "$brightness_link"
+pass "the migration preserves everything but the exact legacy dangling link"
+
 [[ -L "$wants_dir/omarchy-sleep-lock.service" ]] ||
-  fail "a second run leaves valid symlinks alone"
+  fail "repeat runs leave valid symlinks alone"
 pass "the migration is idempotent"
 
 # No user manager (TTY/SSH update): the repair cannot happen, so the
@@ -62,7 +119,17 @@ pass "the migration is idempotent"
 : >"$log"
 if HOME="$fake_home" OMARCHY_PATH="$ROOT" SYSTEMCTL_LOG="$log" \
   SYSTEMCTL_NO_USER_MANAGER=1 PATH="$mock_bin:$PATH" \
-  bash -euo pipefail "$migration" >/dev/null 2>&1; then
+  bash -euo pipefail "$fixture_migration" >/dev/null 2>&1; then
   fail "the migration exits non-zero without a live user manager"
 fi
+[[ -L $brightness_link ]] || fail "manager failure must precede cleanup"
 pass "the migration stays pending without a live user manager"
+
+# A required unit that fails to enable must propagate out of the migration so
+# the runner leaves it pending and the repair is retried.
+if SYSTEMCTL_FAIL_SLEEP=1 run_repair; then
+  fail "required enable failure must leave migration pending"
+fi
+run_repair || fail "retry succeeds after the transient failure clears"
+run_repair || fail "completed cleanup remains idempotent"
+pass "a failed required enable keeps the migration pending until it succeeds"

--- a/test/shell.d/install-mac-test.sh
+++ b/test/shell.d/install-mac-test.sh
@@ -173,3 +173,54 @@ for failing_stage in none system repositories; do
     fail "system setup refreshes restored repositories before user setup ($failing_stage)" "$setup_output (status $setup_status)"
 done
 pass "system setup refreshes restored repositories before user setup and stops on failure"
+
+# 4.0.2 shipped omarchy-brightness-keyboard-auto.service and
+# omarchy-speaker-tuning.service as /usr/share/omarchy documentation while the
+# PKGBUILD's hand-maintained list never installed them to
+# /usr/lib/systemd/user/, wedging first-run into replaying every login. The
+# build patches in a glob install so the next new unit cannot repeat this.
+unit_dir=$(mktemp -d)
+mkdir -p "$unit_dir/default/systemd/user"
+cp "$ROOT"/default/systemd/user/*.service "$unit_dir/default/systemd/user/"
+cat >"$unit_dir/PKGBUILD" <<'EOF'
+package() {
+  cp -r . "$pkgdir/usr/share/omarchy"
+  install -Dm644 default/systemd/user/bt-agent.service              "$pkgdir/usr/lib/systemd/user/bt-agent.service"
+  install -Dm644 default/systemd/user/omarchy-sleep-lock.service    "$pkgdir/usr/lib/systemd/user/omarchy-sleep-lock.service"
+}
+EOF
+if ! (
+  source "$build_script"
+  install_all_user_units "$unit_dir/PKGBUILD"
+); then
+  rm -rf "$unit_dir"
+  fail "install_all_user_units patches a PKGBUILD that installs bt-agent.service"
+fi
+unit_loop=$(grep -F 'for omarchy_user_unit in default/systemd/user/*.service' "$unit_dir/PKGBUILD" || true)
+[[ -n $unit_loop ]] || { rm -rf "$unit_dir"; fail "the patched PKGBUILD gained the user unit glob install"; }
+# Prove the inserted line really stages every shipped unit, including the two
+# the explicit list missed, by executing it the way package() would.
+if ! ( cd "$unit_dir" && pkgdir="$unit_dir/pkg" eval "$unit_loop" ); then
+  rm -rf "$unit_dir"
+  fail "the inserted glob install runs cleanly inside package()"
+fi
+for unit_source in "$ROOT"/default/systemd/user/*.service; do
+  unit_name=${unit_source##*/}
+  if [[ ! -f "$unit_dir/pkg/usr/lib/systemd/user/$unit_name" ]]; then
+    rm -rf "$unit_dir"
+    fail "the glob install stages every shipped user unit" "missing: $unit_name"
+  fi
+done
+rm -rf "$unit_dir"
+# A PKGBUILD upstream restructured must fail the build loudly, not silently
+# ship a package with no user units.
+anchor_dir=$(mktemp -d)
+printf 'package() {\n  :\n}\n' >"$anchor_dir/PKGBUILD"
+if ( source "$build_script"; install_all_user_units "$anchor_dir/PKGBUILD" >/dev/null 2>&1 ); then
+  rm -rf "$anchor_dir"
+  fail "install_all_user_units refuses a PKGBUILD without the expected unit install anchor"
+fi
+rm -rf "$anchor_dir"
+grep -A4 'package == "omarchy-settings"' "$build_script" | grep -q install_all_user_units ||
+  fail "the package build installs every user unit when building omarchy-settings"
+pass "the package build installs every default/systemd/user unit into /usr/lib/systemd/user"

--- a/test/shell.d/user-units-packaging-test.sh
+++ b/test/shell.d/user-units-packaging-test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# 4.0.2 shipped user units in /usr/share/omarchy that were never installed to
+# /usr/lib/systemd/user/, so enabling them failed and first-run replayed at
+# every login. Two invariants stop a repeat: every omarchy unit that first-run
+# or a migration enables must exist as shipped source, and the package build
+# must install every shipped source unit.
+
+units_dir="$ROOT/default/systemd/user"
+enable_script="$ROOT/install/user/first-run/enable-user-units.sh"
+
+# omarchy-update-user-notify.service ships only as a PKGBUILD alias symlink
+# for pre-1785095882 users; config-test.sh guards that alias.
+alias_units='omarchy-update-user-notify.service'
+
+referenced=$(
+  {
+    cat "$enable_script"
+    grep -h 'systemctl --user enable' "$ROOT"/migrations/*.sh || true
+  } | grep -hoE '[A-Za-z0-9@_-]+\.service' | sort -u
+)
+
+checked=0
+while read -r unit; do
+  [[ -n $unit ]] || continue
+  case $unit in
+    omarchy-*.service | bt-agent.service) ;;
+    *) continue ;;
+  esac
+  [[ " $alias_units " == *" $unit "* ]] && continue
+  [[ -f "$units_dir/$unit" ]] ||
+    fail "every enabled omarchy user unit ships as source" "referenced but not in default/systemd/user: $unit"
+  checked=$((checked + 1))
+done <<<"$referenced"
+(( checked >= 7 )) ||
+  fail "the reference scan sees the first-run unit list" "found only $checked units"
+pass "every omarchy user unit enabled by first-run or a migration ships in default/systemd/user"
+
+# Shipped source only reaches /usr/lib/systemd/user/ through the build's glob
+# install; a hand-maintained list is exactly what rotted in 4.0.2.
+grep -qF 'for omarchy_user_unit in default/systemd/user/*.service' "$ROOT/build-packages.sh" ||
+  fail "the package build installs every default/systemd/user unit, not a hand-maintained list"
+grep -A4 'package == "omarchy-settings"' "$ROOT/build-packages.sh" | grep -q install_all_user_units ||
+  fail "the glob install is applied when building omarchy-settings"
+pass "the package build glob-installs every shipped user unit"
+
+# The two units 4.0.2 dropped stay pinned by name so a rename or deletion of
+# either source file is a conscious decision, not silent coverage loss.
+for unit in omarchy-brightness-keyboard-auto.service omarchy-speaker-tuning.service; do
+  [[ -f "$units_dir/$unit" ]] ||
+    fail "the units 4.0.2 failed to package still ship as source" "missing: $unit"
+done
+pass "the units 4.0.2 failed to package still ship as source"


### PR DESCRIPTION
Fixes #366.

## Problem

`omarchy-brightness-keyboard-auto.service` and `omarchy-speaker-tuning.service` ship as source under `/usr/share/omarchy` but never land in `/usr/lib/systemd/user/`, because the omarchy-settings PKGBUILD installs user units from a hand-maintained list. `install/user/first-run/enable-user-units.sh` enabled every unit in a single `systemctl --user enable --now` call under `set -euo pipefail`, so the one missing unit failed the whole step, `first-run-user` was never marked done, and the entire first-run notification stack replayed at every login.

## Changes

- **`build-packages.sh`**: new `install_all_user_units()` patches the omarchy-settings PKGBUILD at build time (same non-forking rewrite mechanism as `strip_limine_dependencies` / `keep_apple_silicon_mkinitcpio_drop_ins`) with a glob loop that installs every `default/systemd/user/*.service`. It fails loudly if upstream restructures the install anchor.
- **`install/user/first-run/enable-user-units.sh`**: enables units one at a time, warns per failing unit, and no longer fails the first-run step. A failed `daemon-reload` still fails, so a dead user manager retries next login.
- **`migrations/1788782695.sh`**: repairs wedged machines — removes the dangling `graphical-session.target.wants` symlink migration `1788139121` left behind and re-runs the enable. Idempotent; stays pending without a live user manager.
- **Tests**: `enable-user-units-test.sh`, `first-run-units-migration-test.sh`, `user-units-packaging-test.sh` (regression: every referenced omarchy user unit must ship, and the build must glob-install them), plus new assertions in `install-mac-test.sh` and a pinned migration lookup in `brightness-keyboard-auto-test.sh`.

## Verification

- `./test/all` — only pre-existing failures remain (`config-test.sh` / `unowned-system-paths-test.sh` need an omarchy-pkgs checkout; `runtime-smoke-test.sh` fails identically on `quattro` at 291a6989)
- `bin/omarchy commands --check` — passed (458 commands)
- `bash -n` / `ast.parse` over `bin/omarchy-*` — clean
- Negative check: hiding `default/systemd/user/omarchy-brightness-keyboard-auto.service` makes `user-units-packaging-test.sh` fail, proving it would have caught the 4.0.2 bug

Plan: `plans/first-run-loop-missing-units-fix.md`