### PR TITLE
fix(hypr): route Apple Silicon lid close to omarchy-system-lid-close

### DIFF
--- a/default/hypr/bindings/utilities.lua
+++ b/default/hypr/bindings/utilities.lua
@@ -35,7 +35,7 @@ o.bind("switch:on:Lid Switch", nil, "omarchy-system-lid-close", { locked = true 
 o.bind("switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
 -- Mac fork: Apple Silicon names the lid switch "Apple SMC power/lid events", not
 -- the generic "Lid Switch", so quattro's binds above never fire on this hardware.
-o.bind("switch:on:Apple SMC power/lid events", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
+o.bind("switch:on:Apple SMC power/lid events", nil, "omarchy-system-lid-close", { locked = true })
 o.bind("switch:off:Apple SMC power/lid events", nil, "omarchy-hyprland-monitor-clamshell", { locked = true })
 
 o.bind("PRINT", "Screenshot", "omarchy-capture-screenshot")

--- a/test/shell.d/monitor-recovery-test.sh
+++ b/test/shell.d/monitor-recovery-test.sh
@@ -99,6 +99,8 @@ pass "internal mirror helper recovers when no active external display remains"
 
 grep -F 'switch:on:Lid Switch", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
 grep -F 'switch:off:Lid Switch", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null
+grep -F 'switch:on:Apple SMC power/lid events", nil, "omarchy-system-lid-close"' "$utilities" >/dev/null
+grep -F 'switch:off:Apple SMC power/lid events", nil, "omarchy-hyprland-monitor-clamshell"' "$utilities" >/dev/null
 pass "lid switch bindings lock on close and reconcile clamshell display state"
 
 grep -F 'omarchy-hyprland-monitor-clamshell >/dev/null 2>&1 || true' "$system_wake" >/dev/null


### PR DESCRIPTION
## Summary

• Apple Silicon MacBooks report lid switch events under `Apple SMC power/lid events`.
• When Quattro introduced `omarchy-system-lid-close` to lock the session and coordinate pre-suspend display state, the Mac-specific `switch:on` binding in `default/hypr/bindings/utilities.lua` remained wired to `omarchy-hyprland-monitor-clamshell`.
• As a result, closing the lid on an Apple Silicon MacBook bypassed `omarchy-system-lid-close` entirely, preventing the session from locking before suspend.
• Route `switch:on:Apple SMC power/lid events` to `omarchy-system-lid-close`, mirroring the generic `switch:on:Lid Switch` bind (resolving the keybinding defect reported in #335).
• Extend `test/shell.d/monitor-recovery-test.sh` to assert both the upstream and Apple SMC lid switch bindings.

Fixes part of #335

## Verification

• `test/shell.d/monitor-recovery-test.sh`: passes (asserts both generic and Apple SMC `switch:on` and `switch:off` bindings).
• Mutation check: inverting `switch:on:Apple SMC power/lid events` back to `omarchy-hyprland-monitor-clamshell` fails `monitor-recovery-test.sh`.
• `test/shell.d/lid-close-test.sh`: passes.
• `test/shell.d/hw-laptop-test.sh`: passes.
• `test/shell.d/monitor-clamshell-scale-test.sh`: passes.
• `test/cli`: all 116 tests pass.
• `git diff --check`: clean (no whitespace or formatting errors).