### PR TITLE
fix(sudo-passwordless): fail closed when the expiry timer cannot be armed

### DIFF
--- a/bin/omarchy-sudo-passwordless
+++ b/bin/omarchy-sudo-passwordless
@@ -13,6 +13,19 @@ if [[ $1 && ! $1 =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+arm_expiry() {
+  if sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
+    rm -f -- "$NOPASSWD_FILE"; then
+    return 0
+  fi
+
+  echo "Failed to schedule passwordless sudo expiry. Revoking access now." >&2
+  if ! sudo rm -f -- "$NOPASSWD_FILE"; then
+    echo "CRITICAL: Could not remove $NOPASSWD_FILE. Remove it as root immediately." >&2
+  fi
+  return 1
+}
+
 echo "Toggle passwordless sudo..."
 
 # Safety: if the file exists but the timer doesn't (e.g. after reboot), clean up
@@ -24,8 +37,7 @@ fi
 if sudo test -f "$NOPASSWD_FILE"; then
   if [[ $1 ]]; then
     sudo systemctl stop "${TIMER_NAME}.timer" 2>/dev/null
-    sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
-      rm "$NOPASSWD_FILE"
+    arm_expiry || exit 1
     echo "Passwordless sudo timer updated. It will now automatically disable in ${MINUTES} minutes."
   else
     sudo rm "$NOPASSWD_FILE"
@@ -48,8 +60,7 @@ else
   if gum confirm "Enable passwordless sudo for ${MINUTES} minutes? This is a significant security risk!"; then
     echo "${USER} ALL=(ALL) NOPASSWD: ALL" | sudo tee "$NOPASSWD_FILE" > /dev/null
     sudo chmod 440 "$NOPASSWD_FILE"
-    sudo systemd-run --on-active=${MINUTES}m --timer-property=AccuracySec=1s --unit="$TIMER_NAME" \
-      rm "$NOPASSWD_FILE"
+    arm_expiry || exit 1
 
     echo ""
     echo "Passwordless sudo has been ENABLED. It will automatically disable in ${MINUTES} minutes."


### PR DESCRIPTION
## Problem

`omarchy-sudo-passwordless` can enable passwordless root and report a time bound it has not actually established.

Both `systemd-run` call sites run unchecked. If the expiry timer fails to schedule, the script continues and prints:

> Passwordless sudo has been ENABLED. It will automatically disable in 10 minutes.

The `NOPASSWD` sudoers rule is in place, no timer exists, and root persists until manually disabled or the file is cleaned up on a later invocation. The failure is silent and **fails open on a security control** — a user who trusts the message walks away believing the grant is bounded.

## Why it triggers repeatedly

The transient unit runs `rm "$NOPASSWD_FILE"` without `-f`. Disabling a window early removes the file immediately, so when the still-scheduled timer fires it exits non-zero and strands the unit:

```
× omarchy-nopasswd-expire-<user>.service - [systemd-run] /usr/bin/rm /etc/sudoers.d/99-omarchy-nopasswd-<user>
     Loaded: loaded (/run/systemd/transient/...; transient)
     Active: failed (Result: exit-code)
```

A failed transient unit stays registered, so the next `systemd-run --unit=<same name>` is refused — and that refusal is the unchecked failure above. Once stranded, **every subsequent enable takes the fail-open path.**

## Reproduction

```bash
omarchy-sudo-passwordless 10     # enable
omarchy-sudo-passwordless        # disable early
# wait past the original expiry
omarchy-sudo-passwordless 10     # enable again
```

```
Failed to start transient timer unit: Unit omarchy-nopasswd-expire-<user>.service
was already loaded or has a fragment file.

Passwordless sudo has been ENABLED. It will automatically disable in 10 minutes.
```

```bash
systemctl list-timers omarchy-nopasswd-expire-$USER.timer   # 0 timers listed
sudo -n true                                                # succeeds, indefinitely
```

Confirmed by the inverse case: when the timer is allowed to fire while the file still exists, `rm` succeeds, the unit is garbage-collected, and the next enable works normally. Observed on `omarchy-mac@291a698`, Arch aarch64, kernel 7.1.6.

## Fix

This is a **backport of `arm_expiry()` from `omacom/omarchy`**, which `omarchy-mac` does not currently carry — the parent repo already solved this. After this change `bin/omarchy-sudo-passwordless` is byte-identical to upstream except for the restart notice (see below).

`arm_expiry()`:

- uses `rm -f --` so the unit cannot strand itself on an already-removed file;
- checks `systemd-run`'s exit status;
- revokes the grant immediately if the timer cannot be scheduled, escalating to a `CRITICAL` message if even that removal fails.

Call sites become `arm_expiry || exit 1`, so the script fails closed rather than asserting an unbacked time bound.

## Intentionally not synced

`omarchy-mac`'s closing message is kept as-is:

```
Note: if you restart before then, run omarchy-sudo-passwordless again to disable it.
```

Upstream says *"A restart removes the passwordless sudo rule as well."* That isn't accurate — a file in `/etc/sudoers.d/` survives reboot and is only removed by the existing "file exists but timer doesn't" cleanup on the *next* invocation. The mac wording describes actual behaviour, so this PR leaves it alone.

## Testing

- `bash -n bin/omarchy-sudo-passwordless` passes.
- Resulting file diffed against `omacom/omarchy@quattro`: only the restart-notice line differs.
- Original failure reproduced three times before the change; the stranding mechanism confirmed in both directions on a live system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5z6wirF6matApdUKH4fFT
