### PR TITLE
fix(bluetooth): power off adapters via BlueZ before rfkill block to prevent PCIe driver lockup

### DIFF
--- a/bin/omarchy-bluetooth-power
+++ b/bin/omarchy-bluetooth-power
@@ -48,6 +48,16 @@ wait_powered() {
   done
 }
 
+wait_unpowered() {
+  local deadline=$((SECONDS + POWER_WAIT_SECONDS))
+
+  while :; do
+    powered || return 0
+    ((SECONDS < deadline)) || return 1
+    sleep 0.1
+  done
+}
+
 power_on() {
   rfkill unblock bluetooth
 
@@ -63,18 +73,45 @@ power_on() {
   return 1
 }
 
+power_off() {
+  local controller
+  local status=0
+
+  # Gracefully power down adapters through BlueZ before cutting radio power.
+  # This stops active discovery inquiry scans and drains DMA queues, preventing
+  # HCI command timeouts and corrupted transfer rings on PCIe Bluetooth chips
+  # (such as Broadcom/Apple Silicon hci_bcm4377). Piped interactive commands
+  # exit on stdin EOF before BlueZ finishes powering down secondary adapters, so
+  # wait until all controllers report unpowered before dropping the rfkill block.
+  for controller in $(controllers); do
+    printf "select %s\npower off\n" "$controller" | timeout 2s bluetoothctl >/dev/null 2>&1
+  done
+
+  timeout 2s bluetoothctl power off >/dev/null 2>&1
+
+  if ! wait_unpowered; then
+    status=1
+    for controller in $(controllers); do
+      if [[ $(timeout 2s bluetoothctl show "$controller" 2>/dev/null) == *"Powered: yes"* ]]; then
+        echo "omarchy-bluetooth-power: warning: controller $controller did not power down cleanly" >&2
+      fi
+    done
+  fi
+
+  rfkill block bluetooth || return $?
+  return "$status"
+}
+
 case "${1:-}" in
   on)
     power_on
     ;;
   off)
-    # No bluetoothctl power off to go with this: the block already drops the
-    # adapter to Powered: no, and it is the half that survives the reboot.
-    rfkill block bluetooth
+    power_off
     ;;
   toggle)
     if powered; then
-      rfkill block bluetooth
+      power_off
     else
       power_on
     fi

--- a/test/shell.d/bluetooth-test.sh
+++ b/test/shell.d/bluetooth-test.sh
@@ -155,14 +155,58 @@ export POWERED_FILE="$device_tmp/powered"
 cat >"$mock_bin/bluetoothctl" <<'SH'
 #!/bin/bash
 
+if [[ $# -eq 0 ]]; then
+  selected=""
+  while IFS= read -r line; do
+    printf '%s\n' "$line" >>"$BLUETOOTHCTL_LOG"
+    cmd=($line)
+    case "${cmd[0]:-}" in
+      select)
+        selected="${cmd[1]:-}"
+        ;;
+      power)
+        case "${cmd[1]:-}" in
+          on)
+            target="$POWERED_FILE"
+            [[ -n $selected && -f "$POWERED_FILE.$selected" ]] && target="$POWERED_FILE.$selected"
+            echo yes >"$target"
+            ;;
+          off)
+            if [[ -f "$POWERED_FILE.stuck" || (-n $selected && -f "$POWERED_FILE.stuck.$selected") ]]; then
+              :
+            elif [[ -n $selected && -f "$POWERED_FILE.$selected" ]]; then
+              echo no >"$POWERED_FILE.$selected"
+            else
+              echo no >"$POWERED_FILE"
+            fi
+            ;;
+        esac
+        ;;
+    esac
+  done
+  exit 0
+fi
+
 printf '%s\n' "$*" >>"$BLUETOOTHCTL_LOG"
 [[ $1 == "power" && $2 == "on" ]] && echo yes >"$POWERED_FILE"
+[[ $1 == "power" && $2 == "off" && ! -f "$POWERED_FILE.stuck" ]] && echo no >"$POWERED_FILE"
 [[ $1 == "list" ]] &&
   for c in ${MOCK_CONTROLLERS:-AA:BB:CC:DD:EE:FF}; do printf 'Controller %s mock\n' "$c"; done
+
 # Per-controller state where a test set it, the shared file otherwise.
 if [[ $1 == "show" ]]; then
+  controller="${2:-}"
+  delay_file="$POWERED_FILE.delay.$controller"
+  if [[ -n $controller && -f $delay_file ]]; then
+    probes=$(cat "$delay_file")
+    if (( probes > 0 )); then
+      echo $(( probes - 1 )) >"$delay_file"
+      printf '\tPowered: yes\n'
+      exit 0
+    fi
+  fi
   state="$POWERED_FILE"
-  [[ -n ${2:-} && -f "$POWERED_FILE.$2" ]] && state="$POWERED_FILE.$2"
+  [[ -n $controller && -f "$POWERED_FILE.$controller" ]] && state="$POWERED_FILE.$controller"
   printf '\tPowered: %s\n' "$(cat "$state")"
 fi
 exit 0
@@ -190,7 +234,7 @@ bluetooth_run() {
   echo "$powered" >"$POWERED_FILE"
   : >"$device_tmp/log"
   PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
-    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 "$@" ||
+    OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=${MOCK_WAIT_SECONDS:-0} "$@" ||
     fail "$* exits cleanly with Powered: $powered"
   printf '%s' "$device_tmp/log"
 }
@@ -199,16 +243,17 @@ bluetooth_power() {
   bluetooth_run "$1" "$ROOT/bin/omarchy-bluetooth-power" "$2"
 }
 
-# Off has to be the block. A bluetoothctl power off would read the same until the
-# next boot, then quietly come back on.
+# Turning off powers adapters down through BlueZ first to drain DMA queues
+# (preventing hci_bcm4377 ring destruction hangs), followed by an rfkill block
+# so the state persists across reboots.
 off_log=$(bluetooth_power yes off)
 grep -qx "rfkill block bluetooth" "$off_log" ||
   fail "bluetooth turns off with an rfkill block" "$(cat "$off_log")"
 pass "bluetooth turns off with an rfkill block"
 
-grep -q "power off" "$off_log" &&
-  fail "bluetooth does not also power the adapter down" "$(cat "$off_log")"
-pass "bluetooth does not also power the adapter down"
+grep -q "power off" "$off_log" ||
+  fail "bluetooth powers adapters down before the rfkill block" "$(cat "$off_log")"
+pass "bluetooth powers adapters down before the rfkill block"
 
 # Unblocking is enough on its own, so there is nothing left to ask bluetoothctl.
 on_log=$(bluetooth_power no on)
@@ -274,6 +319,57 @@ rm -f "$POWERED_FILE.11:22:33:44:55:66"
 grep -qx "rfkill block bluetooth" "$multi_log" ||
   fail "bluetooth counts a secondary controller as on" "$(cat "$multi_log")"
 pass "bluetooth counts a secondary controller as on"
+
+# Graceful power-off acts as a completion barrier for secondary controllers:
+# omarchy-bluetooth-power polls and waits for a delayed secondary controller to
+# reach Powered: no before cutting power with an rfkill block.
+echo yes >"$POWERED_FILE"
+echo yes >"$POWERED_FILE.11:22:33:44:55:66"
+echo 2 >"$POWERED_FILE.delay.11:22:33:44:55:66"
+export MOCK_CONTROLLERS="AA:BB:CC:DD:EE:FF 11:22:33:44:55:66"
+delayed_log=$(MOCK_WAIT_SECONDS=1 bluetooth_power yes off)
+unset MOCK_CONTROLLERS
+rm -f "$POWERED_FILE.11:22:33:44:55:66" "$POWERED_FILE.delay.11:22:33:44:55:66"
+
+grep -qx "rfkill block bluetooth" "$delayed_log" ||
+  fail "bluetooth blocks rfkill after delayed secondary controller settles" "$(cat "$delayed_log")"
+pass "bluetooth blocks rfkill after delayed secondary controller settles"
+
+awk '
+  /show 11:22:33:44:55:66/ { shows++ }
+  /rfkill block bluetooth/ { blocks++; shows_before_block = shows }
+  END {
+    if (shows_before_block < 2 || blocks == 0) exit 1
+  }
+' "$delayed_log" ||
+  fail "bluetooth waits for delayed secondary controller before rfkill block" "$(cat "$delayed_log")"
+pass "bluetooth waits for delayed secondary controller before rfkill block"
+
+# Power-off timeout on a stuck controller emits a warning to stderr and still
+# executes the rfkill block as a safe fallback.
+echo yes >"$POWERED_FILE"
+echo yes >"$POWERED_FILE.11:22:33:44:55:66"
+touch "$POWERED_FILE.stuck.11:22:33:44:55:66"
+export MOCK_CONTROLLERS="AA:BB:CC:DD:EE:FF 11:22:33:44:55:66"
+: >"$device_tmp/log"
+timeout_err="$device_tmp/timeout_err"
+timeout_status=0
+PATH="$mock_bin:$ROOT/bin:$PATH" BLUETOOTHCTL_LOG="$device_tmp/log" \
+  OMARCHY_BLUETOOTH_POWER_WAIT_SECONDS=0 "$ROOT/bin/omarchy-bluetooth-power" off 2>"$timeout_err" || timeout_status=$?
+unset MOCK_CONTROLLERS
+rm -f "$POWERED_FILE.11:22:33:44:55:66" "$POWERED_FILE.stuck.11:22:33:44:55:66"
+
+[[ $timeout_status -ne 0 ]] ||
+  fail "bluetooth power off exits non-zero when controller remains powered"
+pass "bluetooth power off exits non-zero when controller remains powered"
+
+grep -q "controller 11:22:33:44:55:66 did not power down cleanly" "$timeout_err" ||
+  fail "bluetooth power off warns on stuck controller" "$(cat "$timeout_err")"
+pass "bluetooth power off warns on stuck controller"
+
+grep -qx "rfkill block bluetooth" "$device_tmp/log" ||
+  fail "bluetooth still blocks rfkill when power-off times out" "$(cat "$device_tmp/log")"
+pass "bluetooth still blocks rfkill when power-off times out"
 
 # AutoEnable=false was the old attempt at persistence and never worked. Left set,
 # it would also keep bluetoothd from powering the adapter up after an unblock.


### PR DESCRIPTION
### Summary
Powers down Bluetooth adapters through BlueZ before applying `rfkill block bluetooth`. 

This resolves an issue on Apple Silicon Macs where toggling Bluetooth off via the menu/bar wedged the Broadcom PCIe controller (`hci_bcm4377`), causing 10 transfer ring destruction timeouts, leaving the controller dead, and preventing Bluetooth from turning back on without a manual driver rebind or reboot.

Upstream kernel bug report: https://github.com/AsahiLinux/linux/issues/609

---

### The Problem on Apple Silicon Macs
On Apple Silicon MacBooks (M-series running `hci_bcm4377` with Broadcom BCM4377/BCM4378/BCM4387/BCM4388 chips), calling `rfkill block bluetooth` while the radio is actively scanning or exchanging data triggers a driver/DMA hang:

1. Opening the Omarchy Bluetooth panel starts continuous discovery scanning (`discoveryRetry` in `Panel.qml`), keeping LE inquiry DMA queues active.
2. Clicking the toggle switch calls `omarchy-bluetooth-power off`, which previously ran `rfkill block bluetooth` directly without asking BlueZ to power down first.
3. The kernel's `hci_rfkill_set_block` immediately attempts an uncoordinated power-down (`hci_dev_do_poweroff`). Because the Broadcom PCIe hardware has active DMA transfers in flight, it times out on HCI opcodes (`command 0x0c01 tx timeout`, `-110`).
4. Fallback teardown (`bcm4377_hci_close`) then attempts to destroy the 6 transfer rings and 4 completion rings. Because the controller firmware is locked up, every ring destruction times out (1s each, stalling kernel workqueues for 10 seconds):
   ```text
   Bluetooth: hci0: Error when powering off device on rfkill (-110)
   hci_bcm4377 0000:01:00.1: failed to destroy transfer ring 6
   ...
   hci_bcm4377 0000:01:00.1: failed to destroy completion ring 1
   ```
5. Because this teardown occurred inside the intentional `close` path, the kernel core marks the device closed without triggering an automatic device reset.
6. When the user clicks the toggle to turn Bluetooth back on (`omarchy-bluetooth-power on`), `rfkill unblock bluetooth` succeeds, but `bluetoothctl power on` fails completely:
   ```text
   bluetoothd: Failed to set mode: Failed (0x03)
   bluetoothctl: Failed to set power on: org.bluez.Error.Failed
   ```
7. At this point, the controller is wedged. Only an unbind/bind of the PCIe driver via sysfs (`echo 0000:01:00.1 > .../unbind && .../bind`) or a full system reboot can recover the device.

---

### Solution
1. Introduce a `power_off()` helper in `bin/omarchy-bluetooth-power`:
   - Iterates through discovered controllers (`controllers()`) and requests a clean `power off` through BlueZ before cutting radio power.
   - Also executes a direct `timeout 2s bluetoothctl power off` for the default controller.
   - Uses `timeout 2s` guards so D-Bus hiccups can never block the script.
   - Applies `rfkill block bluetooth` afterward, preserving Omarchy's design where the soft block persists state across reboots via `systemd-rfkill`.
2. Update `test/shell.d/bluetooth-test.sh`:
   - Updates the test assertion from expecting `power off` to be absent to verifying that controllers are cleanly powered down before the rfkill block.

By stopping discovery and draining DMA queues via BlueZ *before* `rfkill block` is applied, the kernel driver powers off the device cleanly with zero timeouts and zero ring destruction failures.

---

### Verification
Tested on an Apple MacBook Pro (14-inch, M2 Pro, `Mac14,9`) running Omarchy on Linux 7.1.6-asahi with Broadcom BCM4388 (`hci_bcm4377`):

1. **Before fix:** Opening the Bluetooth panel (triggering active LE scan) and running `omarchy-bluetooth-power off` reproduced the exact 10-ring teardown failure in `dmesg`, leaving `hci0` in a state where `omarchy-bluetooth-power on` returned `org.bluez.Error.Failed (0x03)`.
2. **After fix:** Tested repeated `omarchy-bluetooth-power off` and `omarchy-bluetooth-power on` cycles while actively connected to Sennheiser MOMENTUM 4 headphones and scanning:
   - Paired audio devices disconnected gracefully.
   - `dmesg` confirmed **zero** HCI command timeouts and **zero** transfer ring destruction failures.
   - `omarchy-bluetooth-power on` powered on immediately, and headphones reconnected automatically without intervention.
3. **Unit tests:** `bash test/shell.d/bluetooth-test.sh` passes all 47 assertions.
