### PR TITLE
Fix Apple Silicon mic, screen recording, and speakersafetyd recovery

### DIFF
--- a/bin/omarchy-audio-asahi-mic-map
+++ b/bin/omarchy-audio-asahi-mic-map
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# omarchy:summary=Map the Asahi laptop mic array to a stereo Pulse source
+# omarchy:group=audio
+# omarchy:hidden=true
+
+# asahi-audio publishes the beamformed array as AUX0. Recorders and the
+# desktop+mic null-sink ask for FL/FR, so they either fail to link or write
+# left-only audio that loudnorm then ruins. Duplicate AUX0 onto a low-priority
+# stereo sink and use its monitor as the default source. Never move existing
+# source-outputs — that steals the DSP chain's capture from the raw mics.
+
+set -euo pipefail
+
+omarchy-hw-apple || exit 0
+
+SINK_NAME=omarchy_asahi_mic
+
+wait_for_source() {
+  local pattern=$1
+  local i
+  for ((i = 0; i < 40; i++)); do
+    if pactl list short sources 2>/dev/null | grep -Eq "$pattern"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_for_source 'effect_output\.j[0-9]+-mic' || exit 0
+
+dsp_source=$(pactl list short sources 2>/dev/null | awk '/effect_output\.j[0-9]+-mic\t/ { print $2; exit }')
+[[ -n $dsp_source ]] || exit 0
+
+convolver=$(pactl list short sinks 2>/dev/null | awk '/audio_effect\.j[0-9]+-convolver\t/ { print $2; exit }')
+
+if ! pactl list short sinks 2>/dev/null | grep -q $'\tomarchy_asahi_mic\t'; then
+  pactl load-module module-null-sink \
+    sink_name="$SINK_NAME" \
+    sink_properties='device.description=AsahiMicrophone node.virtual=true priority.session=1' >/dev/null
+fi
+
+for ((i = 0; i < 20; i++)); do
+  if pw-link -o 2>/dev/null | grep -qx "${dsp_source}:capture_AUX0" &&
+    pw-link -i 2>/dev/null | grep -qx "${SINK_NAME}:playback_FL"; then
+    break
+  fi
+  sleep 0.1
+done
+
+pw-link "${dsp_source}:capture_AUX0" "${SINK_NAME}:playback_FL" 2>/dev/null || true
+pw-link "${dsp_source}:capture_AUX0" "${SINK_NAME}:playback_FR" 2>/dev/null || true
+
+pactl set-source-volume "$dsp_source" 100% 2>/dev/null || true
+pactl set-sink-volume "$SINK_NAME" 100% 2>/dev/null || true
+pactl set-source-volume "${SINK_NAME}.monitor" 100% 2>/dev/null || true
+
+# A new null sink otherwise becomes the default output and mutes the speakers.
+if [[ -n $convolver ]]; then
+  pactl set-default-sink "$convolver" 2>/dev/null || true
+fi
+pactl set-default-source "${SINK_NAME}.monitor" 2>/dev/null || true

--- a/bin/omarchy-audio-asahi-mic-map
+++ b/bin/omarchy-audio-asahi-mic-map
@@ -34,6 +34,7 @@ dsp_source=$(pactl list short sources 2>/dev/null | awk '/effect_output\.j[0-9]+
 [[ -n $dsp_source ]] || exit 0
 
 convolver=$(pactl list short sinks 2>/dev/null | awk '/audio_effect\.j[0-9]+-convolver\t/ { print $2; exit }')
+previous_sink=$(pactl get-default-sink 2>/dev/null || true)
 
 if ! pactl list short sinks 2>/dev/null | grep -q $'\tomarchy_asahi_mic\t'; then
   pactl load-module module-null-sink \
@@ -56,8 +57,17 @@ pactl set-source-volume "$dsp_source" 100% 2>/dev/null || true
 pactl set-sink-volume "$SINK_NAME" 100% 2>/dev/null || true
 pactl set-source-volume "${SINK_NAME}.monitor" 100% 2>/dev/null || true
 
-# A new null sink otherwise becomes the default output and mutes the speakers.
-if [[ -n $convolver ]]; then
-  pactl set-default-sink "$convolver" 2>/dev/null || true
+# A new null sink otherwise becomes the default output. Put back whatever
+# was playing — headphones, Bluetooth, or the speaker convolver — and only
+# fall back to the convolver when the dummy sink is what is left.
+current_sink=$(pactl get-default-sink 2>/dev/null || true)
+if [[ $current_sink == "$SINK_NAME" || -z $current_sink ]]; then
+  restore=$previous_sink
+  if [[ -z $restore || $restore == "$SINK_NAME" ]]; then
+    restore=$convolver
+  fi
+  if [[ -n $restore && $restore != "$SINK_NAME" ]]; then
+    pactl set-default-sink "$restore" 2>/dev/null || true
+  fi
 fi
 pactl set-default-source "${SINK_NAME}.monitor" 2>/dev/null || true

--- a/bin/omarchy-capture-screenrecording
+++ b/bin/omarchy-capture-screenrecording
@@ -51,7 +51,7 @@ LOG_FILE=$([[ ${OMARCHY_SCREENRECORD_DEBUG:-false} == "true" ]] && echo "/tmp/om
 
 # Matches whichever recorder backend is running, so stop/toggle/active checks
 # work regardless of which one started the recording.
-RECORDER_PROCESS_RE="^(gpu-screen-recorder|wf-recorder)"
+RECORDER_PROCESS_RE="(^|/)(gpu-screen-recorder|wf-recorder)( |$)"
 # Records the PulseAudio module ids of a combined-audio null sink for cleanup.
 PA_MODULES_FILE="/tmp/omarchy-screenrecord-pa-modules"
 REC_PID=""
@@ -240,7 +240,11 @@ launch_wf_recorder() {
   # -r 60 caps the framerate: capturing a 120 Hz panel at its native rate makes
   # needlessly large files. wf-recorder's default libx264 is CPU-encoded, which
   # is the only option on Asahi (no supported hardware encoder).
-  wf-recorder "${geom_args[@]}" -r 60 "${audio_args[@]}" -f "$filename" 2>>"$LOG_FILE" &
+  #
+  # -R 48000 keeps the AAC track at 48 kHz. Asahi speaker DSP advertises 96 kHz,
+  # and wf-recorder will follow that into a 96 kHz file that this PipeWire graph
+  # (and many players) play as silence.
+  wf-recorder "${geom_args[@]}" -r 60 -R 48000 "${audio_args[@]}" -f "$filename" 2>>"$LOG_FILE" &
   REC_PID=$!
 }
 

--- a/bin/omarchy-hw-apple
+++ b/bin/omarchy-hw-apple
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# omarchy:summary=Detect whether the computer is an Apple Silicon (Asahi) machine.
+
+[[ $(uname -m) == "aarch64" ]] || exit 1
+
+compatible="${OMARCHY_APPLE_COMPATIBLE:-/proc/device-tree/compatible}"
+[[ -f $compatible ]] || exit 1
+grep -Faiq 'apple,' "$compatible"

--- a/default/hypr/apps/webcam-overlay.lua
+++ b/default/hypr/apps/webcam-overlay.lua
@@ -20,6 +20,8 @@ o.window({ class = "^WebcamOverlay-(small|medium|large)$", title = "^WebcamOverl
   float = true,
   pin = true,
   no_initial_focus = true,
+  no_focus = true,
+  no_follow_mouse = true,
   no_dim = true,
   opacity = "1 1",
 })

--- a/default/hypr/autostart.lua
+++ b/default/hypr/autostart.lua
@@ -11,4 +11,6 @@ hl.on("hyprland.start", function()
 
   -- Run post-boot hooks after startup config has loaded.
   hl.exec_cmd("sleep 2 && omarchy-hook post-boot")
+  -- Asahi's beamformed mic is AUX0; remap it to a stereo source for recorders.
+  hl.exec_cmd("omarchy-audio-asahi-mic-map")
 end)

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -57,7 +57,7 @@
   "trigger.reminder": {"icon":"󰢌","label":"Reminder","aliases":["reminder"]},
   "trigger.capture": {"icon":"","label":"Capture","aliases":["capture","screenshot","screenrecord","screen-record","screenrecording"]},
   "trigger.capture.screenshot": {"icon":"","label":"Screenshot","action":"omarchy-capture-screenshot"},
-  "trigger.capture.screenrecord.stop": {"icon":"","label":"Stop Screenrecording","when":"pgrep -f '^gpu-screen-recorder'","action":"omarchy-capture-screenrecording --stop-recording"},
+  "trigger.capture.screenrecord.stop": {"icon":"","label":"Stop Screenrecording","when":"pgrep -f '(^|/)(gpu-screen-recorder|wf-recorder)( |$)'","action":"omarchy-capture-screenrecording --stop-recording"},
   "trigger.capture.screenrecord": {"icon":"","label":"Screenrecord"},
   "trigger.capture.text": {"icon":"󰴑","label":"Text","action":"omarchy-capture-text"},
   "trigger.capture.qr": {"icon":"󰐲","label":"QR Code","action":"omarchy-capture-qr"},

--- a/default/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf
+++ b/default/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf
@@ -1,0 +1,14 @@
+# The 3.5mm headset mic stays in the source list with nothing plugged in.
+# Apps often pick it over the built-in array because it advertises a MONO map.
+monitor.alsa.rules = [
+  {
+    matches = [
+      { node.name = "alsa_input.platform-sound.HiFi__Headset__source" }
+    ]
+    actions = {
+      update-props = {
+        priority.session = 1
+      }
+    }
+  }
+]

--- a/install/hardware/apple/audio.sh
+++ b/install/hardware/apple/audio.sh
@@ -49,8 +49,14 @@ if omarchy-pkg-missing rtkit pipewire-pulse pipewire-alsa asahi-audio speakersaf
 fi
 
 # The daemon has to be running before the speakers will produce anything.
-sudo systemctl enable --now speakersafetyd >/dev/null 2>&1 ||
-  echo "Warning: speakersafetyd did not start; the speakers stay muted."
+# A start-limit-hit after a bad IV-sense sample leaves the kernel holding
+# the drivers at -100 dB, so clear that and try once more.
+sudo systemctl enable --now speakersafetyd >/dev/null 2>&1 || true
+if ! sudo systemctl is-active --quiet speakersafetyd 2>/dev/null; then
+  sudo systemctl reset-failed speakersafetyd >/dev/null 2>&1 || true
+  sudo systemctl start speakersafetyd >/dev/null 2>&1 ||
+    echo "Warning: speakersafetyd did not start; the speakers stay muted."
+fi
 
 # pipewire-pulse is socket-activated per user, so enabling it system-wide is not
 # the job; the user units are enabled at first run.

--- a/install/user/all.sh
+++ b/install/user/all.sh
@@ -11,6 +11,7 @@ run_logged "$OMARCHY_INSTALL/user/hardware/dell/xps13-text-scaling.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/fix-nouveau-cursor.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/apple/share-picker.sh"
 run_logged "$OMARCHY_INSTALL/user/hardware/apple/obsidian.sh"
+run_logged "$OMARCHY_INSTALL/user/hardware/apple/mic.sh"
 
 run_logged "$OMARCHY_INSTALL/user/default-keyring.sh"
 run_logged "$OMARCHY_INSTALL/user/mise.sh"

--- a/install/user/hardware/apple/mic.sh
+++ b/install/user/hardware/apple/mic.sh
@@ -1,0 +1,13 @@
+# Map the Asahi beamformed mic array to a stereo source and drop the unplugged
+# headset jack's session priority so apps do not pick a dead input.
+
+omarchy-hw-apple || return 0
+
+mkdir -p ~/.config/wireplumber/wireplumber.conf.d/
+src="$OMARCHY_PATH/default/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf"
+dst="$HOME/.config/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf"
+if [[ -f $src ]]; then
+  cp "$src" "$dst"
+fi
+
+omarchy-audio-asahi-mic-map >/dev/null 2>&1 || true

--- a/migrations/1788820499.sh
+++ b/migrations/1788820499.sh
@@ -1,0 +1,10 @@
+echo "Map the Asahi mic array to stereo and retry speakersafetyd"
+
+# Fresh installs run the hardware leaf and the per-user mic leaf. Reuse both
+# here so existing Apple Silicon sessions get the same mapping without a
+# reboot, and so a failed speakersafetyd start-limit is cleared.
+audio_setup="$OMARCHY_PATH/install/hardware/apple/audio.sh"
+[[ -f $audio_setup ]] && source "$audio_setup"
+
+mic_setup="$OMARCHY_PATH/install/user/hardware/apple/mic.sh"
+[[ -f $mic_setup ]] && source "$mic_setup"

--- a/shell/plugins/bar/indicators/ScreenRecording.qml
+++ b/shell/plugins/bar/indicators/ScreenRecording.qml
@@ -15,7 +15,7 @@ BarIndicator {
 
   function refresh() {
     if (!root.bar || statusProc.running) return
-    statusProc.command = ["pgrep", "--quiet", "-f", "^(gpu-screen-recorder|wf-recorder)"]
+    statusProc.command = ["pgrep", "--quiet", "-f", "(^|/)(gpu-screen-recorder|wf-recorder)( |$)"]
     statusProc.running = true
   }
 

--- a/test/shell.d/asahi-audio-install-test.sh
+++ b/test/shell.d/asahi-audio-install-test.sh
@@ -65,6 +65,10 @@ cat >"$stub_bin/systemctl" <<'SH'
 printf 'systemctl' >>"$TEST_LOG"
 printf '\t%s' "$@" >>"$TEST_LOG"
 printf '\n' >>"$TEST_LOG"
+
+if [[ $1 == "is-active" ]]; then
+  exit "${SPEAKERSAFETYD_ACTIVE:-0}"
+fi
 SH
 
 cat >"$stub_bin/omarchy-state" <<'SH'
@@ -145,3 +149,21 @@ run_audio_setup "$migration" aarch64 linux,dummy
 [[ ! -s $calls ]] ||
   fail "the Apple Silicon audio repair skips unrelated hardware" "$(cat "$calls")"
 pass "the Apple Silicon audio repair skips unrelated hardware"
+
+rm -f "$installed_marker"
+touch "$installed_marker"
+: >"$calls"
+run_audio_setup "$leaf" aarch64 apple,j413
+grep -Fq $'systemctl\tenable\t--now\tspeakersafetyd' "$calls" ||
+  fail "speakersafetyd is enabled when already running" "$(cat "$calls")"
+! grep -Fq $'systemctl\treset-failed\tspeakersafetyd' "$calls" ||
+  fail "a running speakersafetyd is not reset" "$(cat "$calls")"
+pass "a running speakersafetyd is left alone"
+
+: >"$calls"
+SPEAKERSAFETYD_ACTIVE=3 run_audio_setup "$leaf" aarch64 apple,j413
+grep -Fq $'systemctl\treset-failed\tspeakersafetyd' "$calls" ||
+  fail "a dead speakersafetyd start-limit is cleared" "$(cat "$calls")"
+grep -Fq $'systemctl\tstart\tspeakersafetyd' "$calls" ||
+  fail "speakersafetyd is started after a start-limit" "$(cat "$calls")"
+pass "speakersafetyd recovers from a start-limit-hit"

--- a/test/shell.d/asahi-mic-map-test.sh
+++ b/test/shell.d/asahi-mic-map-test.sh
@@ -39,6 +39,7 @@ stub_bin="$test_tmp/bin"
 calls="$test_tmp/calls.log"
 compatible="$test_tmp/compatible"
 sink_created="$test_tmp/sink-created"
+default_sink="$test_tmp/default-sink"
 mkdir -p "$stub_bin"
 
 cat >"$stub_bin/uname" <<'SH'
@@ -71,7 +72,14 @@ list)
   ;;
 load-module)
   touch "$SINK_CREATED"
+  printf '%s\n' "omarchy_asahi_mic" >"$DEFAULT_SINK_FILE"
   echo 42
+  ;;
+get-default-sink)
+  cat "$DEFAULT_SINK_FILE"
+  ;;
+set-default-sink)
+  printf '%s\n' "$2" >"$DEFAULT_SINK_FILE"
   ;;
 esac
 SH
@@ -118,24 +126,25 @@ run_hw aarch64 ||
   fail "omarchy-hw-apple detects Apple Silicon"
 pass "omarchy-hw-apple detects Apple Silicon"
 
+run_map() {
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_ARCH="${1:-aarch64}" \
+    OMARCHY_APPLE_COMPATIBLE="$compatible" \
+    TEST_LOG="$calls" \
+    SINK_CREATED="$sink_created" \
+    DEFAULT_SINK_FILE="$default_sink" \
+    "$map_cmd"
+}
+
 : >"$calls"
-PATH="$stub_bin:$ROOT/bin:$PATH" \
-  TEST_ARCH=x86_64 \
-  OMARCHY_APPLE_COMPATIBLE="$compatible" \
-  TEST_LOG="$calls" \
-  SINK_CREATED="$sink_created" \
-  "$map_cmd"
+run_map x86_64
 [[ ! -s $calls ]] || fail "omarchy-audio-asahi-mic-map is a no-op off Apple Silicon" "$(cat "$calls")"
 pass "omarchy-audio-asahi-mic-map is a no-op off Apple Silicon"
 
 : >"$calls"
 rm -f "$sink_created"
-PATH="$stub_bin:$ROOT/bin:$PATH" \
-  TEST_ARCH=aarch64 \
-  OMARCHY_APPLE_COMPATIBLE="$compatible" \
-  TEST_LOG="$calls" \
-  SINK_CREATED="$sink_created" \
-  "$map_cmd" || fail "the mapper succeeds on Apple Silicon with DSP present"
+printf '%s\n' "audio_effect.j313-convolver" >"$default_sink"
+run_map || fail "the mapper succeeds on Apple Silicon with DSP present"
 
 grep -Fq $'pactl\tload-module\tmodule-null-sink' "$calls" ||
   fail "the mapper creates a stereo null sink" "$(cat "$calls")"
@@ -144,7 +153,7 @@ grep -Fq $'pw-link\teffect_output.j313-mic:capture_AUX0\tomarchy_asahi_mic:playb
 grep -Fq $'pw-link\teffect_output.j313-mic:capture_AUX0\tomarchy_asahi_mic:playback_FR' "$calls" ||
   fail "the mapper copies AUX0 onto FR" "$(cat "$calls")"
 grep -Fq $'pactl\tset-default-sink\taudio_effect.j313-convolver' "$calls" ||
-  fail "the mapper restores the speaker convolver as the default sink" "$(cat "$calls")"
+  fail "the mapper restores the speaker convolver after the dummy sink steals it" "$(cat "$calls")"
 grep -Fq $'pactl\tset-default-source\tomarchy_asahi_mic.monitor' "$calls" ||
   fail "the mapper uses the stereo monitor as the default source" "$(cat "$calls")"
 ! grep -Fq 'move-source-output' "$calls" ||
@@ -152,15 +161,22 @@ grep -Fq $'pactl\tset-default-source\tomarchy_asahi_mic.monitor' "$calls" ||
 pass "the mapper duplicates AUX0 onto a stereo default source"
 
 : >"$calls"
-PATH="$stub_bin:$ROOT/bin:$PATH" \
-  TEST_ARCH=aarch64 \
-  OMARCHY_APPLE_COMPATIBLE="$compatible" \
-  TEST_LOG="$calls" \
-  SINK_CREATED="$sink_created" \
-  "$map_cmd" || fail "the mapper is idempotent"
+run_map || fail "the mapper is idempotent"
 ! grep -Fq $'pactl\tload-module\tmodule-null-sink' "$calls" ||
   fail "an existing stereo sink is reused" "$(cat "$calls")"
+! grep -Fq $'pactl\tset-default-sink' "$calls" ||
+  fail "a later run does not override an already-correct default sink" "$(cat "$calls")"
 pass "an existing stereo sink is reused"
+
+: >"$calls"
+rm -f "$sink_created"
+printf '%s\n' "bluez_output.headphones" >"$default_sink"
+run_map || fail "the mapper succeeds when headphones are the default sink"
+grep -Fq $'pactl\tset-default-sink\tbluez_output.headphones' "$calls" ||
+  fail "the mapper restores headphones after the dummy sink steals them" "$(cat "$calls")"
+! grep -Fq $'pactl\tset-default-sink\taudio_effect.j313-convolver' "$calls" ||
+  fail "the mapper does not force the speaker convolver over headphones" "$(cat "$calls")"
+pass "the mapper preserves headphones and Bluetooth as the default sink"
 
 fake_home="$test_tmp/home"
 mkdir -p "$fake_home"
@@ -172,6 +188,7 @@ PATH="$stub_bin:$ROOT/bin:$PATH" \
   OMARCHY_APPLE_COMPATIBLE="$compatible" \
   TEST_LOG="$calls" \
   SINK_CREATED="$sink_created" \
+  DEFAULT_SINK_FILE="$default_sink" \
   bash -euo pipefail -c 'source "$1"' bash "$mic_leaf"
 [[ -f $fake_home/.config/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf ]] ||
   fail "user setup copies the headset-mic drop-in"

--- a/test/shell.d/asahi-mic-map-test.sh
+++ b/test/shell.d/asahi-mic-map-test.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+user_all="$ROOT/install/user/all.sh"
+mic_leaf="$ROOT/install/user/hardware/apple/mic.sh"
+headset_conf="$ROOT/default/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf"
+map_cmd="$ROOT/bin/omarchy-audio-asahi-mic-map"
+hw_cmd="$ROOT/bin/omarchy-hw-apple"
+autostart="$ROOT/default/hypr/autostart.lua"
+migration=$(grep -rl 'Map the Asahi mic array to stereo' "$ROOT/migrations" | head -n 1 || true)
+
+[[ -x $map_cmd ]] || fail "omarchy-audio-asahi-mic-map ships and is executable"
+[[ -x $hw_cmd ]] || fail "omarchy-hw-apple ships and is executable"
+[[ -f $mic_leaf ]] || fail "the Apple Silicon mic user leaf ships"
+[[ -f $headset_conf ]] || fail "the headset-mic WirePlumber drop-in ships"
+grep -Fq 'hardware/apple/mic.sh' "$user_all" ||
+  fail "Apple Silicon mic mapping runs during user setup"
+grep -Fq 'omarchy-audio-asahi-mic-map' "$autostart" ||
+  fail "Hyprland start remaps the Asahi mic array"
+[[ -n $migration ]] || fail "existing Apple Silicon installs get the mic mapping"
+grep -Fq 'apple/audio.sh' "$migration" || fail "the migration retries speakersafetyd"
+grep -Fq 'apple/mic.sh' "$migration" || fail "the migration maps the Asahi mic array"
+pass "fresh and existing installs are wired to Asahi mic mapping"
+
+grep -Fq 'HiFi__Headset__source' "$headset_conf" ||
+  fail "the headset drop-in targets the unused jack mic"
+pass "the headset drop-in targets the unused jack mic"
+
+! grep -Fq 'move-source-output' "$map_cmd" ||
+  fail "the mapper does not steal the DSP chain's capture"
+pass "the mapper does not steal the DSP chain's capture"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+stub_bin="$test_tmp/bin"
+calls="$test_tmp/calls.log"
+compatible="$test_tmp/compatible"
+sink_created="$test_tmp/sink-created"
+mkdir -p "$stub_bin"
+
+cat >"$stub_bin/uname" <<'SH'
+#!/bin/bash
+
+if [[ ${1:-} == "-m" ]]; then
+  printf '%s\n' "${TEST_ARCH:-x86_64}"
+else
+  exec /usr/bin/uname "$@"
+fi
+SH
+
+cat >"$stub_bin/pactl" <<'SH'
+#!/bin/bash
+
+printf 'pactl' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+case "${1:-}" in
+list)
+  if [[ ${2:-} == "short" && ${3:-} == "sources" ]]; then
+    printf '58\teffect_output.j313-mic\tPipeWire\ts32le 1ch 48000Hz\tSUSPENDED\n'
+  elif [[ ${2:-} == "short" && ${3:-} == "sinks" ]]; then
+    printf '59\taudio_effect.j313-convolver\tPipeWire\tfloat32le 2ch 48000Hz\tSUSPENDED\n'
+    if [[ -e $SINK_CREATED ]]; then
+      printf '60\tomarchy_asahi_mic\tPipeWire\tfloat32le 2ch 48000Hz\tSUSPENDED\n'
+    fi
+  fi
+  ;;
+load-module)
+  touch "$SINK_CREATED"
+  echo 42
+  ;;
+esac
+SH
+
+cat >"$stub_bin/pw-link" <<'SH'
+#!/bin/bash
+
+printf 'pw-link' >>"$TEST_LOG"
+printf '\t%s' "$@" >>"$TEST_LOG"
+printf '\n' >>"$TEST_LOG"
+
+case "${1:-}" in
+-o)
+  printf '%s\n' "effect_output.j313-mic:capture_AUX0"
+  ;;
+-i)
+  printf '%s\n' "omarchy_asahi_mic:playback_FL"
+  printf '%s\n' "omarchy_asahi_mic:playback_FR"
+  ;;
+esac
+SH
+
+chmod +x "$stub_bin"/*
+
+run_hw() {
+  PATH="$stub_bin:$ROOT/bin:$PATH" \
+    TEST_ARCH="$1" \
+    OMARCHY_APPLE_COMPATIBLE="$compatible" \
+    "$hw_cmd"
+}
+
+: >"$compatible"
+run_hw x86_64 &&
+  fail "omarchy-hw-apple rejects non-aarch64 hosts" ||
+  pass "omarchy-hw-apple rejects non-aarch64 hosts"
+
+printf '%s\0' 'linux,dummy' >"$compatible"
+run_hw aarch64 &&
+  fail "omarchy-hw-apple rejects non-Apple aarch64 hosts" ||
+  pass "omarchy-hw-apple rejects non-Apple aarch64 hosts"
+
+printf '%s\0' 'apple,j313' >"$compatible"
+run_hw aarch64 ||
+  fail "omarchy-hw-apple detects Apple Silicon"
+pass "omarchy-hw-apple detects Apple Silicon"
+
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_ARCH=x86_64 \
+  OMARCHY_APPLE_COMPATIBLE="$compatible" \
+  TEST_LOG="$calls" \
+  SINK_CREATED="$sink_created" \
+  "$map_cmd"
+[[ ! -s $calls ]] || fail "omarchy-audio-asahi-mic-map is a no-op off Apple Silicon" "$(cat "$calls")"
+pass "omarchy-audio-asahi-mic-map is a no-op off Apple Silicon"
+
+: >"$calls"
+rm -f "$sink_created"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_ARCH=aarch64 \
+  OMARCHY_APPLE_COMPATIBLE="$compatible" \
+  TEST_LOG="$calls" \
+  SINK_CREATED="$sink_created" \
+  "$map_cmd" || fail "the mapper succeeds on Apple Silicon with DSP present"
+
+grep -Fq $'pactl\tload-module\tmodule-null-sink' "$calls" ||
+  fail "the mapper creates a stereo null sink" "$(cat "$calls")"
+grep -Fq $'pw-link\teffect_output.j313-mic:capture_AUX0\tomarchy_asahi_mic:playback_FL' "$calls" ||
+  fail "the mapper copies AUX0 onto FL" "$(cat "$calls")"
+grep -Fq $'pw-link\teffect_output.j313-mic:capture_AUX0\tomarchy_asahi_mic:playback_FR' "$calls" ||
+  fail "the mapper copies AUX0 onto FR" "$(cat "$calls")"
+grep -Fq $'pactl\tset-default-sink\taudio_effect.j313-convolver' "$calls" ||
+  fail "the mapper restores the speaker convolver as the default sink" "$(cat "$calls")"
+grep -Fq $'pactl\tset-default-source\tomarchy_asahi_mic.monitor' "$calls" ||
+  fail "the mapper uses the stereo monitor as the default source" "$(cat "$calls")"
+! grep -Fq 'move-source-output' "$calls" ||
+  fail "the mapper does not move existing source-outputs" "$(cat "$calls")"
+pass "the mapper duplicates AUX0 onto a stereo default source"
+
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  TEST_ARCH=aarch64 \
+  OMARCHY_APPLE_COMPATIBLE="$compatible" \
+  TEST_LOG="$calls" \
+  SINK_CREATED="$sink_created" \
+  "$map_cmd" || fail "the mapper is idempotent"
+! grep -Fq $'pactl\tload-module\tmodule-null-sink' "$calls" ||
+  fail "an existing stereo sink is reused" "$(cat "$calls")"
+pass "an existing stereo sink is reused"
+
+fake_home="$test_tmp/home"
+mkdir -p "$fake_home"
+: >"$calls"
+PATH="$stub_bin:$ROOT/bin:$PATH" \
+  HOME="$fake_home" \
+  OMARCHY_PATH="$ROOT" \
+  TEST_ARCH=aarch64 \
+  OMARCHY_APPLE_COMPATIBLE="$compatible" \
+  TEST_LOG="$calls" \
+  SINK_CREATED="$sink_created" \
+  bash -euo pipefail -c 'source "$1"' bash "$mic_leaf"
+[[ -f $fake_home/.config/wireplumber/wireplumber.conf.d/asahi-headset-mic.conf ]] ||
+  fail "user setup copies the headset-mic drop-in"
+pass "user setup copies the headset-mic drop-in"

--- a/test/shell.d/install-stage-wiring-test.sh
+++ b/test/shell.d/install-stage-wiring-test.sh
@@ -79,6 +79,10 @@ grep -qF 'user/hardware/apple/obsidian.sh' "$ROOT/install/user/all.sh" ||
   fail "the Apple Obsidian substitution runs in the per-user stage"
 pass "the Apple Obsidian substitution runs in the per-user stage"
 
+grep -qF 'user/hardware/apple/mic.sh' "$ROOT/install/user/all.sh" ||
+  fail "the Apple Silicon mic mapping runs in the per-user stage"
+pass "the Apple Silicon mic mapping runs in the per-user stage"
+
 # Asking for the pkgbase again would reproduce the bug it exists to fix.
 grep -qF 'obsidian-appimage' "$ROOT/install/user/hardware/apple/obsidian.sh" ||
   fail "the substitution asks for obsidian-appimage by name"

--- a/test/shell.d/screenrecording-test.sh
+++ b/test/shell.d/screenrecording-test.sh
@@ -299,3 +299,22 @@ grep -F 'move = { "(monitor_w-monitor_h*2/9-40)", "(monitor_h-monitor_h/4-40)" }
 grep -F 'move = { "(monitor_w-monitor_h*3/10-40)", "(monitor_h-monitor_h*27/80-40)" }' "$webcam_rules" >/dev/null || \
   fail "large webcam starts at its final corner position"
 pass "webcam size rules place the initial window in its final corner"
+
+grep -Fq 'no_focus = true' "$webcam_rules" ||
+  fail "the webcam overlay does not take focus"
+grep -Fq 'no_follow_mouse = true' "$webcam_rules" ||
+  fail "the webcam overlay does not steal focus on hover"
+pass "the webcam overlay ignores clicks"
+
+recorder="$ROOT/bin/omarchy-capture-screenrecording"
+menu="$ROOT/default/omarchy/omarchy-menu.jsonc"
+bar="$ROOT/shell/plugins/bar/indicators/ScreenRecording.qml"
+grep -Fq -- '-R 48000' "$recorder" ||
+  fail "wf-recorder records AAC at 48 kHz on the software path"
+grep -Fq '(^|/)(gpu-screen-recorder|wf-recorder)( |$)' "$recorder" ||
+  fail "screenrecording stop matches wf-recorder by full path"
+grep -Fq '(^|/)(gpu-screen-recorder|wf-recorder)( |$)' "$menu" ||
+  fail "Capture Stop is visible while wf-recorder is running"
+grep -Fq '(^|/)(gpu-screen-recorder|wf-recorder)( |$)' "$bar" ||
+  fail "the bar recording indicator matches wf-recorder by full path"
+pass "screen recording detects and encodes wf-recorder on Apple Silicon"


### PR DESCRIPTION
On Apple Silicon (Asahi), the built-in mic is silent to apps, screen recordings either have no audio or play as silence, Capture Stop disappears while `wf-recorder` is running, the webcam overlay steals focus, and a `speakersafetyd` start-limit can leave the speakers muted at -100 dB.

Verified on a MacBook Air M1 (J313).

## What this does

### Screen recording
- **`wf-recorder -R 48000`** — Asahi speaker DSP advertises 96 kHz, and wf-recorder follows that into a 96 kHz AAC track that this PipeWire graph (and many players) play as silence. 48 kHz is the rate the rest of the session already uses.
- **Stop / bar / menu matching** — `pgrep -f '^wf-recorder'` misses argv[0] when it is a full path (`/usr/bin/wf-recorder`). Match `(^|/)(gpu-screen-recorder|wf-recorder)( |$)` so Capture Stop and the bar indicator work on the Asahi software path. The existing Stop row and English labels are unchanged.
- **Webcam overlay** — `no_initial_focus` was not enough; a click still focused mpv and froze the mini-me. Set `no_focus` and `no_follow_mouse`.

### Mic array
asahi-audio publishes the beamformed laptop mics as **AUX0**. Recorders and the desktop+mic null-sink ask for **FL/FR**, so they either fail to link or write left-only audio that `loudnorm` then ruins.

- **`omarchy-hw-apple`** — `aarch64` plus `apple,` in the device tree.
- **`omarchy-audio-asahi-mic-map`** — wait for `effect_output.j*-mic`, create a low-priority stereo null sink `omarchy_asahi_mic`, `pw-link` AUX0 onto FL and FR, use the monitor as the default source, restore the default sink to the asahi-audio convolver. **Never moves existing source-outputs** — that steals the DSP chain's capture from the raw mics and kills the filter.
- **Headset jack drop-in** — the unplugged 3.5mm headset source advertises a MONO map and often wins the default. Lower its `priority.session` to 1.
- Wired from `install/user/hardware/apple/mic.sh` (fresh users) and Hyprland start (every login). Existing installs get it from the migration.

### Speakers
`speakersafetyd` can panic on a bad IV-sense sample (`Negative power, bad ivsense data?`), hit start-limit, and leave the kernel holding the drivers at -100 dB. After `enable --now`, if the unit is still inactive, `reset-failed` and try `start` once more.

## Design notes

- **No global PipeWire 48 kHz lock.** That would fight asahi-audio's 96 kHz speaker graph. The sample-rate pin is only on the recorder.
- **No new systemd user unit.** `omarchy-settings` lists user units explicitly in its PKGBUILD; a new unit would need a second PR against omarchy-pkgs. Hyprland autostart plus the user-setup leaf is enough, and `bin/` is glob-installed by the omarchy package.
- **No-op off Apple Silicon.** `omarchy-hw-apple` is the gate; x86 and non-Apple aarch64 leave the graph alone.

## Testing

- `test/cli` — metadata check passes (`omarchy-hw-apple`, hidden `omarchy-audio-asahi-mic-map`).
- `bash test/shell.d/asahi-mic-map-test.sh` — hardware gate, AUX0→FL/FR mapping, no `move-source-output`, headset drop-in, install/autostart/migration wiring.
- `bash test/shell.d/asahi-audio-install-test.sh` — existing Asahi audio package coverage plus speakersafetyd start-limit recovery.
- `bash test/shell.d/screenrecording-test.sh` — 48 kHz, process matching, overlay `no_focus` / `no_follow_mouse`.
- `bash test/shell.d/install-stage-wiring-test.sh` — `user/hardware/apple/mic.sh` is sourced from `install/user/all.sh`.
- On J313: DSP source meters, speakers at 0 dB after the speakersafetyd retry, and a 48 kHz screen recording with audible microphone audio.

Existing installs pick this up through `omarchy update` → `omarchy-migrate`. Factory-reset buyers get it from the packaged `/usr/share/omarchy` defaults once this is in a release; it does not belong in `@factory` as a home-directory overlay.