### PR TITLE
fix(asahi): add experimental HDMI reconnect recovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,19 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/bin:$PATH"
           ./test/all
 
+  asahi-reconnect:
+    name: Asahi HDMI source + C seam
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check pinned patch and RED/GREEN regressions
+        run: python3 test/asahi/reconnect.py
+
   mac:
     name: tests/all
     runs-on: ubuntu-24.04

--- a/docs/asahi-hdmi-reconnect.md
+++ b/docs/asahi-hdmi-reconnect.md
@@ -1,0 +1,88 @@
+# Experimental Asahi HDMI reconnect recovery
+
+This is an opt-in downstream kernel candidate for Omarchy Mac, not an installer migration or a replacement for the distributed `linux-asahi` package. The functional patch is under [`patches/asahi/`](../patches/asahi/apple-dcp-hdmi-reconnect.patch). It is pinned to [AsahiLinux/linux `ce9f2eba72c061a50b2d790450e90af3439d8c24`](https://github.com/AsahiLinux/linux/commit/ce9f2eba72c061a50b2d790450e90af3439d8c24); do not apply it blindly to another revision. It does not implement USB-C DisplayPort support or M3 enablement.
+
+## Failure and repair
+
+On the affected HDMI/DP2HDMI path, disconnect can power down firmware and invalidate the mode while DRM still considers the CRTC active. The diagnostic first reconnect submitted with `active=1`, `active_changed=0`, `mode_changed=0`, and `valid_mode=0`. Firmware swallowed swap 3339 and DRM subsequently timed out. The unplug event associated with swap 3338 **was delivered** through synthetic vblank; the trace does not support blaming that old event for the reconnect stall.
+
+The patch introduces an HDMI disconnect generation, requests a real modeset before `drm_atomic_helper_check`, and performs recovery power-on before programming the mode even when DRM active state did not change. It propagates power-on allocation/timeout failures and consumes only the captured generation after successful power/mode completion. A newer disconnect remains pending. A flush-time guard withholds a swap while recovery is pending, using the driver's existing owned-event/synthetic-vblank path. TEST_ONLY does not perform firmware IO or consume recovery, and the patch does not fabricate `active_changed`, shorten DRM timeouts, or directly complete DRM completions.
+
+This is not full serialization of hotplug and asynchronous submission. See the open validation items below.
+
+## Reproducible source and seam tests
+
+Run from an Omarchy Mac checkout with Python 3, Git, a C11 compiler named `cc`, and HTTPS access:
+
+```bash
+python3 test/asahi/reconnect.py
+bash test/shell.d/asahi-hdmi-reconnect-test.sh
+```
+
+The first command downloads only the seven affected source files at the pinned commit, verifies their SHA-256 manifest, applies the exact patch in a temporary Git repository, and runs the source invariants and extracted-C seam. With a local kernel repository containing the commit, use `python3 test/asahi/reconnect.py --source /absolute/path/to/linux` to avoid downloads. It reads baseline Git blobs, not that repository's working files, and never modifies the supplied source. Baseline must compile and report exactly 11 failed seam assertions; patched code must report zero failures and pass both source tests. Compiler/download failures are not accepted as a RED result.
+
+The C seam executes extracted driver functions but mocks DRM, firmware, atomics, and workqueues. It covers unchanged-active reconnect, modeset permission, no firmware IO during check, power/mode errors, a newer generation during mode ACK, flush withholding, disconnected recovery, and exclusion of non-HDMI displays. It does not model concurrency, firmware, full DRM transactions, framebuffer lifetimes, or actual vblank delivery. CI runs this separately from `test/all`; the offline build-contract test is picked up by `test/shell`.
+
+## Opt-in build integration
+
+There is no kernel package recipe on the current `quattro` branch to modify in place. The supplied build-only wrapper and package recipe deliberately remain outside the normal installer/update path. They never run package installation, modify GRUB, or reboot.
+
+Use a native aarch64 Arch/Asahi build host as an unprivileged user, with the toolchain and build dependencies required by the pinned Asahi kernel (including its matching Rust toolchain when enabled), `makepkg`, Python 3, Git, `cc`, `bsdtar`, and `zstd` already available. Export the toolchain's PATH before invoking the wrapper. Supply a known-good Asahi kernel configuration separately; no generic defconfig or personal configuration is silently substituted.
+
+```bash
+git clone --no-checkout https://github.com/AsahiLinux/linux.git linux-hdmi-reconnect
+git -C linux-hdmi-reconnect checkout --detach ce9f2eba72c061a50b2d790450e90af3439d8c24
+bash patches/asahi/build-hdmi-reconnect.sh \
+  "$PWD/linux-hdmi-reconnect" \
+  /absolute/path/to/known-good-asahi.config \
+  "$PWD/hdmi-reconnect-package"
+```
+
+Source must be a fresh, clean, disposable checkout and the output directory must not exist. The wrapper modifies only that source and creates the requested output. After a failed build, preserve logs and start with a fresh checkout rather than applying the patch again. The wrapper runs RED/GREEN gates, verifies patch applicability, sets the unique local version, prepares and checks the effective release, compiles all five affected translation units, then builds `Image modules dtbs` and packages the result. Its package recipe is for these explicitly built artifacts, not a standalone source-fetching PKGBUILD. Capture build output with your usual logging mechanism.
+
+The package is `linux-asahi-hdmi-recover`, with release `7.1.13-1-1-ARCH-hdmi-recover`; it neither conflicts with nor replaces stock. The archive contains the release-scoped Image, modules, module metadata, `pkgbase`, and Apple DTBs in the stock flat `dtbs/` layout. `validate-package.py` checks compression, package identity, release isolation, required assets, and writes `validation.json` and `SHA256SUMS` in the output directory. Those reports describe the newly built package; `hardware_verified=false` is intentional because building a package cannot validate its boot or display behavior.
+
+The exact functional patch and the equivalent machine-specific build/package sequence were exercised on the hardware below. The generalized wrapper added here has syntax/contract coverage but has **not** itself completed another full native build. A fresh build with this wrapper is an outstanding draft-PR gate. No prebuilt package is distributed by this change.
+
+## Hardware evidence (limited, curated)
+
+The test host reports **Apple MacBook Pro (16-inch, M2 Pro, 2023)**. It booted `7.1.13-1-1-ARCH-hdmi-recover`. The user confirmed a visible image on first connection and on **three complete unplug/replug cycles**, without restarting the compositor/session as a recovery step. The observed external mode was 2560×1440 at 75 Hz. This is one host and display configuration, not a general Apple Silicon compatibility claim.
+
+The retained first-connect and all six disconnect/reconnect kernel captures were checked for `flip_done timed out`, `commit wait timed out`, `Oops:`, `BUG:`, and `Kernel panic`: zero matches in each cumulative capture through the third reconnect. The captures show disconnect callbacks and fresh power-on completion followed by mode completion on reconnect. A swallowed-swap message during the initial boot external-display power-off was already present in the baseline; it was not a new hotplug-test failure. Do not describe the entire boot as containing no swallowed swaps.
+
+Sanitized third-reconnect sequence (monotonic seconds; host names, device addresses, pointers, and private paths omitted):
+
+```text
+809.207597  cb_hotplug() connected:1, valid_mode:0
+809.221237  dcp_poweron() starting
+809.221430  dcp_set_power_state_req returned, 10000 ms remaining
+809.221521  set_digital_out_mode: 2560x1440 at 75 Hz [mode line summarized]
+809.444019  set_digital_out_mode finished:8277
+```
+
+The pre-install build record reports successful compilation of `apple_drv.o`, `dcp.o`, `iomfb.o`, `iomfb_v12_3.o`, and `iomfb_v13_3.o`, followed by the full Image/modules/DTB build. Archive validation recorded 1,862 kernel modules and 110 Apple DTBs, successful zstd integrity, and Image/appledrm correspondence to built artifacts. These are historical validation results, not a new build on the PR preparation host.
+
+- Exact included patch SHA-256: `dbf332ead80ad84d5fb681fe83fc92c89cb88e0d4e416142acbb80565aacedcf`
+- Tested package SHA-256: `25f9294be649e9731363e122a685b5ee1fbebf0e5d1fdcc29788e66c671a1938`
+- Tested Image SHA-256: `3cc1ce2a017910a6bf72d0efa1293808ff763faa3f2813046e1604aa405cf8aa`
+
+Raw journals and machine-specific scripts are deliberately not committed because they contain pointer addresses and private paths. The original pre-install validation file says hardware was unverified at build time; the later physical observations above are separate evidence, not a retroactive change to that file.
+
+## Safe installation and rollback validation
+
+Installation is a separate, deliberate hardware-test action, not something these scripts perform. Before any installation, save work, keep remote recovery available, retain stock `linux-asahi`, and budget `/boot` space for both candidate Image and a complete initramfs. Never remove the running kernel or stock fallback to make room. Verify the package checksum and contents first.
+
+After an authorized side-by-side installation, parse the candidate initramfs with `lsinitcpio`, not just a size/existence check. Resolve the exact stock and candidate entry IDs from the generated GRUB configuration. Preserve stock as the persistent saved default and select the candidate only for one boot (or use its explicit advanced-menu entry with save-default disabled). Do not assume menu index zero is stock after adding a kernel. Read back the GRUB environment and verify the actual running release after boot.
+
+For rollback, select the verified stock advanced-menu entry and boot it; confirm `uname -r` reports stock, the graphical session works, and the saved default remains stock. Only then consider removing the inactive candidate package via the normal Omarchy package removal path. Never remove a candidate while it is running. On the tested host both stock and candidate packages remain installed and `saved_entry` names stock; **a post-fix reboot back to stock has not yet been performed**, so rollback bootability remains a required validation item rather than a claimed pass. Preparing this PR did not install packages, alter GRUB, or reboot the host.
+
+## Remaining gates before promotion
+
+- Perform an ordinary reboot back to stock and verify the graphical session and saved default.
+- Complete a fresh native build/package using the generalized wrapper in this PR.
+- Review and stress the gap between the flush generation check and asynchronous firmware swap submission; the generation check is not a lock around submission.
+- Exercise shared synthetic-vblank work-item coalescing, real callback ordering/event ownership, and framebuffer lifetimes under rapid hotplug. The seam's synchronous mocks cannot establish these properties.
+- Verify compositor liveness when a disconnect after atomic check causes a withheld swap; recovery depends on a subsequent commit permitting modesets.
+- Expand coverage to additional monitors/modes, suspend/resume, repeated sessions, and other supported HDMI hardware/firmware. Both firmware translation units compiled; that is not hardware validation of both firmware versions.
+
+Stop testing on a black reconnect, compositor freeze, firmware/DRM timeout, or crash; preserve the journal before another transition. Three successful cycles support opening this as an experimental draft, not a universal fix or a completed stress/rollback acceptance campaign.

--- a/patches/asahi/PKGBUILD
+++ b/patches/asahi/PKGBUILD
@@ -1,0 +1,22 @@
+pkgname=linux-asahi-hdmi-recover
+pkgver=7.1.13.asahi1
+pkgrel=1
+pkgdesc='Asahi HDMI reconnect recovery candidate (experimental, opt-in)'
+arch=('aarch64')
+url='https://github.com/AsahiLinux/linux'
+license=('GPL-2.0-only')
+depends=('coreutils' 'kmod' 'initramfs' 'm1n1>=1.6.1')
+options=('!strip' '!debug')
+PKGEXT='.pkg.tar.zst'
+COMPRESSZST=(zstd -c -T4 -8 -)
+package() {
+  local kernel_src="${ASAHI_KERNEL_SOURCE:?Run patches/asahi/build-hdmi-reconnect.sh}"
+  local kernel_release
+  kernel_release=$(make -s -C "$kernel_src" LOCALVERSION= kernelrelease)
+  [[ $kernel_release == '7.1.13-1-1-ARCH-hdmi-recover' ]] || return 1
+  make -C "$kernel_src" LOCALVERSION= modules_install INSTALL_MOD_PATH="$pkgdir/usr"
+  install -Dm644 "$kernel_src/arch/arm64/boot/Image" "$pkgdir/usr/lib/modules/$kernel_release/vmlinuz"
+  printf '%s\n' "$pkgname" > "$pkgdir/usr/lib/modules/$kernel_release/pkgbase"
+  install -d "$pkgdir/usr/lib/modules/$kernel_release/dtbs"
+  install -m644 "$kernel_src"/arch/arm64/boot/dts/apple/*.dtb "$pkgdir/usr/lib/modules/$kernel_release/dtbs/"
+}

--- a/patches/asahi/apple-dcp-hdmi-reconnect.patch
+++ b/patches/asahi/apple-dcp-hdmi-reconnect.patch
@@ -1,0 +1,262 @@
+diff --git a/drivers/gpu/drm/apple/apple_drv.c b/drivers/gpu/drm/apple/apple_drv.c
+index 17b5903..4926b87 100644
+--- a/drivers/gpu/drm/apple/apple_drv.c
++++ b/drivers/gpu/drm/apple/apple_drv.c
+@@ -106,9 +106,11 @@ static void apple_crtc_atomic_enable(struct drm_crtc *crtc,
+ 	struct drm_crtc_state *crtc_state;
+ 	crtc_state = drm_atomic_get_new_crtc_state(state, crtc);
+ 
+-	if (crtc_state->active_changed && crtc_state->active) {
++	if (crtc_state->active_changed && crtc_state->active &&
++	    !dcp_needs_recovery(to_apple_crtc(crtc)->dcp)) {
+ 		struct apple_crtc *apple_crtc = to_apple_crtc(crtc);
+-		dcp_poweron(apple_crtc->dcp);
++		if (dcp_poweron(apple_crtc->dcp))
++			return;
+ 		/* Force the CTM to be set on first swap */
+ 		crtc_state->color_mgmt_changed = true;
+ 	}
+@@ -223,8 +225,27 @@ static const struct drm_crtc_funcs apple_crtc_funcs = {
+ 
+ };
+ 
++static int apple_atomic_check(struct drm_device *dev,
++			      struct drm_atomic_state *state)
++{
++	struct drm_crtc *crtc;
++	struct drm_crtc_state *crtc_state;
++	int i;
++
++	/* Set this before check_modeset so allow_modeset and all affected
++	 * connectors/planes are checked. TEST_ONLY never consumes recovery.
++	 */
++	for_each_new_crtc_in_state(state, crtc, crtc_state, i) {
++		if (crtc_state->active &&
++		    dcp_needs_recovery(to_apple_crtc(crtc)->dcp))
++			crtc_state->mode_changed = true;
++	}
++
++	return drm_atomic_helper_check(dev, state);
++}
++
+ static const struct drm_mode_config_funcs apple_mode_config_funcs = {
+-	.atomic_check		= drm_atomic_helper_check,
++	.atomic_check		= apple_atomic_check,
+ 	.atomic_commit		= drm_atomic_helper_commit,
+ 	.fb_create		= drm_gem_fb_create,
+ };
+diff --git a/drivers/gpu/drm/apple/dcp-internal.h b/drivers/gpu/drm/apple/dcp-internal.h
+index 5783248..d49a539 100644
+--- a/drivers/gpu/drm/apple/dcp-internal.h
++++ b/drivers/gpu/drm/apple/dcp-internal.h
+@@ -187,6 +187,11 @@ struct apple_dcp {
+ 	/* Current display mode */
+ 	bool during_modeset;
+ 	bool valid_mode;
++	/* HDMI disconnect generation; recovery is consumed only after mode ACK.
++	 * IRQ/RTKit increment the generation; the CRTC commit tail owns recovered.
++	 */
++	atomic_t hdmi_generation;
++	int hdmi_recovered;
+ 	bool use_timestamps;
+ 	struct dcp_set_digital_out_mode_req mode;
+ 
+diff --git a/drivers/gpu/drm/apple/dcp.c b/drivers/gpu/drm/apple/dcp.c
+index ddd413f..1db7f52 100644
+--- a/drivers/gpu/drm/apple/dcp.c
++++ b/drivers/gpu/drm/apple/dcp.c
+@@ -327,6 +327,14 @@ void dcp_send_message(struct apple_dcp *dcp, u8 endpoint, u64 message)
+ 				 true);
+ }
+ 
++bool dcp_needs_recovery(struct platform_device *pdev)
++{
++	struct apple_dcp *dcp = platform_get_drvdata(pdev);
++
++	return dcp->hdmi_hpd &&
++		atomic_read(&dcp->hdmi_generation) != READ_ONCE(dcp->hdmi_recovered);
++}
++
+ int dcp_crtc_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state)
+ {
+ 	struct platform_device *pdev = to_apple_crtc(crtc)->dcp;
+@@ -463,6 +471,9 @@ static irqreturn_t dcp_dp2hdmi_hpd(int irq, void *data)
+ 	 * IRQs might be helpful for debugging.
+ 	 */
+ 	dev_info(dcp->dev, "DP2HDMI HPD irq, connected:%d\n", connected);
++	/* Invalidate even if firmware gates its callback during a modeset. */
++	if (!connected)
++		atomic_inc(&dcp->hdmi_generation);
+ 
+ 	if (connected) {
+ 		msleep(500);
+@@ -646,9 +657,10 @@ static void __maybe_unused dcp_sleep(struct apple_dcp *dcp)
+ 	}
+ }
+ 
+-void dcp_poweron(struct platform_device *pdev)
++int dcp_poweron(struct platform_device *pdev)
+ {
+ 	struct apple_dcp *dcp = platform_get_drvdata(pdev);
++	int ret;
+ 
+ 	if (dcp->hdmi_hpd) {
+ 		bool connected = gpiod_get_value_cansleep(dcp->hdmi_hpd);
+@@ -660,18 +672,21 @@ void dcp_poweron(struct platform_device *pdev)
+ 
+ 	switch (dcp->fw_compat) {
+ 	case DCP_FIRMWARE_V_12_3:
+-		iomfb_poweron_v12_3(dcp);
++		ret = iomfb_poweron_v12_3(dcp);
+ 		break;
+ 	case DCP_FIRMWARE_V_13_5:
+-		iomfb_poweron_v13_3(dcp);
++		ret = iomfb_poweron_v13_3(dcp);
+ 		break;
+ 	default:
+ 		WARN_ONCE(true, "Unexpected firmware version: %u\n", dcp->fw_compat);
+-		break;
++		return -EINVAL;
+ 	}
+ 
++	if (ret)
++		return ret;
+ 	if (dcp->avep)
+ 		av_service_connect(dcp);
++	return 0;
+ }
+ 
+ void dcp_poweroff(struct platform_device *pdev)
+@@ -996,6 +1011,7 @@ static int dcp_comp_bind(struct device *dev, struct device *main, void *data)
+ 		dev_info(dev, "DCP index:%u dptx target phy: %u dptx die: %u\n",
+ 			 dcp->index, dcp->dptx_phy, dcp->dptx_die);
+ 	mutex_init(&dcp->hpd_mutex);
++	atomic_set(&dcp->hdmi_generation, 0);
+ 
+ 	if (!show_notch)
+ 		ret = of_property_read_u32(dev->of_node, "apple,notch-height",
+diff --git a/drivers/gpu/drm/apple/dcp.h b/drivers/gpu/drm/apple/dcp.h
+index 2b42177..0a1108e 100644
+--- a/drivers/gpu/drm/apple/dcp.h
++++ b/drivers/gpu/drm/apple/dcp.h
+@@ -30,7 +30,8 @@ struct apple_encoder {
+ #define to_apple_encoder(x) container_of(x, struct apple_encoder, base)
+ 
+ void dcp_poweroff(struct platform_device *pdev);
+-void dcp_poweron(struct platform_device *pdev);
++int dcp_poweron(struct platform_device *pdev);
++bool dcp_needs_recovery(struct platform_device *pdev);
+ int dcp_set_crc(struct drm_crtc *crtc, bool enabled);
+ int dcp_crtc_atomic_check(struct drm_crtc *crtc, struct drm_atomic_state *state);
+ int dcp_get_connector_type(struct platform_device *pdev);
+diff --git a/drivers/gpu/drm/apple/iomfb.c b/drivers/gpu/drm/apple/iomfb.c
+index 1d9448f..24d32c0 100644
+--- a/drivers/gpu/drm/apple/iomfb.c
++++ b/drivers/gpu/drm/apple/iomfb.c
+@@ -415,6 +415,8 @@ int dcp_crtc_atomic_modeset(struct drm_crtc *crtc,
+ 	struct drm_crtc_state *crtc_state;
+ 	int ret = -EIO;
+ 	bool modeset;
++	bool recover;
++	int generation;
+ 
+ 	crtc_state = drm_atomic_get_new_crtc_state(state, crtc);
+ 	if (!crtc_state)
+@@ -429,6 +431,19 @@ int dcp_crtc_atomic_modeset(struct drm_crtc *crtc,
+ 	if (crtc_state->mode.hdisplay == 0 && crtc_state->mode.vdisplay == 0)
+ 		return 0;
+ 
++	generation = atomic_read(&dcp->hdmi_generation);
++	recover = dcp->hdmi_hpd &&
++		generation != READ_ONCE(dcp->hdmi_recovered);
++	if (recover) {
++		if (!READ_ONCE(dcp->connector->connected))
++			return -ENOLINK;
++		/* HPD can power firmware down without changing DRM active. */
++		ret = dcp_poweron(apple_crtc->dcp);
++		if (ret)
++			return ret;
++		crtc_state->color_mgmt_changed = true;
++	}
++
+ 	switch (dcp->fw_compat) {
+ 	case DCP_FIRMWARE_V_12_3:
+ 		ret = iomfb_modeset_v12_3(dcp, crtc_state);
+@@ -442,6 +457,9 @@ int dcp_crtc_atomic_modeset(struct drm_crtc *crtc,
+ 		break;
+ 	}
+ 
++	/* Never consume a disconnect that raced the power/mode ACKs. */
++	if (!ret && recover)
++		WRITE_ONCE(dcp->hdmi_recovered, generation);
+ 	return ret;
+ }
+ 
+@@ -463,6 +481,15 @@ void dcp_flush(struct drm_crtc *crtc, struct drm_atomic_state *state)
+ 	struct platform_device *pdev = to_apple_crtc(crtc)->dcp;
+ 	struct apple_dcp *dcp = platform_get_drvdata(pdev);
+ 
++	/* HPD may race atomic_check or the mode ACK. Do not submit a swap
++	 * into powered-down firmware; deliver the owned event normally.
++	 * The next permitted modeset will retry the unconsumed generation.
++	 */
++	if (dcp_needs_recovery(pdev)) {
++		schedule_work(&dcp->vblank_wq);
++		return;
++	}
++
+ 	if (dcp_channel_busy(&dcp->ch_cmd))
+ 	{
+ 		if (!dcp->ch_cmd.warned_busy) {
+diff --git a/drivers/gpu/drm/apple/iomfb_template.c b/drivers/gpu/drm/apple/iomfb_template.c
+index cf40e27..fce7e2a 100644
+--- a/drivers/gpu/drm/apple/iomfb_template.c
++++ b/drivers/gpu/drm/apple/iomfb_template.c
+@@ -799,7 +799,7 @@ static void dcp_on_set_parameter(struct apple_dcp *dcp, void *out, void *cookie)
+ 	dcp_set_parameter_dcp(dcp, false, &param, dcp_on_set_power_state, cookie);
+ }
+ 
+-void DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp)
++int DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp)
+ {
+ 	struct dcp_wait_cookie *cookie;
+ 	int ret;
+@@ -808,7 +808,7 @@ void DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp)
+ 
+ 	cookie = kzalloc(sizeof(*cookie), GFP_KERNEL);
+ 	if (!cookie)
+-		return;
++		return -ENOMEM;
+ 
+ 	init_completion(&cookie->done);
+ 	kref_init(&cookie->refcount);
+@@ -844,6 +844,7 @@ void DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp)
+ 
+ 	/* Force a brightness update after poweron, to restore the brightness */
+ 	dcp->brightness.update = true;
++	return ret > 0 ? 0 : -ETIMEDOUT;
+ }
+ 
+ static void complete_set_powerstate(struct apple_dcp *dcp, void *out,
+@@ -1032,6 +1033,8 @@ static void dcpep_cb_hotplug(struct apple_dcp *dcp, u64 *connected)
+ 
+ 	/* Hotplug invalidates mode. DRM doesn't always handle this. */
+ 	if (!(*connected)) {
++		if (dcp->hdmi_hpd)
++			atomic_inc(&dcp->hdmi_generation);
+ 		dcp->valid_mode = false;
+ 		/* after unplug swap will not complete until the next
+ 		 * set_digital_out_mode */
+diff --git a/drivers/gpu/drm/apple/iomfb_template.h b/drivers/gpu/drm/apple/iomfb_template.h
+index 8efab49..76e8b19 100644
+--- a/drivers/gpu/drm/apple/iomfb_template.h
++++ b/drivers/gpu/drm/apple/iomfb_template.h
+@@ -158,7 +158,7 @@ struct apple_dcp;
+ int DCP_FW_NAME(iomfb_modeset)(struct apple_dcp *dcp,
+ 			       struct drm_crtc_state *crtc_state);
+ void DCP_FW_NAME(iomfb_flush)(struct apple_dcp *dcp, struct drm_crtc *crtc, struct drm_atomic_state *state);
+-void DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp);
++int DCP_FW_NAME(iomfb_poweron)(struct apple_dcp *dcp);
+ void DCP_FW_NAME(iomfb_poweroff)(struct apple_dcp *dcp);
+ void DCP_FW_NAME(iomfb_sleep)(struct apple_dcp *dcp);
+ void DCP_FW_NAME(iomfb_start)(struct apple_dcp *dcp);

--- a/patches/asahi/build-hdmi-reconnect.sh
+++ b/patches/asahi/build-hdmi-reconnect.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Build only: never install a package, change GRUB, or reboot.
+set -euo pipefail
+
+if (( $# != 3 )); then
+  printf 'Usage: %s CLEAN_KERNEL_SOURCE ASAHI_CONFIG NEW_OUTPUT_DIRECTORY\n' "$0" >&2
+  exit 2
+fi
+if (( EUID == 0 )); then
+  printf 'Build as an unprivileged user.\n' >&2
+  exit 1
+fi
+if [[ $(uname -m) != "aarch64" ]]; then
+  printf 'This recipe requires a native aarch64 Arch/Asahi build host.\n' >&2
+  exit 1
+fi
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source_dir=$(realpath -- "$1")
+config=$(realpath -- "$2")
+output=$(realpath -m -- "$3")
+baseline=ce9f2eba72c061a50b2d790450e90af3439d8c24
+[[ -f $config ]]
+[[ $(git -C "$source_dir" rev-parse --show-toplevel) == "$source_dir" ]]
+[[ $(git -C "$source_dir" rev-parse HEAD) == "$baseline" ]]
+[[ -z $(git -C "$source_dir" status --porcelain) ]]
+if [[ -e $output ]]; then
+  printf 'Output directory must not already exist: %s\n' "$output" >&2
+  exit 1
+fi
+# Refuse ignored build products too; use a fresh disposable source checkout.
+if [[ -e $source_dir/.config || -e $source_dir/include/generated/utsrelease.h ]]; then
+  printf 'Source already configured; use a fresh disposable checkout.\n' >&2
+  exit 1
+fi
+python3 "$here/../../test/asahi/reconnect.py" --source "$source_dir"
+git -C "$source_dir" apply --check "$here/apple-dcp-hdmi-reconnect.patch"
+git -C "$source_dir" apply "$here/apple-dcp-hdmi-reconnect.patch"
+git -C "$source_dir" diff --check
+install -m644 "$config" "$source_dir/.config"
+"$source_dir/scripts/config" --file "$source_dir/.config" --set-str LOCALVERSION '-1-1-ARCH-hdmi-recover' --disable LOCALVERSION_AUTO
+make -C "$source_dir" LOCALVERSION= olddefconfig
+make -C "$source_dir" LOCALVERSION= prepare
+[[ $(make -s -C "$source_dir" LOCALVERSION= kernelrelease) == "7.1.13-1-1-ARCH-hdmi-recover" ]]
+make -C "$source_dir" -j"${JOBS:-8}" LOCALVERSION= drivers/gpu/drm/apple/apple_drv.o drivers/gpu/drm/apple/dcp.o drivers/gpu/drm/apple/iomfb.o drivers/gpu/drm/apple/iomfb_v12_3.o drivers/gpu/drm/apple/iomfb_v13_3.o
+make -C "$source_dir" -j"${JOBS:-8}" LOCALVERSION= Image modules dtbs
+mkdir -p -- "$output"
+install -m644 "$here/PKGBUILD" "$output/PKGBUILD"
+export ASAHI_KERNEL_SOURCE="$source_dir"
+# Keep makepkg.conf PKGDEST from sending the candidate outside this directory.
+(cd -- "$output" && PKGDEST="$output" makepkg --nodeps --noconfirm)
+python3 "$here/validate-package.py" "$output"
+printf 'BUILD_AND_PACKAGE_VALIDATED (not installed): %s\n' "$output"

--- a/patches/asahi/validate-package.py
+++ b/patches/asahi/validate-package.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import hashlib,json,pathlib,subprocess,sys
+base=pathlib.Path(sys.argv[1]).resolve()
+packages=list(base.glob('linux-asahi-hdmi-recover-*.pkg.tar.zst'))
+assert len(packages)==1,packages
+p=packages[0]
+subprocess.run(['zstd','--test',str(p)],check=True)
+names=subprocess.check_output(['bsdtar','-tf',str(p)],text=True).splitlines()
+release='7.1.13-1-1-ARCH-hdmi-recover'
+prefix=f'usr/lib/modules/{release}/'
+assert prefix+'vmlinuz' in names
+assert prefix+'pkgbase' in names
+assert any(n.startswith(prefix+'dtbs/') and n.endswith('.dtb') for n in names)
+assert prefix+'modules.dep' in names
+assert prefix+'modules.builtin' in names
+assert subprocess.check_output(['bsdtar','-xOf',str(p),prefix+'pkgbase']).strip()==b'linux-asahi-hdmi-recover'
+info=subprocess.check_output(['bsdtar','-xOf',str(p),'.PKGINFO'],text=True)
+assert 'pkgname = linux-asahi-hdmi-recover\n' in info
+assert 'arch = aarch64\n' in info
+releases=sorted({n.split('/')[3] for n in names if n.startswith('usr/lib/modules/') and len(n.split('/'))>4})
+assert releases==[release],releases
+modules=[n for n in names if n.endswith(('.ko','.ko.zst','.ko.xz'))]
+assert modules
+assert any('/appledrm.ko' in n for n in modules), 'Missing Apple DRM module'
+assert not any(n.startswith(('boot/','etc/')) for n in names)
+h=hashlib.sha256()
+with p.open('rb') as f:
+    for b in iter(lambda:f.read(8*1024*1024),b''):h.update(b)
+report={'package':str(p),'size_bytes':p.stat().st_size,'sha256':h.hexdigest(),'release':release,'modules':len(modules),'archive_entries':len(names),'archive_integrity':'zstd --test PASS','pkginfo':info,'hardware_verified':False}
+(base/'validation.json').write_text(json.dumps(report,indent=2)+'\n')
+(base/'SHA256SUMS').write_text(f'{h.hexdigest()}  {p.name}\n')
+print(json.dumps(report,indent=2))

--- a/test/asahi/baseline-sha256.json
+++ b/test/asahi/baseline-sha256.json
@@ -1,0 +1,9 @@
+{
+  "drivers/gpu/drm/apple/apple_drv.c": "6bf749dac5a74a50f1b5d62ce64326d9f291b7218af79123ae3359bf641d2946",
+  "drivers/gpu/drm/apple/dcp-internal.h": "db2a475b98f6b774178637eb066d49cd3898054b4ef167c030cf7ecb7b1cbce8",
+  "drivers/gpu/drm/apple/dcp.c": "a9dbcde6d6f16e6b1da494807d579317f20c88088b8c203af8be53f9a2da2fcb",
+  "drivers/gpu/drm/apple/dcp.h": "fb90336889a7646033b9fcddccc4dcbc2a3c015b89a394f0702acd2b21458ef8",
+  "drivers/gpu/drm/apple/iomfb.c": "9b0e7d0952f87f9c1b3c6483f00071ecc7480d58e9570382c2323b8dcd0da12e",
+  "drivers/gpu/drm/apple/iomfb_template.c": "616b8a453e78cdb8dc957514e2175b535b9f57e90f7446d30ee9d24a765084d3",
+  "drivers/gpu/drm/apple/iomfb_template.h": "c45bb599efc740fe87b63317ffdddcf297be73ac62f7d3dea495f2eabedfbb88"
+}

--- a/test/asahi/reconnect.py
+++ b/test/asahi/reconnect.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""RED/GREEN gates against pinned source; network needed unless --source is set.
+
+Only a temporary directory is modified. --source reads baseline blobs from Git,
+not the worktree, and checks their hashes just like the downloaded files.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import urllib.request
+
+BASE = "ce9f2eba72c061a50b2d790450e90af3439d8c24"
+HERE = Path(__file__).resolve().parent
+PATCH = HERE.parents[1] / "patches/asahi/apple-dcp-hdmi-reconnect.patch"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--source", type=Path, help="existing Git repository containing the pinned baseline")
+args = parser.parse_args()
+manifest = json.loads((HERE / "baseline-sha256.json").read_text())
+
+with tempfile.TemporaryDirectory(prefix="asahi-reconnect-") as directory:
+  root = Path(directory)
+  for path, digest in manifest.items():
+    if args.source:
+      content = subprocess.check_output(["git", "-C", str(args.source), "show", f"{BASE}:{path}"])
+    else:
+      url = f"https://raw.githubusercontent.com/AsahiLinux/linux/{BASE}/{path}"
+      with urllib.request.urlopen(url, timeout=60) as response:
+        content = response.read()
+    if hashlib.sha256(content).hexdigest() != digest:
+      raise SystemExit(f"Baseline checksum mismatch: {path}")
+    target = root / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+
+  def run(*command, **kwargs):
+    return subprocess.run(command, cwd=root, check=True, **kwargs)
+
+  run("git", "init", "-q")
+  run("git", "add", "drivers")
+  run("git", "-c", "user.name=Regression fixture", "-c", "user.email=fixture@example.invalid",
+      "-c", "commit.gpgsign=false", "commit", "-qm", "Verified pinned source fixture")
+  env = dict(os.environ, ASAHI_TEST_SOURCE=str(root))
+  # A compiler or download failure must never count as the expected RED result.
+  red = subprocess.run(["python3", str(HERE / "run_c_seam_tests.py"), "--baseline"],
+                       cwd=root, env=env, text=True, capture_output=True)
+  print(red.stdout, end="")
+  if red.returncode != 1 or "C seam regression: RED (11 failures)" not in red.stdout:
+    raise SystemExit(f"Unexpected baseline result:\n{red.stderr}")
+  run("git", "apply", "--check", str(PATCH))
+  run("git", "apply", str(PATCH))
+  run("git", "diff", "--check")
+  run("python3", str(HERE / "test_reconnect.py"), env=env)
+  run("python3", str(HERE / "run_c_seam_tests.py"), env=env)
+  print("VERDICT: PASS — pinned patch applies, baseline RED, patched source and C seam GREEN")

--- a/test/asahi/run_c_seam_tests.py
+++ b/test/asahi/run_c_seam_tests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compile real driver functions with mocked DRM/firmware seams, not hardware.
+--baseline extracts pinned local snapshot (ce9f2eba selected source).
+"""
+from pathlib import Path
+import subprocess, sys, os
+root=Path(os.environ["ASAHI_TEST_SOURCE"])
+baseline='--baseline' in sys.argv
+def extract(file,name):
+    path='drivers/gpu/drm/apple/'+file
+    s=subprocess.check_output(['git','show','HEAD:'+path],cwd=root,text=True) if baseline else (root/path).read_text()
+    pos=s.index(name+'('); start=s.rfind('\n',0,pos)+1
+    brace=s.index('{',pos); end=brace+1; depth=1
+    while depth:
+        depth+=(s[end]=='{')-(s[end]=='}');end+=1
+    return s[start:end]
+preamble=r'''
+#include <stdbool.h>
+#include <stdio.h>
+#include <errno.h>
+#include <assert.h>
+#define READ_ONCE(x) (x)
+#define WRITE_ONCE(x,v) ((x)=(v))
+#define atomic_read(x) (*(x))
+#define WARN_ONCE(...) ((void)0)
+#define DCP_FIRMWARE_V_12_3 1
+#define DCP_FIRMWARE_V_13_5 2
+struct drm_display_mode { int hdisplay,vdisplay; };
+struct drm_crtc_state { bool active,active_changed,mode_changed,color_mgmt_changed; struct drm_display_mode mode; };
+struct apple_connector { bool connected; };
+struct channel { bool warned_busy; };
+struct apple_dcp { void *dev; bool hdmi_hpd,valid_mode; int hdmi_generation,hdmi_recovered,fw_compat,vblank_wq; struct apple_connector *connector; struct channel ch_cmd; };
+struct platform_device { struct apple_dcp *data; };
+struct apple_crtc { struct platform_device *dcp; };
+struct drm_crtc { struct apple_crtc apple; };
+struct drm_device { int unused; };
+struct drm_atomic_state { struct drm_crtc_state *cs; struct drm_crtc *crtc; bool allow_modeset; };
+#define to_apple_crtc(c) (&(c)->apple)
+#define platform_get_drvdata(p) ((p)->data)
+#define for_each_new_crtc_in_state(s,c,newcs,i) for ((i)=0,(c)=(s)->crtc,(newcs)=(s)->cs;(i)<1;(i)++)
+static int power_calls,mode_calls,submit_calls,vblanks,power_error,mode_error,race;
+static struct drm_crtc_state *drm_atomic_get_new_crtc_state(struct drm_atomic_state *s,struct drm_crtc *c) { (void)c;return s->cs; }
+static bool drm_atomic_crtc_needs_modeset(struct drm_crtc_state *s) { return s->mode_changed || s->active_changed; }
+static int drm_atomic_helper_check(struct drm_device *d,struct drm_atomic_state *s) { (void)d;return !s->allow_modeset && drm_atomic_crtc_needs_modeset(s->cs) ? -EINVAL : 0; }
+int dcp_poweron(struct platform_device *p) { (void)p;power_calls++;return power_error; }
+static int iomfb_modeset_v12_3(struct apple_dcp *d, struct drm_crtc_state *s) { (void)s;mode_calls++;if(race)d->hdmi_generation++;if(!mode_error)d->valid_mode=true;return mode_error; }
+#define iomfb_modeset_v13_3 iomfb_modeset_v12_3
+static bool dcp_channel_busy(struct channel *c) { (void)c;return false; }
+#define dev_err(...) ((void)0)
+static void schedule_work(int *w) { (void)w;vblanks++; }
+static void iomfb_flush_v12_3(struct apple_dcp *d,struct drm_crtc *c,struct drm_atomic_state *s) { (void)d;(void)c;(void)s;submit_calls++; }
+#define iomfb_flush_v13_3 iomfb_flush_v12_3
+'''
+functions=[]
+if baseline:
+    functions.append('static bool dcp_needs_recovery(struct platform_device *p) { return p->data->hdmi_hpd && p->data->hdmi_generation != p->data->hdmi_recovered; }')
+    functions.append('static int apple_atomic_check(struct drm_device *d, struct drm_atomic_state *s) { return drm_atomic_helper_check(d,s); }')
+else:
+    functions += [extract('dcp.c','dcp_needs_recovery'),extract('apple_drv.c','apple_atomic_check')]
+functions += [extract('iomfb.c','dcp_crtc_atomic_modeset'),extract('iomfb.c','dcp_flush')]
+main=r'''
+#define CHECK(x) do { if (!(x)) { printf("FAIL: %s\n",#x); failures++; } } while(0)
+int main(void) {
+ int failures=0;
+ struct apple_connector con={.connected=true};
+ struct apple_dcp d={.hdmi_hpd=true,.hdmi_generation=2,.hdmi_recovered=0,.fw_compat=1,.connector=&con};
+ struct platform_device p={.data=&d};
+ struct drm_crtc c={.apple={.dcp=&p}};
+ struct drm_crtc_state cs={.active=true,.mode={1920,1080}};
+ struct drm_atomic_state s={.cs=&cs,.crtc=&c,.allow_modeset=true};
+ struct drm_device dev={0};
+ // Same active/mode as before unplug. Check must schedule recovery, no IO.
+ CHECK(apple_atomic_check(&dev,&s)==0);
+ CHECK(cs.mode_changed && !cs.active_changed);
+ CHECK(power_calls==0 && mode_calls==0 && d.hdmi_recovered==0);
+ s.allow_modeset=false; CHECK(apple_atomic_check(&dev,&s)==-EINVAL);
+ s.allow_modeset=true;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==0);
+ CHECK(power_calls==1 && mode_calls==1 && d.hdmi_recovered==2);
+ dcp_flush(&c,&s); CHECK(submit_calls==1);
+ // Pending newer generation at flush, including HPD after atomic_check.
+ d.hdmi_generation++; dcp_flush(&c,&s);
+ CHECK(submit_calls==1 && vblanks==1);
+ power_error=-ETIMEDOUT; mode_calls=0;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==-ETIMEDOUT);
+ CHECK(mode_calls==0 && d.hdmi_recovered==2);
+ power_error=0; mode_error=-EIO;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==-EIO);
+ CHECK(d.hdmi_recovered==2);
+ mode_error=0; race=1;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==0);
+ CHECK(dcp_needs_recovery(&p));
+ dcp_flush(&c,&s); CHECK(submit_calls==1);
+ race=0; CHECK(dcp_crtc_atomic_modeset(&c,&s)==0);
+ CHECK(!dcp_needs_recovery(&p));
+ // Generic invalid mode without HDMI generation is NOT evidence of poweroff.
+ power_calls=0; d.valid_mode=false;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==0); CHECK(power_calls==0);
+ // Disconnected recovery must not power on or consume generation.
+ d.hdmi_generation++;con.connected=false;
+ CHECK(dcp_crtc_atomic_modeset(&c,&s)==-ENOLINK); CHECK(power_calls==0);
+ // Internal display is excluded even with different counters.
+ d.hdmi_hpd=false; CHECK(!dcp_needs_recovery(&p));
+ printf("C seam regression: %s (%d failures)\n",failures?"RED":"GREEN",failures);
+ return failures?1:0;
+}
+'''
+tag='baseline' if baseline else 'patched'
+cfile=root/f'seam-{tag}.c';exe=root/f'seam-{tag}'
+cfile.write_text(preamble+'\n'.join(functions)+main)
+subprocess.run(['cc','-std=c11','-Wall','-Wextra','-Werror',str(cfile),'-o',str(exe)],check=True)
+sys.exit(subprocess.run([str(exe)]).returncode)

--- a/test/asahi/test_reconnect.py
+++ b/test/asahi/test_reconnect.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Source regression gates; not a firmware/hardware simulation."""
+import pathlib, unittest, re, os
+P = pathlib.Path(os.environ['ASAHI_TEST_SOURCE']) / 'drivers/gpu/drm/apple'
+def src(n): return (P/n).read_text()
+def body(n, fn):
+    text = src(n); start = text.index(fn+'('); start = text.index('{', start)
+    level=1; end=start+1
+    while level:
+        level += (text[end]=='{')-(text[end]=='}'); end+=1
+    return text[start:end]
+class Reconnect(unittest.TestCase):
+    def test_first_reconnect_gets_real_modeset_before_helper(self):
+        s=src('apple_drv.c')
+        self.assertIn('static int apple_atomic_check(',s,
+                      'baseline submits first reconnect without DRM modeset')
+        b=body('apple_drv.c','apple_atomic_check')
+        self.assertLess(b.index('mode_changed = true'),b.index('drm_atomic_helper_check('))
+        self.assertIn('dcp_needs_recovery',b)
+        self.assertIn('crtc_state->active',b)
+        self.assertNotIn('active_changed =',b)
+        self.assertNotIn('dcp_poweron(',b) # TEST_ONLY must not consume recovery
+        self.assertRegex(s,r'\.atomic_check\s*= apple_atomic_check')
+    def test_recovery_power_ack_before_modeset_and_generation_retained(self):
+        b=body('iomfb.c','dcp_crtc_atomic_modeset')
+        self.assertIn('dcp_poweron(',b,'mode_changed alone still skips poweron')
+        self.assertLess(b.index('dcp_poweron('),b.index('iomfb_modeset_v12_3('))
+        self.assertIn('if (ret)',b)
+        self.assertIn('WRITE_ONCE(dcp->hdmi_recovered, generation)',b)
+        self.assertIn('if (!ret && recover)',b)
+        p=src('iomfb_template.c')
+        self.assertIn('int DCP_FW_NAME(iomfb_poweron)',p)
+        self.assertIn('return ret > 0 ? 0 : -ETIMEDOUT;',p)
+        self.assertIn('atomic_inc(&dcp->hdmi_generation)',p)
+        self.assertIn('atomic_inc(&dcp->hdmi_generation)',body('dcp.c','dcp_dp2hdmi_hpd'))
+        f=body('iomfb.c','dcp_flush')
+        self.assertLess(f.index('dcp_needs_recovery('),f.index('iomfb_flush_v12_3('))
+        self.assertIn('schedule_work(&dcp->vblank_wq)',f)
+        self.assertNotIn('active_changed =',src('apple_drv.c'))
+        # Preserve clear-submit ACK path; never pretend swap_complete is ACK.
+        self.assertIn('dcp_swap_start(dcp, false, &swap_req, dcp_swap_clear_started, cookie);',p)
+        self.assertIn('wait_for_completion_timeout(&cookie->done, msecs_to_jiffies(50))',p)
+if __name__=='__main__': unittest.main(verbosity=2)

--- a/test/shell.d/asahi-hdmi-reconnect-test.sh
+++ b/test/shell.d/asahi-hdmi-reconnect-test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+require_command python3
+
+python3 - "$ROOT" <<'PY'
+from pathlib import Path
+import hashlib
+import subprocess
+import sys
+root = Path(sys.argv[1])
+patches = root / 'patches/asahi'
+patch = patches / 'apple-dcp-hdmi-reconnect.patch'
+assert hashlib.sha256(patch.read_bytes()).hexdigest() == 'dbf332ead80ad84d5fb681fe83fc92c89cb88e0d4e416142acbb80565aacedcf', 'Hardware-tested patch changed; refresh evidence deliberately'
+build = (patches / 'build-hdmi-reconnect.sh').read_text()
+recipe = (patches / 'PKGBUILD').read_text()
+assert 'ce9f2eba72c061a50b2d790450e90af3439d8c24' in build
+assert 'git -C "$source_dir" apply --check' in build
+assert build.index('apply --check') < build.index('apply "$here/')
+assert 'LOCALVERSION_AUTO' in build and '--file "$source_dir/.config"' in build
+assert 'LOCALVERSION= Image modules dtbs' in build
+assert '7.1.13-1-1-ARCH-hdmi-recover' in build and '7.1.13-1-1-ARCH-hdmi-recover' in recipe
+assert 'pkgname=linux-asahi-hdmi-recover' in recipe
+assert 'ASAHI_KERNEL_SOURCE:?' in recipe
+assert 'arch/arm64/boot/dts/apple/*.dtb' in recipe
+assert 'INSTALL_MOD_PATH="$pkgdir/usr"' in recipe
+assert 'provides=' not in recipe and 'conflicts=' not in recipe and 'replaces=' not in recipe
+assert 'pacman -' not in build and 'grub-' not in build and 'makepkg -i' not in build
+assert 'validate-package.py' in build
+subprocess.run(['bash', '-n', str(patches / 'build-hdmi-reconnect.sh'), str(patches / 'PKGBUILD')], check=True)
+# Argument validation must fail before any source/build/host mutation.
+result = subprocess.run(['bash', str(patches / 'build-hdmi-reconnect.sh')], capture_output=True, text=True)
+assert result.returncode == 2 and 'Usage:' in result.stderr
+print('ok - exact hardware patch, opt-in build/package contracts, and argument rejection')
+PY


### PR DESCRIPTION
## Summary

- Add an **experimental, opt-in downstream Asahi HDMI reconnect kernel patch**, pinned to `AsahiLinux/linux` commit `ce9f2eba72c061a50b2d790450e90af3439d8c24`.
- Track HDMI disconnect generations, request a real DRM modeset, and recover firmware power before programming the mode even when DRM's active state is unchanged. Preserve a newer disconnect and withhold swaps while recovery remains pending.
- Include an isolated build-only wrapper/package recipe, package validation, pinned-source RED/GREEN regression tests, extracted-C seam tests, and a dedicated CI job.
- Document curated hardware evidence, limitations, safe side-by-side installation and rollback procedures in `docs/asahi-hdmi-reconnect.md`.

**Ready for maintainer review as an experimental, opt-in patch; not proposed for automatic deployment.** No installer/update integration, package installation, GRUB changes, or reboots are performed by this PR. No raw journals, personal configuration, or prebuilt kernel package are included.

## Validation

- [x] Focused offline build/package-contract test: `bash test/shell.d/asahi-hdmi-reconnect-test.sh`.
- [x] `python3 test/asahi/reconnect.py`: pinned baseline SHA-256 checks and patch applicability; baseline C seam produces exactly 11 expected assertion failures; patched seam reports zero failures; both source regression tests pass. The expected baseline RED is a regression check, not a full-suite pass.
- [x] Separate Bash syntax checks for the build wrapper and PKGBUILD; `bin/omarchy commands --check` passes (465 commands).
- [ ] Repository-level `git diff --check` exits 2 on the embedded `.patch` file's required context-line prefixes (space before kernel tabs and space-only context lines). The patch is deliberately preserved byte-for-byte; the applied kernel-source diff passes its whitespace check in the focused regression runner.
- [x] Included patch SHA-256 is `dbf332ead80ad84d5fb681fe83fc92c89cb88e0d4e416142acbb80565aacedcf`, identical to the hardware-tested functional patch.
- [x] Prior hardware campaign: Apple MacBook Pro (16-inch, M2 Pro, 2023), candidate release `7.1.13-1-1-ARCH-hdmi-recover`, 2560×1440 at 75 Hz. User confirmed initial image and **three complete unplug/replug cycles**, without compositor/session restart. Retained captures through the third reconnect had no `flip_done timed out`, `commit wait timed out`, Oops, BUG, or panic matches. An initial-boot swallowed-swap message also existed in baseline; this is not a claim of a completely clean boot log.
- [x] Prior machine-specific build compiled the five affected translation units and completed Image/modules/DTBs and package validation. This is historical evidence for the exact functional patch, **not** a completed build with the newly generalized wrapper.
- [ ] **Earlier local full-suite run failed; GitHub full-suite CI now passes:** the prior `./test/all` run exited 1. Its local log contains locale-sensitive benchmark arithmetic, jq parsing, and awk syntax diagnostics. Baseline comparison was interrupted, so these failures have **not** been established as pre-existing or unrelated. The local failure is retained for transparency; both GitHub suite jobs subsequently passed.
- [x] All five GitHub checks passed: Syntax + shellcheck, test/all, tests/all, Asahi HDMI source + C seam, and install.sh on Arch Linux ARM.

## Remaining validation and maintainer review items

- [ ] Complete a fresh native aarch64 build/package with this PR's generalized wrapper. Current wrapper coverage is syntax/contract validation, not end-to-end native build validation.
- [ ] Reboot back to stock, verify the graphical session and persistent stock boot default. Stock and candidate remain installed, but post-fix stock rollback bootability has not been exercised.
- [ ] Review/stress the gap between flush generation check and asynchronous firmware submission; the check does not serialize hotplug against submission.
- [ ] Exercise synthetic-vblank work coalescing, real event ownership/callback ordering and framebuffer lifetime under rapid hotplug. Synchronous seam mocks cannot establish these properties.
- [ ] Verify compositor liveness if disconnect after atomic check withholds a swap; recovery depends on a subsequent modeset-permitted commit.
- [ ] Expand monitor/mode, suspend/resume, session and HDMI hardware/firmware coverage. Compilation of both firmware translation units is not hardware coverage of both versions.

## Review scope

The staged patch, build/package path, tests and documentation received a separate publication review. No new functional kernel edits were made after the hardware campaign. Concurrency/liveness and packaging end-to-end validation remain explicit limitations for maintainer review rather than being represented as solved by the unit seam. This candidate does not implement USB-C DisplayPort or M3 enablement.

## Extended runtime follow-up

The user reported another reconnection hours later. A read-only check found the same recovery kernel running after approximately 11 hours 46 minutes of uptime, with zero `flip_done timed out`, `commit wait timed out`, `DCP has crashed`, or `set_digital_out_mode timed out` matches in the retained current-boot journal. The journal includes a later reconnect with power-on and successful mode completion at monotonic time 15244 seconds. HDMI was disconnected when inspected, so this is not an independent confirmation of a currently visible image. Additional swallowed-swap messages exist in the extended journal; no claim of an entirely error-free log is made. The post-fix stock rollback reboot and broader race/stress coverage remain untested.
