### PR TITLE
Add MLX (Apple GPU) to the AI install menu

### DIFF
--- a/bin/omarchy-install-ai-mlx
+++ b/bin/omarchy-install-ai-mlx
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Install mlx-omarchy: Apple's MLX running on the Apple GPU through Honeykrisp Vulkan
+# omarchy:requires-sudo=true
+
+set -e
+
+if [ "$(uname -m)" != "aarch64" ]; then
+  echo "Skipping: mlx-omarchy runs on Apple Silicon only"
+  exit 0
+fi
+
+echo "Installing mlx-omarchy..."
+# Installs the verified release wheel and a chat demo into a private venv under
+# ~/.local/share/mlx-omarchy. Installs lapack and blas through omarchy-pkg-add;
+# does not replace Mesa or change any Omarchy file. Verified on the M1.
+curl -fsSL https://raw.githubusercontent.com/joshuaswarren/mlx-omarchy/main/install.sh | bash
+
+echo ""
+echo "mlx-omarchy has been installed. Run 'mlx-omarchy-demo' or open 'MLX Chat (Apple GPU)' from the launcher."

--- a/bin/omarchy-install-ai-mlx
+++ b/bin/omarchy-install-ai-mlx
@@ -19,6 +19,38 @@ if ! grep -Faiq 'apple,t8103' "$compatible"; then
   exit 0
 fi
 
+# The artifacts the pinned installer creates, and the ones its --uninstall
+# deletes. Kept in step with it by hand; MLX_OMARCHY_HOME is honoured the same
+# way so this entry and the installer always agree on where things live.
+PREFIX="${MLX_OMARCHY_HOME:-$HOME/.local/share/mlx-omarchy}"
+BIN="$HOME/.local/bin"
+APPS="$HOME/.local/share/applications"
+
+# Refuse before touching anything if an installation is already there. The
+# failure path below runs the installer's --uninstall, which deletes all of
+# these unconditionally, so a failed install over an existing one would take
+# the existing one with it. Checking first is what makes that impossible.
+existing=()
+for artifact in \
+  "$PREFIX" \
+  "$BIN/mlx-omarchy" \
+  "$BIN/mlx-omarchy-demo" \
+  "$APPS/mlx-omarchy-demo.desktop"; do
+  [ -e "$artifact" ] && existing+=("$artifact")
+done
+
+if [ ${#existing[@]} -gt 0 ]; then
+  echo "mlx-omarchy is already installed, or a previous attempt left files behind:" >&2
+  printf '  %s\n' "${existing[@]}" >&2
+  echo "" >&2
+  echo "Refusing to install over it, because cleaning up after a failure here" >&2
+  echo "would delete what is already there." >&2
+  echo "Remove it first with 'omarchy-remove-ai-mlx' (or the Remove > AI > MLX" >&2
+  echo "menu entry), then run this again. Model downloads in ~/.cache/huggingface" >&2
+  echo "are kept either way." >&2
+  exit 1
+fi
+
 # Pinned installer commit and its checksum. Bump both together; never point at a
 # moving branch, because this menu entry runs on other people's machines.
 INSTALLER_REPO="joshuaswarren/mlx-omarchy"
@@ -52,8 +84,18 @@ if [ "$status" -ne 0 ]; then
   echo "" >&2
   echo "mlx-omarchy installation failed (exit $status). The output above is the error." >&2
   echo "Cleaning up the partial install..." >&2
-  bash "$tmp/install.sh" --uninstall >/dev/null 2>&1 || true
-  echo "Nothing from mlx-omarchy is left installed. Re-run this entry to try again." >&2
+  # Only this attempt's files can be here: the guard above refused to start if
+  # anything already existed. Say what actually happened rather than asserting
+  # a clean machine, because a cleanup that failed leaves files to remove.
+  if bash "$tmp/install.sh" --uninstall >/dev/null 2>&1; then
+    echo "Nothing from mlx-omarchy is left installed. Re-run this entry to try again." >&2
+  else
+    echo "Cleanup did not finish. Files may remain in:" >&2
+    echo "  $PREFIX" >&2
+    echo "  $BIN/mlx-omarchy, $BIN/mlx-omarchy-demo" >&2
+    echo "  $APPS/mlx-omarchy-demo.desktop" >&2
+    echo "Run 'omarchy-remove-ai-mlx' before trying again." >&2
+  fi
   exit "$status"
 fi
 

--- a/bin/omarchy-install-ai-mlx
+++ b/bin/omarchy-install-ai-mlx
@@ -3,18 +3,59 @@
 # omarchy:summary=Install mlx-omarchy: Apple's MLX running on the Apple GPU through Honeykrisp Vulkan
 # omarchy:requires-sudo=true
 
-set -e
+set -euo pipefail
 
-if [ "$(uname -m)" != "aarch64" ]; then
-  echo "Skipping: mlx-omarchy runs on Apple Silicon only"
+# The wheel is built for the M1 (t8103) only. Newer Apple GPUs need driver work
+# that is not done yet, so refuse rather than install something that cannot run.
+if ! omarchy-hw-apple; then
+  echo "Skipping: mlx-omarchy runs on Apple Silicon only."
   exit 0
 fi
 
-echo "Installing mlx-omarchy..."
+compatible="${OMARCHY_APPLE_COMPATIBLE:-/proc/device-tree/compatible}"
+if ! grep -Faiq 'apple,t8103' "$compatible"; then
+  echo "Skipping: mlx-omarchy currently supports the M1 (t8103) only."
+  echo "This machine reports: $(tr '\0' '\n' <"$compatible" 2>/dev/null | paste -sd' ' - || echo unknown)"
+  exit 0
+fi
+
+# Pinned installer commit and its checksum. Bump both together; never point at a
+# moving branch, because this menu entry runs on other people's machines.
+INSTALLER_REPO="joshuaswarren/mlx-omarchy"
+INSTALLER_REF="286ef7297b0db6576c70d9999c6f6b005ce1c8de"
+INSTALLER_SHA256="cdfa8a985d38984c68053c2765b50cc8875b7f894001c44d4c6732e47921ebf1"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Fetching the mlx-omarchy installer (${INSTALLER_REF:0:12})..."
+curl -fsSL "https://raw.githubusercontent.com/$INSTALLER_REPO/$INSTALLER_REF/install.sh" -o "$tmp/install.sh"
+
+echo "$INSTALLER_SHA256  $tmp/install.sh" | sha256sum -c --quiet - || {
+  echo "Checksum mismatch on the mlx-omarchy installer. Refusing to run it." >&2
+  exit 1
+}
+
 # Installs the verified release wheel and a chat demo into a private venv under
-# ~/.local/share/mlx-omarchy. Installs lapack and blas through omarchy-pkg-add;
-# does not replace Mesa or change any Omarchy file. Verified on the M1.
-curl -fsSL https://raw.githubusercontent.com/joshuaswarren/mlx-omarchy/main/install.sh | bash
+# ~/.local/share/mlx-omarchy. Installs lapack, blas, and openblas through
+# omarchy-pkg-add; does not replace Mesa or change any Omarchy file.
+echo "Installing mlx-omarchy..."
+# Capture the installer's own status. `if ! cmd; then status=$?` would record the
+# negation's status (always 0) and report a failure as a success, which is the
+# bug this entry is meant to avoid.
+set +e
+bash "$tmp/install.sh"
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "mlx-omarchy installation failed (exit $status). The output above is the error." >&2
+  echo "Cleaning up the partial install..." >&2
+  bash "$tmp/install.sh" --uninstall >/dev/null 2>&1 || true
+  echo "Nothing from mlx-omarchy is left installed. Re-run this entry to try again." >&2
+  exit "$status"
+fi
 
 echo ""
 echo "mlx-omarchy has been installed. Run 'mlx-omarchy-demo' or open 'MLX Chat (Apple GPU)' from the launcher."

--- a/bin/omarchy-launch-floating-terminal-with-presentation
+++ b/bin/omarchy-launch-floating-terminal-with-presentation
@@ -8,6 +8,12 @@
 source omarchy-restart-gum
 
 cmd="$*"
-presentation_script="omarchy-show-logo; $cmd; if (( \$? != 130 )); then omarchy-show-done; fi"
+
+# Capture the command's status on the line after it runs, before anything else
+# can overwrite $?, then report that status and exit with it. Reporting
+# unconditionally is how a failed menu entry used to end on a green "Done!"
+# and hand its caller a 0: the error was displayed, then thrown away.
+# Cancellation (130) still skips the message, but no longer becomes a 0.
+presentation_script="omarchy-show-logo; $cmd; status=\$?; if (( status != 130 )); then omarchy-show-done \"\$status\"; fi; exit \$status"
 
 exec setsid uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.terminal --title=Omarchy -e bash -c "$presentation_script"

--- a/bin/omarchy-remove-ai-mlx
+++ b/bin/omarchy-remove-ai-mlx
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Remove mlx-omarchy along with its private venv and chat demo.
+# omarchy:requires-sudo=true
+
+set -euo pipefail
+
+# Same pinned installer as the install entry: it owns the uninstall path, so the
+# two stay in step. Bump both together.
+INSTALLER_REPO="joshuaswarren/mlx-omarchy"
+INSTALLER_REF="286ef7297b0db6576c70d9999c6f6b005ce1c8de"
+INSTALLER_SHA256="cdfa8a985d38984c68053c2765b50cc8875b7f894001c44d4c6732e47921ebf1"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL "https://raw.githubusercontent.com/$INSTALLER_REPO/$INSTALLER_REF/install.sh" -o "$tmp/install.sh"
+
+echo "$INSTALLER_SHA256  $tmp/install.sh" | sha256sum -c --quiet - || {
+  echo "Checksum mismatch on the mlx-omarchy installer. Refusing to run it." >&2
+  exit 1
+}
+
+bash "$tmp/install.sh" --uninstall
+
+echo ""
+echo "mlx-omarchy has been removed."

--- a/bin/omarchy-show-done
+++ b/bin/omarchy-show-done
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-# omarchy:summary=Display a "Done!" message and wait for user to press any key.
+# omarchy:summary=Display the outcome of the command that just ran and wait for a key.
+# omarchy:args=[status]
+
+# The exit status of the command being reported on. It defaults to 0 so the
+# existing no-argument callers (omarchy-pkg-install, omarchy-pkg-aur-install,
+# omarchy-pkg-remove) keep their previous behaviour exactly.
+status="${1:-0}"
+
+# A status that is not a number is a caller bug, and claiming success would be
+# the worse failure of the two, so treat it as a failure.
+[[ $status =~ ^[0-9]+$ ]] || status=1
 
 # The device node is there whether or not a terminal is behind it, so opening
 # it is the only test that means anything.
@@ -13,6 +23,10 @@ while read -rsn 1 -t 0.1 _ </dev/tty; do :; done
 
 # Prompt on the terminal rather than stdout, or a caller that redirects us
 # leaves the user waiting on a prompt they were never shown.
-printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+if ((status == 0)); then
+  printf '\n\033[32m● \033[0mDone! Press any key to close...' >/dev/tty
+else
+  printf '\n\033[31m● \033[0mFailed (exit %d). Press any key to close...' "$status" >/dev/tty
+fi
 read -rsn 1 </dev/tty
 echo >/dev/tty

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -304,6 +304,7 @@
   "remove.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","when":"omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-chatgpt"},
   "remove.ai.dictation": {"icon":"","label":"Dictation","when":"omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-remove"},
   "remove.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","when":"omarchy-pkg-present grok-bot","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-grok-bot"},
+  "remove.ai.mlx": {"icon":"4","label":"MLX (Apple GPU)","when":"omarchy-cmd-present mlx-omarchy-demo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-mlx"},
   "remove.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","when":"omarchy-pkg-present lmstudio-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-lm-studio"},
   "remove.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","when":"omarchy-pkg-present ollama","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-ollama"},
   "remove.ai.t3-code": {"icon":"","iconFont":"omarchy","label":"T3 Code","when":"omarchy-pkg-present t3code-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-ai-t3-code"},

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -239,6 +239,7 @@
   "install.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","disabled":"omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
   "install.ai.dictation": {"icon":"","label":"Dictation","disabled":"omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"},
   "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","disabled":"omarchy-pkg-present grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
+  "install.ai.mlx": {"icon":"4","label":"MLX (Apple GPU)","description":"Apple MLX on the M1 GPU via Vulkan, with a chat demo","disabled":"omarchy-cmd-present mlx-omarchy-demo","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-mlx"},
   "install.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","disabled":"omarchy-pkg-present lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
   "install.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","disabled":"omarchy-cmd-present ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},
   "install.ai.t3-code": {"icon":"","iconFont":"omarchy","label":"T3 Code","disabled":"omarchy-pkg-present t3code-bin","action":"omarchy-install-and-launch 'T3 Code' t3code-bin t3code"},

--- a/tests/test-ai-mlx-install-guards.sh
+++ b/tests/test-ai-mlx-install-guards.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Checks the failure contracts of the MLX menu entry: it must not install over an
+# existing installation, and when an install fails it must say what it actually
+# cleaned up.
+#
+# The entry's failure path runs the upstream installer's --uninstall, which
+# deletes every artifact unconditionally. Without the guard, a failed install
+# over a working one removes the working one.
+#
+# Everything here runs against a disposable HOME with stub commands on PATH, so
+# it needs no Apple hardware and installs nothing. The two cases that need the
+# real pinned installer skip themselves when there is no network.
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL="$ROOT/bin/omarchy-install-ai-mlx"
+
+pass() { echo "✓ $*"; }
+skip() { echo "- $* (skipped)"; }
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+echo "=== MLX install guards ==="
+echo "Repo: $ROOT"
+
+[[ -f $INSTALL ]] || fail "the install entry is missing"
+bash -n "$INSTALL" || fail "the install entry does not parse"
+pass "the install entry is present and parses"
+
+work="$(mktemp -d)"
+# $BIN is deliberately made unreadable by one case; restore it or the cleanup
+# of the scratch directory fails too.
+trap 'chmod -R u+rwX -- "$work" 2>/dev/null; rm -rf -- "$work"' EXIT
+
+stub_dir="$work/stubs"
+mkdir -p "$stub_dir"
+
+# The entry gates on Apple hardware first; say yes, and present an M1 device
+# tree, so the paths under test are the ones that run on a real M1.
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/omarchy-hw-apple"
+chmod +x "$stub_dir/omarchy-hw-apple"
+printf 'apple,j313\0apple,t8103\0' >"$work/compatible"
+
+curl_log="$work/curl.log"
+
+# Serves the cached installer instead of the network, honouring -o. Logs every
+# call so a test can prove the entry refused before reaching the network.
+make_curl_stub() {
+  {
+    echo '#!/bin/bash'
+    echo 'printf "%s\n" "$*" >>"$CURL_LOG"'
+    echo 'out=""; prev=""'
+    echo 'for a in "$@"; do [[ $prev == -o ]] && out="$a"; prev="$a"; done'
+    echo '[[ -n $out && -n ${INSTALLER_FIXTURE:-} ]] && cp -- "$INSTALLER_FIXTURE" "$out"'
+    echo 'exit 0'
+  } >"$stub_dir/curl"
+  chmod +x "$stub_dir/curl"
+}
+make_curl_stub
+
+# Runs the entry against the disposable HOME. Echoes its exit status; output is
+# left in $work/out for the caller to inspect.
+run_entry() {
+  local home="$1" prefix="$2"
+  local status=0
+  : >"$curl_log"
+  PATH="$stub_dir:$PATH" \
+    HOME="$home" \
+    MLX_OMARCHY_HOME="$prefix" \
+    OMARCHY_APPLE_COMPATIBLE="$work/compatible" \
+    CURL_LOG="$curl_log" \
+    INSTALLER_FIXTURE="${INSTALLER_FIXTURE:-}" \
+    bash "$INSTALL" >"$work/out" 2>&1 || status=$?
+  echo "$status"
+}
+
+echo
+echo "=== it refuses when an installation already exists ==="
+
+# Each artifact on its own, because the installer's --uninstall deletes all four
+# and any one of them means something is already there.
+i=0
+for artifact in prefix bin-launcher bin-demo desktop-entry; do
+  i=$((i + 1))
+  home="$work/home$i"
+  prefix="$home/.local/share/mlx-omarchy"
+  mkdir -p "$home/.local/bin" "$home/.local/share/applications"
+  case $artifact in
+    prefix) mkdir -p "$prefix" && echo keep >"$prefix/marker" ;;
+    bin-launcher) echo keep >"$home/.local/bin/mlx-omarchy" ;;
+    bin-demo) echo keep >"$home/.local/bin/mlx-omarchy-demo" ;;
+    desktop-entry) echo keep >"$home/.local/share/applications/mlx-omarchy-demo.desktop" ;;
+  esac
+
+  got="$(run_entry "$home" "$prefix")"
+  [[ $got != 0 ]] || fail "$artifact present: the entry should refuse, it exited 0"
+  grep -q "already installed" "$work/out" ||
+    fail "$artifact present: no explanation given: $(cat "$work/out")"
+  grep -q "omarchy-remove-ai-mlx" "$work/out" ||
+    fail "$artifact present: refusal should name how to remove it"
+  [[ ! -s $curl_log ]] ||
+    fail "$artifact present: refused only after fetching the installer: $(cat "$curl_log")"
+
+  # The point of the guard: what was there is still there.
+  case $artifact in
+    prefix) [[ -f "$prefix/marker" ]] || fail "the existing installation was deleted" ;;
+    bin-launcher) [[ -f "$home/.local/bin/mlx-omarchy" ]] || fail "the existing launcher was deleted" ;;
+    bin-demo) [[ -f "$home/.local/bin/mlx-omarchy-demo" ]] || fail "the existing demo launcher was deleted" ;;
+    desktop-entry) [[ -f "$home/.local/share/applications/mlx-omarchy-demo.desktop" ]] || fail "the existing desktop entry was deleted" ;;
+  esac
+  pass "$artifact present: refuses before any change, and keeps it"
+done
+
+echo
+echo "=== a failing install reports its own status ==="
+
+fixture="$work/install.sh"
+ref="$(grep -m1 '^INSTALLER_REF=' "$INSTALL" | cut -d'"' -f2)"
+repo="$(grep -m1 '^INSTALLER_REPO=' "$INSTALL" | cut -d'"' -f2)"
+
+if command -v curl >/dev/null &&
+  /usr/bin/env curl -fsSL --max-time 20 \
+    "https://raw.githubusercontent.com/$repo/$ref/install.sh" -o "$fixture" 2>/dev/null; then
+  pass "fetched the pinned installer (${ref:0:12}) as a fixture"
+  export INSTALLER_FIXTURE="$fixture"
+
+  # The real installer, failing early on its own hardware/interpreter checks
+  # before it writes anything: a partial fresh install.
+  home="$work/home-fail"
+  prefix="$home/.local/share/mlx-omarchy"
+  mkdir -p "$home/.local/bin" "$home/.local/share/applications"
+
+  got="$(run_entry "$home" "$prefix")"
+  [[ $got != 0 ]] || fail "a failing install should not exit 0"
+  grep -q "installation failed (exit $got)" "$work/out" ||
+    fail "the failure message should name the real status: $(cat "$work/out")"
+  if grep -q "installation failed (exit 0)" "$work/out"; then
+    fail "the old bug is back: a real failure reported as exit 0"
+  fi
+  pass "a failing install exits $got and names that status"
+
+  grep -q "Nothing from mlx-omarchy is left installed" "$work/out" ||
+    fail "a successful cleanup should say so: $(cat "$work/out")"
+  [[ ! -e $prefix ]] || fail "cleanup left $prefix behind"
+  pass "cleanup ran and reported a clean machine"
+
+  echo
+  echo "=== a failing cleanup says so ==="
+
+  # Same failing install, but with $HOME/.local/bin unreadable so the
+  # uninstall's own rm cannot complete. The guard still passes because the
+  # artifacts cannot be seen either.
+  home="$work/home-dirty"
+  prefix="$home/.local/share/mlx-omarchy"
+  mkdir -p "$home/.local/bin" "$home/.local/share/applications"
+  chmod 000 "$home/.local/bin"
+
+  got="$(run_entry "$home" "$prefix")"
+  chmod 755 "$home/.local/bin"
+
+  if grep -q "Cleanup did not finish" "$work/out"; then
+    [[ $got != 0 ]] || fail "a failed cleanup should still return the install's status"
+    grep -q "omarchy-remove-ai-mlx" "$work/out" ||
+      fail "a failed cleanup should say how to finish removing it"
+    if grep -q "Nothing from mlx-omarchy is left installed" "$work/out"; then
+      fail "it claimed a clean machine and a failed cleanup at once"
+    fi
+    pass "a failed cleanup is reported instead of claiming nothing remains"
+  else
+    # rm can still succeed here as root, which ignores the mode.
+    if [[ $(id -u) -eq 0 ]]; then
+      skip "running as root, so an unwritable directory does not fail rm"
+    else
+      fail "the failed-cleanup path was not reached: $(cat "$work/out")"
+    fi
+  fi
+else
+  skip "no network for the pinned installer, so the failure paths are not exercised"
+fi
+
+echo
+echo "All MLX install guard checks passed."

--- a/tests/test-presentation-exit-status.sh
+++ b/tests/test-presentation-exit-status.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Checks the exit-status contract of the shared presentation wrapper: the status
+# of the command it runs must reach both the message and the caller.
+#
+# A wrapper that always returns 0 turns every failing menu entry into a green
+# "Done!", which is how an install failure was reported as a success. These
+# checks run anywhere: they evaluate the wrapper's own presentation script with
+# stub commands on PATH, so no terminal, no gum and no Apple hardware needed.
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$ROOT/bin/omarchy-launch-floating-terminal-with-presentation"
+SHOW_DONE="$ROOT/bin/omarchy-show-done"
+
+pass() { echo "✓ $*"; }
+skip() { echo "- $* (skipped)"; }
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+echo "=== presentation wrapper exit status ==="
+echo "Repo: $ROOT"
+
+[[ -f $WRAPPER ]] || fail "the wrapper is missing"
+[[ -f $SHOW_DONE ]] || fail "omarchy-show-done is missing"
+bash -n "$WRAPPER" || fail "the wrapper does not parse"
+bash -n "$SHOW_DONE" || fail "omarchy-show-done does not parse"
+pass "both scripts are present and parse"
+
+# The wrapper execs a terminal, so what is under test is the presentation script
+# it builds. Take that line from the file and evaluate it exactly as written.
+script_line="$(grep -m1 '^presentation_script=' "$WRAPPER")" ||
+  fail "no presentation_script assignment in the wrapper"
+
+stub_dir="$(mktemp -d)"
+log="$stub_dir/show-done.log"
+trap 'rm -rf -- "$stub_dir"' EXIT
+
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/omarchy-show-logo"
+# Records its argument so the test can tell "called with 37" from "called with
+# nothing", which is the difference between a real report and the old bug.
+{
+  echo '#!/bin/bash'
+  echo 'printf "%s\n" "${1-<no-argument>}" >>"$SHOW_DONE_LOG"'
+} >"$stub_dir/omarchy-show-done"
+chmod +x "$stub_dir/omarchy-show-logo" "$stub_dir/omarchy-show-done"
+
+# Runs the wrapper's presentation script with a command that exits $1.
+# Echoes the status it returned; the show-done log is left for the caller.
+run_case() {
+  local code="$1"
+  : >"$log"
+  printf '#!/bin/bash\nexit %d\n' "$code" >"$stub_dir/fake-cmd"
+  chmod +x "$stub_dir/fake-cmd"
+  local status=0
+  PATH="$stub_dir:$PATH" SHOW_DONE_LOG="$log" cmd="fake-cmd" \
+    bash -c "$script_line"'; bash -c "$presentation_script"' >/dev/null 2>&1 || status=$?
+  echo "$status"
+}
+
+echo
+echo "=== the caller gets the command's status ==="
+
+for code in 0 1 2 37; do
+  got="$(run_case "$code")"
+  [[ $got == "$code" ]] ||
+    fail "a command exiting $code left the wrapper returning $got"
+  pass "exit $code propagates"
+done
+
+echo
+echo "=== the message matches the status ==="
+
+run_case 0 >/dev/null
+[[ "$(cat "$log")" == "0" ]] ||
+  fail "success should call omarchy-show-done with 0, got: $(cat "$log")"
+pass "success reports 0 to omarchy-show-done"
+
+run_case 37 >/dev/null
+[[ "$(cat "$log")" == "37" ]] ||
+  fail "a failure should report its real status, got: $(cat "$log")"
+pass "failure reports 37, not an empty or zero status"
+
+echo
+echo "=== cancellation ==="
+
+got="$(run_case 130)"
+[[ $got == 130 ]] || fail "cancellation should return 130, got $got"
+[[ ! -s $log ]] || fail "cancellation should show no message, logged: $(cat "$log")"
+pass "130 returns 130 and shows no message"
+
+echo
+echo "=== omarchy-show-done argument handling ==="
+
+# The existing callers (omarchy-pkg-install, omarchy-pkg-aur-install,
+# omarchy-pkg-remove) pass nothing, so no argument must still mean success.
+grep -q 'status="${1:-0}"' "$SHOW_DONE" ||
+  fail "omarchy-show-done should default a missing status to 0"
+pass "a missing status defaults to 0, keeping the no-argument callers working"
+
+for caller in omarchy-pkg-install omarchy-pkg-aur-install omarchy-pkg-remove; do
+  [[ -f "$ROOT/bin/$caller" ]] || continue
+  bash -n "$ROOT/bin/$caller" || fail "$caller does not parse"
+  pass "$caller still parses against the new signature"
+done
+
+if command -v script >/dev/null && command -v timeout >/dev/null; then
+  # omarchy-show-done reads the keypress from /dev/tty, so the input has to go
+  # to the pty rather than the pipeline. It also drains queued input first, so
+  # a key sent immediately gets swallowed and the read then waits forever:
+  # hence the delay. timeout keeps a hang from stalling the suite.
+  on_tty() {
+    (
+      sleep 0.4
+      printf 'x'
+    ) | timeout 10 script -qec "$*" /dev/null 2>/dev/null | tr -d '\r'
+  }
+
+  out="$(on_tty "$SHOW_DONE")" || true
+  case $out in
+    *Done!*) pass "no argument shows the success message on a terminal" ;;
+    *) fail "no argument should show Done!, got: $out" ;;
+  esac
+
+  out="$(on_tty "$SHOW_DONE 37")" || true
+  case $out in
+    *"Failed (exit 37)"*) pass "a status of 37 shows a failure message naming it" ;;
+    *) fail "status 37 should show Failed (exit 37), got: $out" ;;
+  esac
+
+  out="$(on_tty "$SHOW_DONE not-a-number")" || true
+  case $out in
+    *Failed*) pass "a non-numeric status is treated as a failure, not a success" ;;
+    *) fail "a non-numeric status should not claim success, got: $out" ;;
+  esac
+else
+  skip "no script(1) or timeout(1), so the on-terminal messages are not exercised here"
+fi
+
+echo
+echo "All presentation exit-status checks passed."


### PR DESCRIPTION
Adds an **Install > AI > MLX (Apple GPU)** entry and `bin/omarchy-install-ai-mlx`.

[mlx-omarchy](https://github.com/joshuaswarren/mlx-omarchy) is Apple's MLX array framework running on the Apple GPU under Linux through Mesa's Honeykrisp Vulkan driver, with a chat demo (`mlx-omarchy-demo`, also registered in the launcher as "MLX Chat (Apple GPU)"). Demo video and install walkthrough are in that repo's README.

What the install script does:
- runs the upstream installer (`curl -fsSL .../install.sh | bash`), which installs the verified release wheel into a private venv under `~/.local/share/mlx-omarchy`, adds two launchers to `~/.local/bin`, one `.desktop` entry, and calls `omarchy-menu refresh`;
- installs `lapack` and `blas` through `omarchy-pkg-add`;
- touches nothing else: no Mesa replacement, no Hyprland or Omarchy config edits; `bash install.sh --uninstall` removes it all;
- skips with a message on non-aarch64.

Verified on an M1 MacBook Air running Omarchy 4.0.1rc2 with the stock asahi-alarm Mesa 26.1.7 (out-of-box install, demo, launcher entry). The M3 is not supported yet: on the current Omarchy Mac kernel no Apple GPU is exposed to Vulkan there, and the installer's smoke test reports that instead of falling back to the CPU.

Menu row follows the existing `install.ai.*` entries (`disabled` when `mlx-omarchy-demo` is present; action runs in the floating presentation terminal).