### PR TITLE
feat(hw): detect fingerprint readers beyond the USB bus

### DIFF
--- a/bin/omarchy-hw-fingerprint
+++ b/bin/omarchy-hw-fingerprint
@@ -10,6 +10,8 @@
 # reader — those still match on the product string below when present.
 fingerprint_vendors=" 27c6 138a 06cb 08ff 1c7a 147e "
 usb_devices_path="${OMARCHY_USB_DEVICES_PATH:-/sys/bus/usb/devices}"
+bus_devices_root="${OMARCHY_BUS_DEVICES_PATH:-/sys/bus}"
+fprintd_service_file="${OMARCHY_FPRINTD_SERVICE_FILE:-/usr/share/dbus-1/system-services/net.reactivated.Fprint.service}"
 
 # libfprint drives every reader it supports from userspace over libusb, so a
 # real reader sits there with no kernel driver bound to any of its interfaces.
@@ -52,5 +54,28 @@ for dev in "$usb_devices_path"/*; do
       ! has_kernel_driver "$dev" && exit 0
   fi
 done
+
+# Readers on other buses. USB covers nearly every shipping reader, but nothing
+# about a fingerprint sensor requires USB — Touch ID, if it ever gets a driver,
+# would sit on the SoC's own fabric. A device that names itself a fingerprint
+# reader is trusted here too; there is no vendor list to guess from.
+for dev in "$bus_devices_root"/*/devices/*; do
+  [[ $dev == "$bus_devices_root"/usb/* ]] && continue
+  for attr in name product modalias; do
+    [[ -r $dev/$attr ]] || continue
+    text=$(<"$dev/$attr")
+    text=${text,,}
+    [[ $text == *fingerprint* || $text == *biometric* || $text == *touchid* || $text == *touch_id* ]] && exit 0
+  done
+done
+
+# When fprintd is installed, its device list is the authoritative "a usable
+# reader exists" answer and catches sensors the sysfs passes miss. Skipped when
+# absent so this still works before the fingerprint setup pulls anything in.
+if [[ -f $fprintd_service_file ]]; then
+  busctl call net.reactivated.Fprint /net/reactivated/Fprint/Manager \
+    net.reactivated.Fprint.Manager GetDevices --timeout=2 2>/dev/null |
+    grep -q "/net/reactivated/Fprint/Device/" && exit 0
+fi
 
 exit 1

--- a/test/shell.d/hw-fingerprint-test.sh
+++ b/test/shell.d/hw-fingerprint-test.sh
@@ -35,7 +35,26 @@ write_usb_devices() {
 }
 
 hw_fingerprint() {
-  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" "$ROOT/bin/omarchy-hw-fingerprint"
+  OMARCHY_USB_DEVICES_PATH="$tmp_dir/devices" \
+    OMARCHY_BUS_DEVICES_PATH="${OMARCHY_TEST_BUS:-$tmp_dir/bus-empty}" \
+    OMARCHY_FPRINTD_SERVICE_FILE="${OMARCHY_TEST_FPRINTD:-$tmp_dir/no-fprintd}" \
+    "$ROOT/bin/omarchy-hw-fingerprint"
+}
+
+write_bus_devices() {
+  rm -rf "$tmp_dir/bus"
+  local spec
+  for spec in "$@"; do
+    local bus=${spec%%:*}
+    local rest=${spec#*:}
+    local name=${rest%%:*}
+    local product=${rest#*:}
+    local dev="$tmp_dir/bus/$bus/devices/$name"
+
+    mkdir -p "$dev"
+    [[ -n $product ]] && printf '%s\n' "$product" >"$dev/name"
+  done
+  OMARCHY_TEST_BUS="$tmp_dir/bus"
 }
 
 assert_detects() {
@@ -103,3 +122,43 @@ assert_detects "a self-named reader is detected with a driver bound"
 
 write_usb_devices '1234:5678:Generic USB Device'
 assert_rejects "a machine with no matching USB devices detects nothing"
+
+# Non-USB pass: a reader on another bus (SPI, platform fabric — where a Touch
+# ID driver would live if one ever lands) names itself and is trusted.
+write_usb_devices '1234:5678:Generic USB Device'
+write_bus_devices 'platform:fingerprint0:Apple Touch ID Fingerprint Sensor'
+assert_detects "a fingerprint-named platform device is detected"
+
+write_usb_devices '1234:5678:Generic USB Device'
+write_bus_devices 'spi:spi0.0:Fingerprint Reader'
+assert_detects "a fingerprint-named SPI device is detected"
+
+write_usb_devices '1234:5678:Generic USB Device'
+write_bus_devices 'platform:pmic0:apple,maverick-pmic' 'iio:iio0:aop-sensors-als'
+assert_rejects "non-USB devices naming other functions detect nothing"
+
+# fprintd pass: when the service file exists its device list is authoritative,
+# catching readers the sysfs scans miss entirely.
+write_usb_devices '1234:5678:Generic USB Device'
+mkdir -p "$tmp_dir/bin" "$tmp_dir/fprintd"
+: >"$tmp_dir/fprintd/net.reactivated.Fprint.service"
+cat >"$tmp_dir/bin/busctl" <<'STUB'
+#!/bin/bash
+printf 'ao 1 "/net/reactivated/Fprint/Device/0"\n'
+STUB
+chmod +x "$tmp_dir/bin/busctl"
+OMARCHY_TEST_FPRINTD="$tmp_dir/fprintd/net.reactivated.Fprint.service" \
+  PATH="$tmp_dir/bin:$PATH" \
+  hw_fingerprint || fail "fprintd reporting a device detects a reader"
+pass "fprintd reporting a device detects a reader"
+
+cat >"$tmp_dir/bin/busctl" <<'STUB'
+#!/bin/bash
+printf 'ao 0\n'
+STUB
+chmod +x "$tmp_dir/bin/busctl"
+if OMARCHY_TEST_FPRINTD="$tmp_dir/fprintd/net.reactivated.Fprint.service" \
+  PATH="$tmp_dir/bin:$PATH" hw_fingerprint; then
+  fail "fprintd reporting no devices detects nothing"
+fi
+pass "fprintd reporting no devices detects nothing"


### PR DESCRIPTION
## Summary

`omarchy-hw-fingerprint` only scanned `/sys/bus/usb`, but nothing about a fingerprint sensor requires USB. This adds two passes after the USB scan so detection keeps working whatever bus a reader lands on:

- **Non-USB sysfs**: any device on another bus whose `name`/`product`/`modalias` says fingerprint/biometric/touchid is trusted — no vendor list, since there's nothing to guess from. This is what would catch a Touch ID driver on Apple Silicon if one ever exists (today the sensor is Secure-Enclave-bound with no device-tree node, so nothing to drive — but when a driver appears, `omarchy setup security fingerprint` and the first-run invitation hook will just work).
- **fprintd probe**: when `net.reactivated.Fprint.service` is installed, `GetDevices` is the authoritative usable-reader answer and catches sensors the sysfs scans miss. Skipped when fprintd isn't installed, preserving the works-before-setup contract.

Verified on a 4.0.3-1 package install (MacBookPro18,1): exits 1 cleanly — no false positives from the SPMI PMIC, `aop-sensors-*` IIO devices, or SPI input devices.

#### Test plan

- [x] `test/shell.d/hw-fingerprint-test.sh` extended: platform/SPI fingerprint-named devices detected, PMIC/IIO non-matches rejected, fprintd device-present and device-absent both honored (16/16 pass)
- [x] Existing USB-detection cases all still pass
- [x] Real-hardware run on M1 Pro exits 1 without hanging

Generated with [Devin](https://devin.ai)