### PR TITLE
Harden Apple Silicon first login and snapshot setup

### DIFF
--- a/bin/omarchy-cmd-electron-gl-args
+++ b/bin/omarchy-cmd-electron-gl-args
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# omarchy:summary=Print Chromium/Electron flags for software GL when no render GPU is present
+# omarchy:hidden=true
+
+if omarchy-hw-render-gpu; then
+  exit 0
+fi
+
+printf '%s\n' --ozone-platform=wayland --disable-gpu

--- a/bin/omarchy-cmd-electron-gl-wrap
+++ b/bin/omarchy-cmd-electron-gl-wrap
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# omarchy:summary=Install a PATH wrapper that adds software GL flags when no render GPU is present
+# omarchy:args=<command-name> <real-binary>
+# omarchy:examples=omarchy-cmd-electron-gl-wrap 1password /opt/1Password/1password | omarchy-cmd-electron-gl-wrap chromium /usr/bin/chromium
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+if (($# != 2)); then
+  echo "Usage: omarchy-cmd-electron-gl-wrap <command-name> <real-binary>" >&2
+  exit 2
+fi
+
+name=$1
+real=$2
+bind_dir=${OMARCHY_ELECTRON_GL_BIND_DIR:-/usr/local/bin}
+dest=$bind_dir/$name
+
+if [[ ! -x $real ]]; then
+  echo "omarchy-cmd-electron-gl-wrap: not executable: $real" >&2
+  exit 1
+fi
+
+if [[ $dest -ef $real ]]; then
+  echo "omarchy-cmd-electron-gl-wrap: refusing to wrap a binary over itself: $dest" >&2
+  exit 1
+fi
+
+as_root() {
+  if ((EUID == 0)) || [[ -d $bind_dir && -w $bind_dir ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+quoted_real=$(printf '%q' "$real")
+wrapper=$(cat <<EOF
+#!/bin/bash
+# omarchy-electron-gl-wrapper
+real=$quoted_real
+extra=()
+if omarchy-cmd-present omarchy-cmd-electron-gl-args; then
+  while IFS= read -r flag; do
+    [[ -n \$flag ]] && extra+=("\$flag")
+  done < <(omarchy-cmd-electron-gl-args)
+fi
+exec "\$real" "\${extra[@]}" "\$@"
+EOF
+)
+
+if [[ -f $dest ]] && grep -q '^# omarchy-electron-gl-wrapper$' "$dest" &&
+  grep -Fq "real=$quoted_real" "$dest"; then
+  as_root chmod 755 "$dest"
+  exit 0
+fi
+
+as_root mkdir -p "$bind_dir"
+as_root tee "$dest" >/dev/null <<<"$wrapper"
+as_root chmod 755 "$dest"

--- a/bin/omarchy-cmd-electron-gl-wrap
+++ b/bin/omarchy-cmd-electron-gl-wrap
@@ -53,7 +53,11 @@ EOF
 
 if [[ -f $dest ]] && grep -q '^# omarchy-electron-gl-wrapper$' "$dest" &&
   grep -Fq "real=$quoted_real" "$dest"; then
-  as_root chmod 755 "$dest"
+  # System setup may already have installed this wrapper before user finalization.
+  # Leave correct permissions alone so first login needs no root access.
+  if [[ $(stat -c %a "$dest") != "755" ]]; then
+    as_root chmod 755 "$dest"
+  fi
   exit 0
 fi
 

--- a/bin/omarchy-cmd-electron-gl-wrap
+++ b/bin/omarchy-cmd-electron-gl-wrap
@@ -15,6 +15,11 @@ fi
 
 name=$1
 real=$2
+if [[ -z $name || $name == */* || $name == "." || $name == ".." ]]; then
+  echo "omarchy-cmd-electron-gl-wrap: command name must be a basename: $name" >&2
+  exit 2
+fi
+
 bind_dir=${OMARCHY_ELECTRON_GL_BIND_DIR:-/usr/local/bin}
 dest=$bind_dir/$name
 
@@ -23,9 +28,26 @@ if [[ ! -x $real ]]; then
   exit 1
 fi
 
-if [[ $dest -ef $real ]]; then
+# The old 1Password installer created this specific symlink. Replace the link,
+# not the executable it names; no other symlink is an Omarchy-owned launcher.
+# Honor the binary/install-directory overrides used by Apple setup and installer.
+legacy_real=${OMARCHY_1PASSWORD_BIN:-${OMARCHY_1PASSWORD_INSTALL_DIR:-/opt/1Password}/1password}
+legacy_link=false
+if [[ $name == "1password" && $real == "$legacy_real" && -L $dest ]] &&
+  [[ $(readlink -- "$dest") == "$real" ]]; then
+  legacy_link=true
+fi
+
+if [[ $dest == "$real" ]] || { [[ $dest -ef $real ]] && ! $legacy_link; }; then
   echo "omarchy-cmd-electron-gl-wrap: refusing to wrap a binary over itself: $dest" >&2
   exit 1
+fi
+
+if [[ -e $dest || -L $dest ]] && ! $legacy_link; then
+  if [[ -L $dest || ! -f $dest ]] || ! grep -q '^# omarchy-electron-gl-wrapper$' "$dest"; then
+    echo "omarchy-cmd-electron-gl-wrap: refusing to replace an unmanaged launcher: $dest" >&2
+    exit 1
+  fi
 fi
 
 as_root() {
@@ -51,8 +73,7 @@ exec "\$real" "\${extra[@]}" "\$@"
 EOF
 )
 
-if [[ -f $dest ]] && grep -q '^# omarchy-electron-gl-wrapper$' "$dest" &&
-  grep -Fq "real=$quoted_real" "$dest"; then
+if [[ ! -L $dest && -f $dest && $(<"$dest") == "$wrapper" ]]; then
   # System setup may already have installed this wrapper before user finalization.
   # Leave correct permissions alone so first login needs no root access.
   if [[ $(stat -c %a "$dest") != "755" ]]; then
@@ -61,6 +82,19 @@ if [[ -f $dest ]] && grep -q '^# omarchy-electron-gl-wrapper$' "$dest" &&
   exit 0
 fi
 
-as_root mkdir -p "$bind_dir"
-as_root tee "$dest" >/dev/null <<<"$wrapper"
-as_root chmod 755 "$dest"
+staged=""
+cleanup() {
+  if [[ -n $staged ]]; then
+    as_root rm -f -- "$staged"
+  fi
+}
+trap cleanup EXIT
+
+# Stage beside the launcher so rename replaces a legacy symlink atomically and
+# a failed write or chmod leaves the old launcher (and real binary) untouched.
+as_root mkdir -p -- "$bind_dir"
+staged=$(as_root mktemp -- "$bind_dir/.omarchy-electron-gl.XXXXXX")
+as_root tee -- "$staged" >/dev/null <<<"$wrapper"
+as_root chmod 755 -- "$staged"
+as_root mv -fT -- "$staged" "$dest"
+staged=""

--- a/bin/omarchy-hw-render-gpu
+++ b/bin/omarchy-hw-render-gpu
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether a DRM render GPU is present
+# omarchy:hidden=true
+
+dri=${OMARCHY_DRI_PATH:-/dev/dri}
+
+shopt -s nullglob
+for node in "$dri"/renderD*; do
+  if [[ -e $node ]]; then
+    exit 0
+  fi
+done
+
+exit 1

--- a/bin/omarchy-install-1password
+++ b/bin/omarchy-install-1password
@@ -7,8 +7,8 @@ set -euo pipefail
 
 VERSION="8.12.0"
 ARCH_SUFFIX="arm64"
-INSTALL_DIR="/opt/1Password"
-BIN_LINK="/usr/local/bin/1password"
+INSTALL_DIR="${OMARCHY_1PASSWORD_INSTALL_DIR:-/opt/1Password}"
+BIN_LINK="${OMARCHY_1PASSWORD_BIN_LINK:-/usr/local/bin/1password}"
 
 # Only run on aarch64
 if [ "$(uname -m)" != "aarch64" ]; then
@@ -16,10 +16,27 @@ if [ "$(uname -m)" != "aarch64" ]; then
     exit 0
 fi
 
+link_1password() {
+  if [[ -x ${INSTALL_DIR}/1password ]]; then
+    if omarchy-cmd-present omarchy-cmd-electron-gl-wrap; then
+      OMARCHY_ELECTRON_GL_BIND_DIR=$(dirname "$BIN_LINK") \
+        omarchy-cmd-electron-gl-wrap "$(basename "$BIN_LINK")" "${INSTALL_DIR}/1password"
+    else
+      sudo ln -sf "${INSTALL_DIR}/1password" "${BIN_LINK}"
+    fi
+  fi
+
+  desktop=/usr/share/applications/1password.desktop
+  if [[ -f $desktop ]] && ! grep -q "^Exec=${BIN_LINK}" "$desktop"; then
+    sudo sed -i "s|^Exec=.*|Exec=${BIN_LINK} %U|" "$desktop"
+  fi
+}
+
 # Check if already installed
 if [ -f "${BIN_LINK}" ] && [ -d "${INSTALL_DIR}" ]; then
     INSTALLED_VERSION=$("${BIN_LINK}" --version 2>/dev/null || echo "unknown")
     echo "1Password already installed (version: ${INSTALLED_VERSION})"
+    link_1password
     exit 0
 fi
 
@@ -48,14 +65,14 @@ sudo mv "1password-${VERSION}.${ARCH_SUFFIX}" "${INSTALL_DIR}"
 sudo chown -R root:root "${INSTALL_DIR}"
 sudo chmod 4755 "${INSTALL_DIR}/chrome-sandbox"
 
-# Create symlink
-echo "Creating symlink..."
-sudo ln -sf "${INSTALL_DIR}/1password" "${BIN_LINK}"
-
 # Install desktop file
 echo "Installing desktop file..."
 sudo mkdir -p /usr/share/applications
 sudo cp "${INSTALL_DIR}/resources/1password.desktop" /usr/share/applications/
+
+# PATH wrapper (not a raw symlink) so missing AGX gets --disable-gpu
+echo "Creating launcher..."
+link_1password
 
 # Install icons
 echo "Installing icons..."

--- a/bin/omarchy-system-boot-to-esp
+++ b/bin/omarchy-system-boot-to-esp
@@ -83,6 +83,29 @@ recovery_note() {
   warn "and restore the /boot/efi line in /etc/fstab before rebooting."
 }
 
+# ISO installs keep their boot files in a private UUID directory on the ESP.
+# Moving /boot and reinstalling GRUB would overwrite the shared boot owner.
+# The UUID check also protects installs made before the marker was introduced.
+refuse_iso_boot_layout() {
+  local system_root=${1:-/} root_uuid esp_directory
+
+  if [[ -e $system_root/etc/omarchy-mac-iso-shared-esp ]]; then
+    fail "this ISO installation shares its EFI partition; boot-to-esp would overwrite its bootloader. Keep the existing UUID-private boot layout."
+  fi
+
+  for esp_directory in "$system_root/boot/efi" "$system_root/boot"; do
+    if [[ -d $esp_directory/EFI/omarchy || -d $esp_directory/grub/omarchy-roots ]]; then
+      root_uuid=$(findmnt -nro UUID --target "$system_root") ||
+        fail "cannot identify the root filesystem UUID to check the ISO boot layout; refusing to move /boot"
+      [[ $root_uuid =~ ^[0-9A-Fa-f-]+$ ]] ||
+        fail "cannot identify the root filesystem UUID to check the ISO boot layout; refusing to move /boot"
+      if [[ -d $esp_directory/EFI/omarchy/$root_uuid || -f $esp_directory/grub/omarchy-roots/$root_uuid.cfg ]]; then
+        fail "this ISO installation uses UUID-private EFI boot files; boot-to-esp would overwrite its bootloader. Keep the existing boot layout."
+      fi
+    fi
+  done
+}
+
 main() {
   local esp esp_fstype boot_kb avail_kb typed assume_yes=0
 
@@ -93,6 +116,8 @@ main() {
     esac
     shift
   done
+
+  refuse_iso_boot_layout
 
   (( EUID == 0 )) || fail "run as root"
   [[ $(uname -m) == "aarch64" ]] || fail "this tool is for Apple Silicon (aarch64) installs"

--- a/install/config/snapper.sh
+++ b/install/config/snapper.sh
@@ -5,17 +5,24 @@ template="${OMARCHY_SNAPPER_TEMPLATE:-${OMARCHY_PATH:-/usr/share/omarchy}/defaul
 echo "Configuring Omarchy Snapper snapshot retention"
 
 snapper_configured=1
+snapper_root_filesystem=$(stat -f -c %T /)
 
 if [[ ! -f $SNAPPER_CONFIG_PATH ]]; then
   mkdir -p "$(dirname "$SNAPPER_CONFIG_PATH")"
 
   if [[ ${OMARCHY_SNAPPER_CONFIGURE_TEST:-0} == "1" ]]; then
     : >"$SNAPPER_CONFIG_PATH"
-  elif ! snapper --no-dbus -c root create-config / >/dev/null 2>&1 &&
-    ! snapper -c root create-config / >/dev/null 2>&1; then
-    # Snapper needs a snapshot-capable root; Asahi installs land on ext4.
-    # Left unhandled this aborts system setup before services are enabled.
+  elif [[ $snapper_root_filesystem != "btrfs" ]]; then
+    # Omarchy's root snapshot policy uses btrfs; older installs may use ext4.
     snapper_configured=0
+  elif snapper --no-dbus -c root create-config /; then
+    :
+  else
+    snapper_status=$?
+    echo "Error: Snapper root configuration failed on btrfs (exit $snapper_status). See the command output above." >&2
+    # This leaf is sourced by the logged setup runner under errexit. Preserve
+    # the backend error instead of claiming a missing/broken Snapper is ext4.
+    (exit "$snapper_status")
   fi
 fi
 
@@ -34,5 +41,5 @@ if (( snapper_configured )); then
     systemctl enable --now limine-snapper-sync.service >/dev/null 2>&1 || true
   fi
 else
-  echo "Skipping Snapper setup: / is not a snapshot-capable filesystem."
+  echo "Skipping Snapper setup: / is $snapper_root_filesystem, not btrfs."
 fi

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -11,6 +11,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/apple/share-picker.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/apple/obsidian.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/apple/electron-gl.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"
 run_logged "$OMARCHY_INSTALL/user/mise.sh"

--- a/install/user/first-run/timezone.sh
+++ b/install/user/first-run/timezone.sh
@@ -24,5 +24,5 @@ timezone_needs_setting() {
 if timezone_needs_setting; then
   omarchy-notification-send -u critical -g 󰥔 "Set your timezone" \
     "This machine is on $(current_timezone). Click to choose yours." \
-    --exec "omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced"
+    --exec omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced
 fi

--- a/install/user/hardware/apple/electron-gl.sh
+++ b/install/user/hardware/apple/electron-gl.sh
@@ -1,0 +1,43 @@
+# Chromium/Electron need a DRM render node. Apple Silicon without AGX only
+# exposes the DCP scanout device, so GPU process init fails and the app can
+# stay running with no window. Wrappers live on /usr/local/bin (ahead of
+# /usr/bin in PATH) so upstream omarchy-launch-* scripts stay untouched.
+# Flags are chosen at launch: when a render node appears, the same wrapper
+# stops passing --disable-gpu.
+compatible=${OMARCHY_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}
+
+if [[ -f $compatible ]] && grep -qi apple "$compatible"; then
+  if omarchy-cmd-present omarchy-cmd-electron-gl-wrap; then
+    chromium_bin=${OMARCHY_CHROMIUM_BIN:-/usr/bin/chromium}
+    if [[ -x $chromium_bin ]]; then
+      omarchy-cmd-electron-gl-wrap chromium "$chromium_bin"
+      chromium_desktop=${OMARCHY_CHROMIUM_DESKTOP:-/usr/share/applications/chromium.desktop}
+      user_chromium=$HOME/.local/share/applications/chromium.desktop
+      if [[ -f $chromium_desktop ]]; then
+        mkdir -p "$HOME/.local/share/applications"
+        sed 's|^Exec=/usr/bin/chromium|Exec=/usr/local/bin/chromium|' \
+          "$chromium_desktop" >"$user_chromium"
+      fi
+    fi
+
+    onepassword_bin=${OMARCHY_1PASSWORD_BIN:-/opt/1Password/1password}
+    if [[ -x $onepassword_bin ]]; then
+      omarchy-cmd-electron-gl-wrap 1password "$onepassword_bin"
+    fi
+  fi
+
+  looknfeel=$HOME/.config/hypr/looknfeel.lua
+  if ! omarchy-hw-render-gpu && [[ -f $looknfeel ]] &&
+    ! grep -q 'no_hardware_cursors' "$looknfeel"; then
+    cat >>"$looknfeel" <<'EOF'
+
+-- Apple Silicon without AGX has no DRM render node. Hardware cursors never
+-- appear; draw the pointer in software like the nouveau workaround.
+hl.config({
+  cursor = {
+    no_hardware_cursors = true,
+  },
+})
+EOF
+  fi
+fi

--- a/migrations/1788639443.sh
+++ b/migrations/1788639443.sh
@@ -1,0 +1,21 @@
+echo "Wrap Electron apps when Apple Silicon has no render GPU"
+
+
+# New installs get this from install/user/hardware/apple/electron-gl.sh.
+# Existing 1Password installs used a raw /usr/local/bin symlink, so Hyprland
+# launched Electron without --disable-gpu and the window never mapped.
+
+[[ -f /proc/device-tree/compatible ]] || exit 0
+grep -qi apple /proc/device-tree/compatible || exit 0
+
+if omarchy-cmd-present omarchy-cmd-electron-gl-wrap; then
+  if [[ -x /usr/bin/chromium ]]; then
+    omarchy-cmd-electron-gl-wrap chromium /usr/bin/chromium
+  fi
+  if [[ -x /opt/1Password/1password ]]; then
+    omarchy-cmd-electron-gl-wrap 1password /opt/1Password/1password
+  fi
+fi
+
+# shellcheck disable=SC1091
+source "$OMARCHY_PATH/install/user/hardware/apple/electron-gl.sh"

--- a/test/shell.d/boot-to-esp-test.sh
+++ b/test/shell.d/boot-to-esp-test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+fixture_root_uuid=01234567-89ab-cdef-0123-456789abcdef
+
+run_guard() (
+  fixture=$1
+  source "$ROOT/bin/omarchy-system-boot-to-esp"
+  findmnt() {
+    [[ $* == "-nro UUID --target $work/$fixture" ]] || return 99
+    printf '%s\n' "${fixture_uuid-$fixture_root_uuid}"
+    return "${fixture_status:-0}"
+  }
+  refuse_iso_boot_layout "$work/$fixture"
+)
+
+expect_refusal() {
+  local fixture=$1 expected=$2 output
+  if output=$(run_guard "$fixture" 2>&1); then
+    fail "$fixture refuses migration"
+  fi
+  [[ $output == *"$expected"* ]] || fail "$fixture explains the refusal" "$output"
+  pass "$fixture refuses migration"
+}
+
+mkdir -p "$work/marker/etc"
+touch "$work/marker/etc/omarchy-mac-iso-shared-esp"
+expect_refusal marker 'shares its EFI partition'
+
+mkdir -p "$work/private/boot/efi/EFI/omarchy/$fixture_root_uuid"
+expect_refusal private 'UUID-private EFI boot files'
+
+mkdir -p "$work/boot-mounted/boot/EFI/omarchy/$fixture_root_uuid"
+expect_refusal boot-mounted 'UUID-private EFI boot files'
+
+mkdir -p "$work/config-only/boot/efi/grub/omarchy-roots"
+touch "$work/config-only/boot/efi/grub/omarchy-roots/$fixture_root_uuid.cfg"
+expect_refusal config-only 'UUID-private EFI boot files'
+
+mkdir -p "$work/other-root/boot/efi/EFI/omarchy/11111111-2222-3333-4444-555555555555"
+run_guard other-root || fail 'another root UUID does not block an ordinary installation'
+pass 'another root UUID does not block an ordinary installation'
+
+mkdir -p "$work/normal/boot/efi/EFI/BOOT" "$work/normal/boot/grub"
+run_guard normal || fail 'ordinary Asahi layout remains supported'
+pass 'ordinary Asahi layout remains supported'
+
+fixture_status=1 expect_refusal private 'cannot identify the root filesystem UUID'
+fixture_uuid='' expect_refusal private 'cannot identify the root filesystem UUID'
+fixture_uuid='../bad' expect_refusal private 'cannot identify the root filesystem UUID'
+
+# Run the real main entrypoint with only its filesystem fixture redirected.
+# Protected layouts must stop before either the no-op mount check or writes.
+for fixture in marker private; do
+  before=$(find "$work/$fixture" -printf '%P %y\n' | sort)
+  if output=$( {
+    source "$ROOT/bin/omarchy-system-boot-to-esp"
+    eval "$(declare -f refuse_iso_boot_layout | sed '1s/refuse_iso_boot_layout/fixture_guard/')"
+    refuse_iso_boot_layout() { fixture_guard "$work/$fixture"; }
+    findmnt() { printf '%s\n' "$fixture_root_uuid"; }
+    uname() { printf 'aarch64\n'; }
+    for command in mount umount mkdir rmdir cp mv grub-install grub-mkconfig mkinitcpio; do
+      eval "$command() { printf '%s\\n' '$command' >> '$work/mutations'; return 99; }"
+    done
+    main --yes
+  } 2>&1); then
+    fail "$fixture main must refuse even with --yes"
+  fi
+  [[ $output == *'this ISO installation'* ]] || fail "$fixture main reaches the protection guard" "$output"
+  [[ ! -e $work/mutations ]] || fail "$fixture main performs no mutation"
+  after=$(find "$work/$fixture" -printf '%P %y\n' | sort)
+  [[ $before == "$after" ]] || fail "$fixture boot files remain unchanged"
+  pass "$fixture main refuses before writes, even with --yes"
+done

--- a/test/shell.d/electron-gl-test.sh
+++ b/test/shell.d/electron-gl-test.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+dri="$test_tmp/dri"
+mkdir -p "$dri"
+
+if OMARCHY_DRI_PATH="$dri" "$ROOT/bin/omarchy-hw-render-gpu"; then
+  fail "render GPU is absent when dri is empty"
+fi
+pass "render GPU is absent when dri is empty"
+
+touch "$dri/card1"
+if OMARCHY_DRI_PATH="$dri" "$ROOT/bin/omarchy-hw-render-gpu"; then
+  fail "a scanout node is not a render GPU"
+fi
+pass "a scanout node is not a render GPU"
+
+touch "$dri/renderD128"
+OMARCHY_DRI_PATH="$dri" "$ROOT/bin/omarchy-hw-render-gpu" ||
+  fail "renderD128 is a render GPU"
+pass "renderD128 is a render GPU"
+
+args=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" \
+  "$ROOT/bin/omarchy-cmd-electron-gl-args")
+[[ -z $args ]] || fail "no Electron GL flags when a render GPU exists" "$args"
+pass "no Electron GL flags when a render GPU exists"
+
+rm -f "$dri/renderD128"
+args=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" \
+  "$ROOT/bin/omarchy-cmd-electron-gl-args")
+[[ $args == $'--ozone-platform=wayland\n--disable-gpu' ]] ||
+  fail "software GL flags when no render GPU" "$args"
+pass "software GL flags when no render GPU"
+
+real="$test_tmp/real-bin"
+bind="$test_tmp/bind"
+mkdir -p "$bind"
+printf '#!/bin/bash\nprintf "real %%s\\n" "$*"\n' >"$real"
+chmod +x "$real"
+
+PATH="$ROOT/bin:$PATH" \
+  OMARCHY_ELECTRON_GL_BIND_DIR="$bind" \
+  "$ROOT/bin/omarchy-cmd-electron-gl-wrap" demo "$real"
+
+grep -q '^# omarchy-electron-gl-wrapper$' "$bind/demo" ||
+  fail "wrapper is marked as an Omarchy Electron GL wrapper"
+pass "wrapper is marked as an Omarchy Electron GL wrapper"
+
+out=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" "$bind/demo" hello)
+[[ $out == "real --ozone-platform=wayland --disable-gpu hello" ]] ||
+  fail "wrapper injects software GL flags" "$out"
+pass "wrapper injects software GL flags"
+
+mkdir -p "$dri"
+touch "$dri/renderD128"
+out=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" "$bind/demo" hello)
+[[ $out == "real hello" ]] ||
+  fail "wrapper is a no-op when a render GPU exists" "$out"
+pass "wrapper is a no-op when a render GPU exists"
+
+grep -Fq 'apple/electron-gl.sh' "$ROOT/install/user/all.sh" ||
+  fail "Apple Electron GL setup runs during user hardware setup"
+pass "Apple Electron GL setup runs during user hardware setup"
+
+grep -Fq 'omarchy-cmd-electron-gl-wrap' "$ROOT/bin/omarchy-install-1password" ||
+  fail "1Password aarch64 installer installs the Electron GL wrapper"
+pass "1Password aarch64 installer installs the Electron GL wrapper"
+
+grep -Fq 'exec setsid uwsm-app -- 1password' "$ROOT/bin/omarchy-launch-1password" ||
+  fail "1Password launcher is still the upstream uwsm-app invocation"
+pass "1Password launcher is still the upstream uwsm-app invocation"
+
+compatible="$test_tmp/compatible"
+printf 'apple,j613\0apple,t8122\n' >"$compatible"
+looknfeel="$test_tmp/home/.config/hypr/looknfeel.lua"
+mkdir -p "$(dirname "$looknfeel")"
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+rm -f "$dri/renderD128"
+
+run_apple_gl() {
+  HOME="$test_tmp/home" \
+    PATH="$ROOT/bin:$PATH" \
+    OMARCHY_DEVICE_TREE_COMPATIBLE="$compatible" \
+    OMARCHY_DRI_PATH="$dri" \
+    OMARCHY_CHROMIUM_BIN=/dev/null/missing \
+    OMARCHY_1PASSWORD_BIN=/dev/null/missing \
+    bash -euo pipefail -c 'source "$ROOT/install/user/hardware/apple/electron-gl.sh"'
+}
+
+run_apple_gl
+
+grep -F 'no_hardware_cursors = true' "$looknfeel" >/dev/null ||
+  fail "Apple Electron GL setup enables software cursors without a render GPU"
+pass "Apple Electron GL setup enables software cursors without a render GPU"
+
+run_apple_gl
+(( $(grep -c 'no_hardware_cursors = true' "$looknfeel") == 1 )) ||
+  fail "Apple software cursor setup is idempotent"
+pass "Apple software cursor setup is idempotent"
+
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+touch "$dri/renderD128"
+run_apple_gl
+if grep -q 'no_hardware_cursors' "$looknfeel"; then
+  fail "Apple software cursors are skipped when a render GPU exists"
+fi
+pass "Apple software cursors are skipped when a render GPU exists"
+
+printf 'intel,something\n' >"$compatible"
+printf '%s\n' '-- User look and feel' >"$looknfeel"
+rm -f "$dri/renderD128"
+run_apple_gl
+if grep -q 'no_hardware_cursors' "$looknfeel"; then
+  fail "Apple Electron GL setup ignores non-Apple machines"
+fi
+pass "Apple Electron GL setup ignores non-Apple machines"
+
+migration=$(grep -rl 'Wrap Electron apps when Apple Silicon has no render GPU' "$ROOT/migrations" | head -n 1 || true)
+[[ -n $migration ]] || fail "existing installs get the Electron GL wrapper migration"
+pass "existing installs get the Electron GL wrapper migration"

--- a/test/shell.d/electron-gl-test.sh
+++ b/test/shell.d/electron-gl-test.sh
@@ -52,6 +52,45 @@ grep -q '^# omarchy-electron-gl-wrapper$' "$bind/demo" ||
   fail "wrapper is marked as an Omarchy Electron GL wrapper"
 pass "wrapper is marked as an Omarchy Electron GL wrapper"
 
+# A repeated user finalization must not chmod an already-correct system wrapper.
+stubs="$test_tmp/stubs"
+mkdir -p "$stubs"
+cat >"$stubs/chmod" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$*" >>"$OMARCHY_TEST_PERMISSION_CALLS"
+[[ ${OMARCHY_TEST_ALLOW_CHMOD:-0} == "1" ]] || exit 91
+exec /usr/bin/chmod "$@"
+STUB
+cat >"$stubs/sudo" <<'STUB'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$OMARCHY_TEST_PERMISSION_CALLS"
+exit 92
+STUB
+chmod +x "$stubs/chmod" "$stubs/sudo"
+permission_calls="$test_tmp/permission-calls"
+run_wrap() {
+  PATH="$stubs:$ROOT/bin:$PATH" \
+    OMARCHY_TEST_PERMISSION_CALLS="$permission_calls" \
+    OMARCHY_ELECTRON_GL_BIND_DIR="$bind" \
+    "$ROOT/bin/omarchy-cmd-electron-gl-wrap" demo "$real"
+}
+
+chmod 555 "$bind"
+run_wrap || fail "correct wrapper needs no privilege or permission changes on repeat"
+chmod 755 "$bind"
+[[ ! -e $permission_calls ]] ||
+  fail "correct wrapper must not invoke chmod or sudo"
+pass "correct wrapper needs no privilege or permission changes on repeat"
+
+for mode in 644 775; do
+  chmod "$mode" "$bind/demo"
+  OMARCHY_TEST_ALLOW_CHMOD=1 run_wrap ||
+    fail "wrapper repairs incorrect mode $mode"
+  [[ $(stat -c %a "$bind/demo") == "755" ]] ||
+    fail "wrapper restores mode 755 from $mode"
+done
+pass "wrapper repairs missing execute and excessive write permissions"
+
 out=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" "$bind/demo" hello)
 [[ $out == "real --ozone-platform=wayland --disable-gpu hello" ]] ||
   fail "wrapper injects software GL flags" "$out"

--- a/test/shell.d/electron-gl-test.sh
+++ b/test/shell.d/electron-gl-test.sh
@@ -103,6 +103,148 @@ out=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" "$bind/demo" hello)
   fail "wrapper is a no-op when a render GPU exists" "$out"
 pass "wrapper is a no-op when a render GPU exists"
 
+wrap() {
+  PATH="$ROOT/bin:$PATH" OMARCHY_ELECTRON_GL_BIND_DIR="$bind" \
+    "$ROOT/bin/omarchy-cmd-electron-gl-wrap" "$@"
+}
+
+# Recognize only the legacy 1Password link, using the setup leaf's binary override
+# so this exercises the unmodified helper without writing to /opt.
+legacy_real="$test_tmp/1Password/1password"
+mkdir -p "$(dirname "$legacy_real")"
+cp "$real" "$legacy_real"
+chmod 751 "$legacy_real"
+legacy_hash=$(sha256sum "$legacy_real")
+ln -s "$legacy_real" "$bind/1password"
+if wrap 1password "$legacy_real" 2>"$test_tmp/error"; then
+  fail "default legacy exception must refuse an arbitrary 1Password target"
+fi
+OMARCHY_1PASSWORD_BIN="$legacy_real" wrap 1password "$legacy_real" ||
+  fail "known legacy 1Password symlink can be migrated"
+[[ ! -L $bind/1password && -f $bind/1password ]] ||
+  fail "legacy symlink is replaced with a regular wrapper"
+[[ $(sha256sum "$legacy_real") == "$legacy_hash" && $(stat -c %a "$legacy_real") == "751" ]] ||
+  fail "legacy migration preserves the real binary bytes and permissions"
+out=$(PATH="$ROOT/bin:$PATH" OMARCHY_DRI_PATH="$dri" "$bind/1password" "vault with spaces")
+[[ $out == "real vault with spaces" ]] || fail "migrated 1Password wrapper executes the real binary" "$out"
+legacy_wrapper_hash=$(sha256sum "$bind/1password")
+OMARCHY_1PASSWORD_BIN="$legacy_real" wrap 1password "$legacy_real"
+[[ $(sha256sum "$bind/1password") == "$legacy_wrapper_hash" ]] ||
+  fail "legacy migration is idempotent"
+pass "legacy 1Password migration preserves and executes the real binary, and is idempotent"
+
+rm "$bind/1password"
+ln -s "$legacy_real" "$bind/1password"
+OMARCHY_1PASSWORD_INSTALL_DIR="$(dirname "$legacy_real")" wrap 1password "$legacy_real" ||
+  fail "legacy migration honors the installer's configured directory"
+[[ ! -L $bind/1password && $(sha256sum "$legacy_real") == "$legacy_hash" ]] ||
+  fail "configured install-directory migration replaces only the link"
+pass "legacy migration honors the installer's configured directory"
+
+other_real="$test_tmp/other-real"
+cp "$real" "$other_real"
+wrap demo "$other_real"
+grep -Fxq "real=$other_real" "$bind/demo" || fail "marked wrapper can be updated to another binary"
+pass "marked regular wrappers can be updated"
+
+printf '#!/bin/bash\nprintf custom\\n\n' >"$bind/chromium"
+chmod 750 "$bind/chromium"
+custom_hash=$(sha256sum "$bind/chromium")
+if wrap chromium "$real" 2>"$test_tmp/error"; then
+  fail "custom Chromium launcher must be refused"
+fi
+[[ $(sha256sum "$bind/chromium") == "$custom_hash" && $(stat -c %a "$bind/chromium") == "750" ]] ||
+  fail "custom Chromium launcher bytes and permissions are preserved"
+grep -Fq 'unmanaged launcher' "$test_tmp/error" || fail "custom launcher refusal explains the conflict"
+pass "custom Chromium launcher is refused and preserved"
+
+for link_target in "$other_real" "$test_tmp/missing" "$bind/demo"; do
+  ln -s "$link_target" "$bind/unknown"
+  if wrap unknown "$real" 2>"$test_tmp/error"; then
+    fail "unknown symlink must be refused" "$link_target"
+  fi
+  [[ -L $bind/unknown && $(readlink "$bind/unknown") == "$link_target" ]] ||
+    fail "unknown symlink is preserved" "$link_target"
+  rm "$bind/unknown"
+done
+pass "unknown, dangling, and marked-wrapper symlinks are refused and preserved"
+
+ln -s "$other_real" "$bind/1password-other"
+if OMARCHY_1PASSWORD_BIN="$other_real" wrap 1password-other "$other_real" 2>"$test_tmp/error"; then
+  fail "legacy exception requires the 1password command name"
+fi
+rm "$bind/1password"
+ln -s "$other_real" "$bind/1password"
+if OMARCHY_1PASSWORD_BIN="$legacy_real" wrap 1password "$other_real" 2>"$test_tmp/error"; then
+  fail "legacy exception requires the configured 1Password binary"
+fi
+[[ $(readlink "$bind/1password") == "$other_real" ]] || fail "unknown 1Password link is preserved"
+pass "legacy exception requires both the known command name and binary"
+
+cp "$real" "$bind/self"
+self_hash=$(sha256sum "$bind/self")
+if wrap self "$bind/self" 2>"$test_tmp/error"; then
+  fail "literal self-wrap must be refused"
+fi
+[[ $(sha256sum "$bind/self") == "$self_hash" ]] || fail "self-wrap preserves real executable"
+ln "$real" "$bind/hardlink"
+if wrap hardlink "$real" 2>"$test_tmp/error"; then
+  fail "hardlink self-wrap must be refused"
+fi
+[[ $bind/hardlink -ef $real ]] || fail "hardlink self-wrap preserves hardlink"
+# The legacy exception applies to symlinks, never hardlinked 1Password binaries.
+rm "$bind/1password"
+ln "$legacy_real" "$bind/1password"
+if OMARCHY_1PASSWORD_BIN="$legacy_real" wrap 1password "$legacy_real" 2>"$test_tmp/error"; then
+  fail "hardlinked 1Password binary must be refused"
+fi
+[[ $(sha256sum "$legacy_real") == "$legacy_hash" && $(stat -c %a "$legacy_real") == "751" ]] ||
+  fail "hardlink self-wrap preserves binary bytes and mode"
+pass "literal self-wrap and hardlinked binaries are refused"
+
+for invalid_name in "" . .. ../escape nested/launcher; do
+  if wrap "$invalid_name" "$real" 2>"$test_tmp/error"; then
+    fail "command name must be a basename" "$invalid_name"
+  fi
+done
+[[ ! -e $test_tmp/escape && ! -e $bind/nested ]] || fail "invalid names do not escape the launcher directory"
+pass "invalid and traversing command names are refused"
+
+# Fail after staging has begun: neither an old wrapper nor the legacy symlink
+# may be replaced until both the staged write and permissions have succeeded.
+failure_stubs="$test_tmp/failure-stubs"
+mkdir -p "$failure_stubs"
+for command in mktemp tee chmod mv; do
+  printf '#!/bin/bash\nexit 93\n' >"$failure_stubs/$command"
+  chmod +x "$failure_stubs/$command"
+  for launcher in demo 1password; do
+    rm -f "$bind/1password"
+    ln -s "$legacy_real" "$bind/1password"
+    old_wrapper_hash=$(sha256sum "$bind/demo")
+    if [[ $launcher == "1password" ]]; then
+      target_real=$legacy_real
+    else
+      target_real=$real
+    fi
+    if PATH="$failure_stubs:$ROOT/bin:$PATH" \
+      OMARCHY_ELECTRON_GL_BIND_DIR="$bind" OMARCHY_1PASSWORD_BIN="$legacy_real" \
+      "$ROOT/bin/omarchy-cmd-electron-gl-wrap" "$launcher" "$target_real" \
+      2>"$test_tmp/error"; then
+      fail "failed staging $command must be reported for $launcher"
+    fi
+    [[ $(sha256sum "$bind/demo") == "$old_wrapper_hash" ]] || fail "failed $command preserves old wrapper"
+    [[ -L $bind/1password && $(readlink "$bind/1password") == "$legacy_real" ]] ||
+      fail "failed $command preserves legacy symlink"
+    [[ $(sha256sum "$legacy_real") == "$legacy_hash" && $(stat -c %a "$legacy_real") == "751" ]] ||
+      fail "failed $command preserves real binary bytes and mode"
+    if compgen -G "$bind/.omarchy-electron-gl.*" >/dev/null; then
+      fail "failed $command cleans up staged files"
+    fi
+  done
+  rm "$failure_stubs/$command"
+done
+pass "mktemp, write, chmod, and rename failures preserve launchers and clean up staged files"
+
 grep -Fq 'apple/electron-gl.sh' "$ROOT/install/user/all.sh" ||
   fail "Apple Electron GL setup runs during user hardware setup"
 pass "Apple Electron GL setup runs during user hardware setup"

--- a/test/shell.d/settings-package-units-test.sh
+++ b/test/shell.d/settings-package-units-test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+require_command git
+require_command tar
+pkgs_root="${OMARCHY_PKGS_PATH:-$ROOT/../omarchy-pkgs}"
+[[ ! -d $pkgs_root/pkgbuilds ]] || pkgs_root="$pkgs_root/pkgbuilds"
+[[ -f $pkgs_root/omarchy-settings/PKGBUILD ]] || fail 'omarchy-pkgs checkout required; set OMARCHY_PKGS_PATH'
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/source/omarchy"
+
+# Use tracked checkout contents, not an installed desktop or the developer's
+# unrelated files. Execute the real package() function, including its native
+# systemd destination, rather than accepting a matching string in a comment.
+git -C "$ROOT" ls-files -z config etc default applications logo.txt logo.svg icon.txt icon.png \
+  bin/omarchy-upload-log bin/omarchy-debug bin/omarchy-debug-idle \
+  | tar -C "$ROOT" --null -T - -cf - \
+  | tar -C "$test_tmp/source/omarchy" -xf -
+
+for flavor in omarchy omarchy-dev; do
+  (
+    CARCH=aarch64 OMARCHY_SRC="$test_tmp/source/omarchy"
+    source "$pkgs_root/$flavor/PKGBUILD"
+    printf '%s\n' "${depends[@]}" "${depends_aarch64[@]}" >"$test_tmp/$flavor.dependencies"
+  )
+  grep -Fx snapper "$test_tmp/$flavor.dependencies" >/dev/null || fail "$flavor requires Snapper on aarch64"
+  ! grep -q '^limine' "$test_tmp/$flavor.dependencies" || fail "$flavor does not require Limine on aarch64"
+done
+pass 'stable and development desktop packages require Snapper, but not Limine, on aarch64'
+
+# The default stable build uses its pinned Git commit, not OMARCHY_SRC. A
+# newer checkout can require units absent from that release; exercise both
+# layouts so a current-source packaging fix cannot break the stable pin.
+pinned_commit=$(
+  unset OMARCHY_SRC
+  CARCH=aarch64
+  source "$pkgs_root/omarchy-settings/PKGBUILD"
+  printf '%s\n' "$_commit"
+)
+if git -C "$ROOT" cat-file -e "$pinned_commit^{commit}" 2>/dev/null; then
+  mkdir -p "$test_tmp/pinned-source/omarchy"
+  git -C "$ROOT" archive "$pinned_commit" \
+    | tar -C "$test_tmp/pinned-source/omarchy" -xf -
+  for flavor in omarchy-settings omarchy-settings-dev; do
+    for architecture in aarch64 x86_64; do
+      (
+        unset OMARCHY_SRC
+        CARCH=$architecture
+        srcdir="$test_tmp/pinned-source" pkgdir="$test_tmp/pinned-$flavor-$architecture"
+        mkdir -p "$pkgdir"
+        source "$pkgs_root/$flavor/PKGBUILD"
+        magick() { :; }
+        package >"$test_tmp/pinned-$flavor-$architecture.output" 2>&1
+        cmp "$srcdir/omarchy/default/systemd/user/bt-agent.service" "$pkgdir/usr/lib/systemd/user/bt-agent.service"
+        keyboard_unit=default/systemd/user/omarchy-brightness-keyboard-auto.service
+        if [[ -f $srcdir/omarchy/$keyboard_unit ]]; then
+          cmp "$srcdir/omarchy/$keyboard_unit" "$pkgdir/usr/lib/systemd/user/${keyboard_unit##*/}"
+        else
+          [[ ! -e $pkgdir/usr/lib/systemd/user/${keyboard_unit##*/} ]] || fail 'older source does not invent a keyboard unit'
+        fi
+      )
+      pass "$flavor/$architecture also stages the actual stable source pin $pinned_commit"
+    done
+  done
+else
+  pass "stable source pin $pinned_commit absent from local Git history; skipping pinned-source staging"
+fi
+for flavor in omarchy-settings omarchy-settings-dev; do
+  for architecture in aarch64 x86_64; do
+    (
+      CARCH=$architecture OMARCHY_SRC="$test_tmp/source/omarchy"
+      srcdir="$test_tmp/source" pkgdir="$test_tmp/$flavor-$architecture"
+      mkdir -p "$pkgdir"
+      source "$pkgs_root/$flavor/PKGBUILD"
+      # Image conversion is unrelated to unit installation; retain package()
+      # control flow and file staging without requiring ImageMagick in CI.
+      magick() { :; }
+      package >"$test_tmp/$flavor-$architecture.output" 2>&1
+
+      systemctl() {
+        [[ $* != '--user daemon-reload' ]] || return 0
+        [[ ${1:-} == '--user' && ${2:-} == 'enable' && ${3:-} == '--now' ]] || return 1
+        shift 3
+        (( $# > 0 )) || return 1
+        local unit
+        for unit in "$@"; do
+          [[ -f $pkgdir/usr/lib/systemd/user/$unit ]] || fail "$flavor/$architecture stages required unit $unit"
+          cmp "$ROOT/default/systemd/user/$unit" "$pkgdir/usr/lib/systemd/user/$unit" \
+            || fail "$flavor/$architecture installs the current $unit"
+          [[ $(stat -c %a "$pkgdir/usr/lib/systemd/user/$unit") == 644 ]] \
+            || fail "$flavor/$architecture unit permissions are 0644"
+        done
+      }
+      source "$ROOT/install/user/first-run/enable-user-units.sh"
+    )
+    pass "$flavor/$architecture stages every unit required by actual first-run setup"
+  done
+done

--- a/test/shell.d/snapper-configure-test.sh
+++ b/test/shell.d/snapper-configure-test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin"
+
+cat >"$test_tmp/bin/stat" <<'STUB'
+#!/bin/bash
+[[ $* == '-f -c %T /' ]] || exit 2
+if [[ ${TEST_FILESYSTEM:-btrfs} == error ]]; then
+  echo 'stat: cannot inspect root filesystem' >&2
+  exit 1
+fi
+printf '%s\n' "${TEST_FILESYSTEM:-btrfs}"
+STUB
+cat >"$test_tmp/bin/snapper" <<'STUB'
+#!/bin/bash
+printf 'snapper %s\n' "$*" >>"$TEST_LOG"
+[[ $* == '--no-dbus -c root create-config /' ]] || exit 99
+if (( ${TEST_SNAPPER_STATUS:-0} )); then
+  echo 'snapper: fixture backend failure' >&2
+  exit "$TEST_SNAPPER_STATUS"
+fi
+printf 'SUBVOLUME="/"\nFSTYPE="btrfs"\n' >"$OMARCHY_SNAPPER_CONFIG_PATH"
+STUB
+cat >"$test_tmp/bin/systemctl" <<'STUB'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >>"$TEST_LOG"
+[[ $* != 'cat limine-snapper-sync.service' ]]
+STUB
+chmod +x "$test_tmp/bin/"*
+
+run_configure() {
+  PATH="$test_tmp/bin:$PATH" TEST_LOG="$test_tmp/$1.calls" \
+    OMARCHY_PATH="$ROOT" \
+    OMARCHY_SNAPPER_CONFIG_PATH="$test_tmp/$1/root" \
+    OMARCHY_SNAPPER_CONF_PATH="$test_tmp/$1/conf" \
+    bash -euo pipefail "$ROOT/install/config/snapper.sh"
+}
+
+run_configure success >"$test_tmp/success.output" 2>&1
+cmp "$ROOT/default/snapper/root" "$test_tmp/success/root"
+grep -Fx 'snapper --no-dbus -c root create-config /' "$test_tmp/success.calls" >/dev/null
+grep -Fx 'systemctl enable --now snapper-cleanup.timer' "$test_tmp/success.calls" >/dev/null
+run_configure success >>"$test_tmp/success.output" 2>&1
+[[ $(grep -c '^snapper ' "$test_tmp/success.calls") == 1 ]] || fail 'existing root config is not recreated'
+pass 'fresh btrfs root uses offline Snapper setup and normalizes policy idempotently'
+
+for status in 1 127; do
+  result=0
+  TEST_SNAPPER_STATUS=$status run_configure "failure-$status" >"$test_tmp/failure.output" 2>&1 || result=$?
+  [[ $result == "$status" ]] || fail 'Snapper backend status propagates' "got $result, expected $status"
+  grep -F 'snapper: fixture backend failure' "$test_tmp/failure.output" >/dev/null
+  grep -F "Snapper root configuration failed on btrfs (exit $status)" "$test_tmp/failure.output" >/dev/null
+  ! grep -F 'Skipping' "$test_tmp/failure.output" >/dev/null || fail 'btrfs failure is not called unsupported'
+  [[ ! -e $test_tmp/failure-$status/root && ! -e $test_tmp/failure-$status/conf ]] || fail 'failed setup does not install policy'
+  ! grep -q '^systemctl ' "$test_tmp/failure-$status.calls" || fail 'failed setup does not enable timers'
+done
+pass 'missing or broken Snapper fails btrfs setup with its original diagnostic and status'
+
+TEST_FILESYSTEM=ext2/ext3 run_configure ext4 >"$test_tmp/ext4.output" 2>&1
+grep -F 'ext2/ext3, not btrfs' "$test_tmp/ext4.output" >/dev/null
+[[ ! -e $test_tmp/ext4.calls && ! -e $test_tmp/ext4/root ]] || fail 'ext4 is skipped before invoking Snapper'
+pass 'non-btrfs roots skip snapshot setup based on the actual filesystem'
+
+if TEST_FILESYSTEM=error run_configure stat-error >"$test_tmp/stat-error.output" 2>&1; then
+  fail 'filesystem inspection failure must not be treated as an unsupported root'
+fi
+grep -F 'cannot inspect root filesystem' "$test_tmp/stat-error.output" >/dev/null
+pass 'filesystem inspection errors remain fatal and visible'

--- a/test/shell.d/snapper-test.sh
+++ b/test/shell.d/snapper-test.sh
@@ -112,8 +112,8 @@ find_omarchy_pks_root() {
 # Packaging coverage lives in the sibling omarchy-pkgs checkout, which is present
 # in CI/dev but not on an installed machine. Skip (don't fail) when it's absent.
 if pkgs_root=$(find_omarchy_pks_root); then
-  settings_pkgbuild="$pkgs_root/omarchy-settings-dev/PKGBUILD"
-  omarchy_pkgbuild="$pkgs_root/omarchy-dev/PKGBUILD"
+  settings_pkgbuild="$pkgs_root/omarchy-settings/PKGBUILD"
+  omarchy_pkgbuild="$pkgs_root/omarchy/PKGBUILD"
 
   grep -F 'cp -a default/. "$pkgdir/usr/share/omarchy/default/"' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package bundles default/"
   grep -F 'install -Dm644 default/snapper/root \' "$settings_pkgbuild" >/dev/null || fail "omarchy-settings package installs Snapper template source"
@@ -167,15 +167,15 @@ else
   pass "omarchy-iso checkout absent; skipping installer coverage"
 fi
 
-# Snapper needs a snapshot-capable root and Asahi installs land on ext4, where
-# create-config fails. config/all.sh runs early, so a non-zero exit here aborts
-# system setup before services are ever enabled.
+# Older installs may have an ext4 root; detect that filesystem independently
+# of Snapper's command status, which can also mean missing/broken packages.
 unsupported_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp" "$unsupported_tmp"' EXIT
 mkdir -p "$unsupported_tmp/bin"
 
 cat >"$unsupported_tmp/bin/snapper" <<'STUB'
 #!/bin/bash
+echo 'Snapper must not run on this ext4 fixture' >&2
 exit 1
 STUB
 chmod +x "$unsupported_tmp/bin/snapper"
@@ -185,6 +185,12 @@ cat >"$unsupported_tmp/bin/systemctl" <<'STUB'
 exit 0
 STUB
 chmod +x "$unsupported_tmp/bin/systemctl"
+
+cat >"$unsupported_tmp/bin/stat" <<'STUB'
+#!/bin/bash
+echo ext2/ext3
+STUB
+chmod +x "$unsupported_tmp/bin/stat"
 
 unsupported_output=$(
   PATH="$unsupported_tmp/bin:$PATH" \

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -46,3 +46,38 @@ grep -F -- '--exec omarchy-launch-floating-terminal-with-presentation omarchy-cm
 ! grep -F -- '--exec "' "$first_run_tz" >/dev/null ||
   fail "first-run timezone toast does not quote --exec as one string"
 pass "first-run timezone toast matches notification-send --exec argv"
+
+# Exercise the actual notification parser, replacing only its D-Bus transport.
+require_command jq
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/home"
+cat >"$test_tmp/bin/timedatectl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$OMARCHY_TEST_TIMEZONE"
+STUB
+cat >"$test_tmp/bin/busctl" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$@" >"$OMARCHY_TEST_NOTIFICATION_ARGS"
+STUB
+chmod +x "$test_tmp/bin/"*
+notification_args="$test_tmp/notification-args"
+run_timezone() {
+  HOME="$test_tmp/home" PATH="$test_tmp/bin:$ROOT/bin:$PATH" \
+    OMARCHY_PATH="$ROOT" OMARCHY_TEST_TIMEZONE="$1" \
+    OMARCHY_TEST_NOTIFICATION_ARGS="$notification_args" \
+    bash -euo pipefail "$first_run_tz"
+}
+
+for zone in UTC ""; do
+  run_timezone "$zone" || fail "unset timezone notification is accepted"
+  grep -Fx '["omarchy-launch-floating-terminal-with-presentation","omarchy-cmd-tzupdate-enhanced"]' \
+    "$notification_args" >/dev/null ||
+    fail "timezone notification carries separate executable and argument"
+done
+pass "unset timezone sends an actionable notification through the real parser"
+
+rm "$notification_args"
+run_timezone Europe/London
+[[ ! -e $notification_args ]] || fail "configured timezone sends no notification"
+pass "configured timezone sends no notification"

--- a/test/shell.d/timezone-test.sh
+++ b/test/shell.d/timezone-test.sh
@@ -38,3 +38,11 @@ grep -F 'omarchy-shell -q omarchy.clock refresh' "$timezone_menu" >/dev/null ||
   fail "timezone menu no longer refreshes the retired Clock IPC target"
 
 pass "timezone menu refreshes clock after timezone changes"
+
+first_run_tz="$ROOT/install/user/first-run/timezone.sh"
+grep -F -- '--exec omarchy-launch-floating-terminal-with-presentation omarchy-cmd-tzupdate-enhanced' \
+  "$first_run_tz" >/dev/null ||
+  fail "first-run timezone toast passes --exec as separate words"
+! grep -F -- '--exec "' "$first_run_tz" >/dev/null ||
+  fail "first-run timezone toast does not quote --exec as one string"
+pass "first-run timezone toast matches notification-send --exec argv"


### PR DESCRIPTION
## Summary

This is the accumulated desktop companion branch used by the fresh M3 installer test.

- Provide software-GL Electron wrappers when Apple Silicon has no render GPU, including 1Password setup, and avoid privileged chmod when an existing wrapper already has the correct permissions.
- Refuse boot-to-ESP migration for ISO/shared/UUID-private boot layouts instead of moving files into an incompatible layout.
- Correct first-run timezone notification argument handling and add coverage.
- Detect non-btrfs roots explicitly during Snapper setup. On btrfs, retain real setup diagnostics and exit status instead of hiding missing/broken Snapper as an unsupported filesystem.
- Add focused Snapper setup regressions and actual package-staging coverage for every first-run user service.

## Verification

- Focused Snapper tests pass; all eight stable/development × ARM/x86 × current-source/actual-stable-pin package-staging cases pass with the companion package changes.
- Earlier focused wrapper, boot-layout, and timezone tests passed. Command metadata validation (461 commands), shebang-aware syntax checks, and whitespace checks passed in isolated QA.
- Full aggregate QA is not entirely green: three environment-dependent failures remained (inherited NO_COLOR, sandbox network access, and inherited Git signing). Baseline checks or isolated reruns identified these limitations; this PR does not claim a clean aggregate run.
- SWE → QA → review completed, including a second round testing the actual stable source pin.
- A full ISO/rootfs rebuild with these sources completed a fresh encrypted M3 (j613) install. First-run completed, Snapper and the factory snapshot were present, and required services were enabled with no failed units. Tester subsequently confirmed reboot, acceptable UI responsiveness, 1Password installation, and no repeated first-boot alerts.

## Dependencies and review scope

- Package recipes and this new package-staging test must land together: https://github.com/omacom/omarchy-pkgs/pull/341. The test intentionally fails against the unfixed upstream recipes. CI using the package repository's default branch needs that PR merged (or an explicit companion checkout).
- Installer companion: https://github.com/omarchy-mac/omarchy-mac-iso/pull/19.
- This branch already contains the source changes from #349 and #362, plus the wrapper-permission and timezone regression follow-ups; those portions overlap the existing PRs.
- #367 is a separate first-run repair/build-wrapper approach. This branch tests the real package recipes and preserves fatal setup errors; it does not include that PR's migration or alter it.

Hardware validation covers one M3 with `7.2.2-omarchy-wip72+`, not all Apple Silicon models.
