### PR TITLE
Require Snapper for Mac installs and report setup failures

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -90,6 +90,20 @@ strip_limine_dependencies() {
   done
 }
 
+# Limine's snapshot integration normally pulls in Snapper transitively. Macs
+# still need Snapper for btrfs setup and snapshots after dropping that stack,
+# so make it a hard dependency rather than a best-effort default package.
+ensure_snapper_dependency() {
+  local pkgbuild="$1"
+
+  grep -qx 'depends=(' "$pkgbuild" ||
+    fail "omarchy PKGBUILD no longer has the expected depends array: $pkgbuild"
+  if ! sed -n '/^depends=(/,/^)/p' "$pkgbuild" |
+    grep -qE "^[[:space:]]*['\"]snapper([<>=][^'\"]*)?['\"]([[:space:]]|$)"; then
+    sed -i "/^depends=(/a\\  'snapper'" "$pkgbuild"
+  fi
+}
+
 # Upstream's package() deletes /etc/mkinitcpio.conf.d wholesale on aarch64,
 # reasoning that omarchy_hooks.conf is the x86 file that would inject the
 # Limine hooks into an Asahi initramfs. That is true of upstream's copy and
@@ -169,6 +183,7 @@ build_package() {
 
   if [[ $package == "omarchy" ]]; then
     strip_limine_dependencies "$build_dir/$package/PKGBUILD"
+    ensure_snapper_dependency "$build_dir/$package/PKGBUILD"
   fi
   if [[ $package == "omarchy-settings" ]]; then
     keep_apple_silicon_mkinitcpio_drop_ins "$build_dir/$package/PKGBUILD"

--- a/install/helpers/logging.sh
+++ b/install/helpers/logging.sh
@@ -71,6 +71,10 @@ run_logged() {
     omarchy_log_line "[$(date '+%Y-%m-%d %H:%M:%S')] Completed: $script"
   else
     omarchy_log_line "[$(date '+%Y-%m-%d %H:%M:%S')] Failed: $script (exit code: $exit_code)"
+    if ! omarchy_log_to_stdout; then
+      printf 'Error: setup failed in %s (exit code: %s). See %s for details.\n' \
+        "$script" "$exit_code" "$OMARCHY_INSTALL_LOG_FILE" >&2
+    fi
   fi
 
   return $exit_code

--- a/test/shell.d/clipboard-test.sh
+++ b/test/shell.d/clipboard-test.sh
@@ -438,9 +438,10 @@ pass "clipboard reaper pattern matches running watchers"
 
 watch_owner="$clipboard_lifecycle_dir/watch-owner.sh"
 watch_pid_file="$clipboard_lifecycle_dir/watch.pid"
+watch_log_file="$clipboard_lifecycle_dir/watch.log"
 cat >"$watch_owner" <<SH
 #!/bin/bash
-PATH="$TMPDIR/bin:\$PATH" setpriv --pdeathsig TERM wl-paste --type text --watch "$current_script" text &
+WL_PASTE_LOG="$watch_log_file" PATH="$TMPDIR/bin:\$PATH" setpriv --pdeathsig TERM wl-paste --type text --watch "$current_script" text &
 printf '%s\n' "\$!" >"$watch_pid_file"
 wait
 SH
@@ -458,6 +459,14 @@ done
 watch_pid=$(<"$watch_pid_file")
 [[ -n $watch_pid ]] && process_alive "$watch_pid" || fail "clipboard watcher starts under setpriv"
 PIDS_TO_KILL+=("$watch_pid")
+
+# The parent can publish the PID before setpriv installs the death signal.
+# Wait for wl-paste itself to start before terminating its owner.
+for _ in {1..40}; do
+  [[ -s $watch_log_file ]] && break
+  sleep 0.1
+done
+[[ -s $watch_log_file ]] && process_alive "$watch_pid" || fail "clipboard watcher is ready under setpriv"
 
 kill "$owner_pid" 2>/dev/null || true
 process_gone "$watch_pid" || fail "clipboard watcher dies with its owner via pdeathsig"

--- a/test/shell.d/install-mac-snapper-dependency-test.sh
+++ b/test/shell.d/install-mac-snapper-dependency-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+# Exercise the actual build path with a harmless makepkg substitute that
+# evaluates dependencies from the patched PKGBUILD as makepkg would.
+for dependency in absent snapper 'snapper>=0.12'; do
+  case_dir="$work_dir/${dependency//[>=]/_}"
+  mkdir -p "$case_dir/source/omarchy" "$case_dir/build" "$case_dir/output"
+  cat >"$case_dir/source/omarchy/PKGBUILD" <<'PKGBUILD'
+pkgrel=1
+depends=(
+  'gum'
+  'limine'
+  'limine-mkinitcpio-hook'
+  'limine-snapper-sync'
+)
+optdepends=('snapper: optional snapshots')
+PKGBUILD
+  if [[ $dependency != "absent" ]]; then
+    sed -i "/^depends=(/a\\  '$dependency' # Existing upstream requirement" "$case_dir/source/omarchy/PKGBUILD"
+  fi
+  cp "$case_dir/source/omarchy/PKGBUILD" "$case_dir/original"
+
+  (
+    export OMARCHY_PACKAGE_OUTPUT="$case_dir/output"
+    unset OMARCHY_PKGREL
+    source "$ROOT/build-packages.sh"
+    makepkg() {
+      source ./PKGBUILD
+      printf '%s\n' "${depends[@]}" >omarchy.pkg.tar.zst
+    }
+    build_package omarchy "$case_dir/source" "$case_dir/build"
+    cp "$case_dir/build/omarchy/PKGBUILD" "$case_dir/once"
+    ensure_snapper_dependency "$case_dir/build/omarchy/PKGBUILD"
+    cmp "$case_dir/once" "$case_dir/build/omarchy/PKGBUILD"
+  )
+
+  expected_dependency=$dependency
+  [[ $dependency != "absent" ]] || expected_dependency=snapper
+  expected=$(printf '%s\n' gum "$expected_dependency" | sort)
+  actual=$(sort "$case_dir/output/omarchy.pkg.tar.zst")
+  [[ $actual == "$expected" ]] ||
+    fail "Mac build requires Snapper exactly once and preserves other dependencies ($dependency)" "$actual"
+  cmp "$case_dir/original" "$case_dir/source/omarchy/PKGBUILD" ||
+    fail "Mac build leaves the upstream source PKGBUILD untouched"
+  pass "Mac build requires Snapper without Limine and remains idempotent ($dependency)"
+done

--- a/test/shell.d/logging-test.sh
+++ b/test/shell.d/logging-test.sh
@@ -9,6 +9,8 @@ trap 'rm -rf "$work_dir"' EXIT
 
 failing_script="$work_dir/fail.sh"
 log_file="$work_dir/install.log"
+console_file="$work_dir/console.log"
+unset OMARCHY_LOG_TO_STDOUT
 cat >"$failing_script" <<'SCRIPT'
 echo "about to fail"
 false
@@ -21,14 +23,16 @@ set +e
   source "$ROOT/install/helpers/logging.sh"
   run_logged "$failing_script"
   echo "unreachable"
-)
+) >"$console_file" 2>&1
 status=$?
 set -e
 
-(( status != 0 )) || fail "run_logged returns failing script status"
+(( status == 1 )) || fail "run_logged returns failing script status"
 grep -q "Starting: $failing_script" "$log_file" || fail "run_logged logs script start"
 grep -q "about to fail" "$log_file" || fail "run_logged captures script output"
 grep -q "Failed: $failing_script (exit code: 1)" "$log_file" || fail "run_logged logs failed script before errexit exits"
+[[ $(cat "$console_file") == "Error: setup failed in $failing_script (exit code: 1). See $log_file for details." ]] ||
+  fail "file logging identifies the failed script, status, and log path on the console"
 
 stdout_log="$work_dir/stdout.log"
 set +e
@@ -42,10 +46,52 @@ set +e
 stdout_status=$?
 set -e
 
-(( stdout_status != 0 )) || fail "stdout run_logged returns failing script status"
+(( stdout_status == 1 )) || fail "stdout run_logged returns failing script status"
 [[ ! -e $work_dir/iso-owned.log ]] || fail "stdout logging mode does not write directly to install log"
 grep -q "Starting: $failing_script" "$stdout_log" || fail "stdout logging mode emits script start"
 grep -q "about to fail" "$stdout_log" || fail "stdout logging mode emits script output"
 grep -q "Failed: $failing_script (exit code: 1)" "$stdout_log" || fail "stdout logging mode emits failure marker"
+if grep -q 'Error: setup failed' "$stdout_log"; then
+  fail "stdout logging mode does not duplicate its failure report"
+fi
 
 pass "run_logged records failures under errexit"
+
+# Reproduce the silent exit 127 from a missing setup command without running
+# any real system setup. Its shell diagnostic stays in the log, while the
+# console identifies the failed leaf and points to the details.
+cat >"$failing_script" <<SCRIPT
+"$work_dir/missing-setup-command"
+echo "unreachable"
+SCRIPT
+
+set +e
+(
+  set -euo pipefail
+  export OMARCHY_INSTALL_LOG_FILE="$log_file"
+  source "$ROOT/install/helpers/logging.sh"
+  run_logged "$failing_script"
+  echo "unreachable"
+) >"$console_file" 2>&1
+status=$?
+set -e
+
+(( status == 127 )) || fail "run_logged preserves missing-command status 127"
+[[ $(cat "$console_file") == "Error: setup failed in $failing_script (exit code: 127). See $log_file for details." ]] ||
+  fail "a missing setup command reports its failed leaf and log path"
+grep -qF "$work_dir/missing-setup-command" "$log_file" || fail "the log retains the original shell diagnostic"
+if grep -q 'unreachable' "$log_file" "$console_file"; then
+  fail "a missing setup command stops both the leaf and setup caller"
+fi
+pass "a missing setup command is visible on the console and keeps exit 127"
+
+printf 'echo "successful setup output"\n' >"$work_dir/success.sh"
+(
+  set -euo pipefail
+  export OMARCHY_INSTALL_LOG_FILE="$log_file"
+  source "$ROOT/install/helpers/logging.sh"
+  run_logged "$work_dir/success.sh"
+) >"$console_file" 2>&1
+[[ ! -s $console_file ]] || fail "successful file logging stays quiet on the console"
+grep -qF "Completed: $work_dir/success.sh" "$log_file" || fail "successful setup still records completion"
+pass "successful file logging stays quiet"


### PR DESCRIPTION
Fresh Apple Silicon installs can reach `install/config/snapper.sh` without Snapper installed and abort with exit 127. Removing the Limine stack also removes the dependency path that previously supplied Snapper.

Make Snapper an explicit runtime dependency in the Mac-built Omarchy package before `makepkg` runs. Preserve an existing Snapper version constraint and leave the upstream PKGBUILD untouched. When a setup leaf fails with file logging enabled, print its path, exit status, and log location on stderr so the installer no longer ends with an unexplained status alone.

Validation:

- Regression tests exercise the real package-build path with stubbed packaging for missing, existing, and versioned Snapper dependencies, including repeat application and preservation of the source PKGBUILD.
- Logging tests cover exit codes 1 and 127, stopping execution, quiet success, and stdout mode without duplicate diagnostics.
- Installer tests, command metadata, shell syntax, and review passed.
- Local full suite: CLI passed; 265 of 266 shell tests passed. The unchanged network QR test failed because the sandbox rejects its unmocked netlink socket request. Test environment used a private runtime directory, the existing package checkout, and normalized color and Git-signing settings.

Already-failed installs can recover by installing `snapper` and rerunning setup with `--resume`. Republishing an existing package version needs a package-release bump because installation uses `--needed`.

The clipboard lifecycle fixture also waits for the fake watcher to report startup before terminating its parent. This removes a CI race where the parent could exit before `setpriv` installed the parent-death signal. A delayed-start reproduction passes with the fix; a negative control without `--pdeathsig` still fails the original lifecycle assertion.

GitHub validation on `bc8f108f2`: [CI passed](https://github.com/omacom/omarchy-mac/actions/runs/34476118246), including `test/all`, `tests/all`, and syntax/shellcheck. The separate ARM installation workflow is still running.
