### PR TITLE
fix(install): install the Spotify web app when no native client exists

### DIFF
--- a/bin/omarchy-install-service-spotify
+++ b/bin/omarchy-install-service-spotify
@@ -6,10 +6,26 @@
 set -e
 
 echo "Installing Spotify..."
-omarchy-pkg-add spotify
 
-echo "Opening Spotify..."
-setsid uwsm-app -- /usr/bin/spotify >/dev/null 2>&1 &
+if pacman -Q spotify &>/dev/null || pacman -Si spotify &>/dev/null; then
+  omarchy-pkg-add spotify
 
-echo ""
-echo "Spotify has been installed."
+  echo "Opening Spotify..."
+  setsid uwsm-app -- /usr/bin/spotify >/dev/null 2>&1 &
+
+  echo ""
+  echo "Spotify has been installed."
+else
+  # No aarch64 Spotify client exists, so on systems the repos cannot serve the
+  # web app is the client. omarchy-launch-spotify already matches a window
+  # whose class or title contains "spotify", so the SUPER+SHIFT+M binding
+  # focuses this app the same as the native one.
+  echo "No native Spotify client is available on this system; installing the web app."
+  omarchy-webapp-install "Spotify" "https://open.spotify.com" "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/spotify.png"
+
+  echo "Opening Spotify..."
+  setsid omarchy-launch-webapp "https://open.spotify.com" >/dev/null 2>&1 &
+
+  echo ""
+  echo "Spotify has been installed as a web app."
+fi

--- a/bin/omarchy-launch-spotify
+++ b/bin/omarchy-launch-spotify
@@ -10,6 +10,8 @@ if [[ -n $WINDOW_ADDRESS ]]; then
   hyprctl dispatch "hl.dsp.focus({ window = \"address:$WINDOW_ADDRESS\" })" >/dev/null 2>&1 || hyprctl dispatch focuswindow "address:$WINDOW_ADDRESS"
 elif [[ -x /usr/bin/spotify ]]; then
   exec setsid uwsm-app -- /usr/bin/spotify
+elif [[ -f $HOME/.local/share/applications/Spotify.desktop ]]; then
+  exec omarchy-launch-webapp "https://open.spotify.com"
 else
   exec omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify
 fi

--- a/default/omarchy/omarchy-menu.jsonc
+++ b/default/omarchy/omarchy-menu.jsonc
@@ -218,7 +218,7 @@
   "install.browser.zen": {"icon":"󰖟","label":"Zen","disabled":"omarchy-pkg-present zen-browser-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser zen'"},
   "install.service.1password": {"icon":"󰢁","label":"1Password","disabled":"omarchy-pkg-present 1password","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-1password"},
   "install.service.dropbox": {"icon":"","label":"Dropbox","disabled":"omarchy-pkg-present dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-dropbox"},
-  "install.service.spotify": {"icon":"󰓇","label":"Spotify","disabled":"omarchy-pkg-present spotify","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify"},
+  "install.service.spotify": {"icon":"󰓇","label":"Spotify","disabled":"omarchy-pkg-present spotify || [[ -f $HOME/.local/share/applications/Spotify.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify"},
   "install.service.signal": {"icon":"󰭹","label":"Signal","disabled":"omarchy-pkg-present signal-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-signal"},
   "install.service.tailscale": {"icon":"","label":"Tailscale","disabled":"omarchy-pkg-present tailscale","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-tailscale"},
   "install.service.nordvpn": {"icon":"󱇱","label":"NordVPN","disabled":"omarchy-pkg-present nordvpn-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-nordvpn"},


### PR DESCRIPTION
## Summary

Fixes #317.

`omarchy-install-service-spotify` ran `omarchy-pkg-add spotify`, which skips the package via the ARM repo filter and exits 0 — then unconditionally launched `/usr/bin/spotify` (an `App failure` notification) and printed "Spotify has been installed."

Since no aarch64 Spotify client exists, when the `spotify` package is neither installed nor in the repos the installer now installs the **Spotify web app** (`open.spotify.com` via `omarchy-webapp-install`, dashboard-icons artwork) — the fork's intended client per the intentional-divergences list — and launches it. Systems that can install the package keep the native path unchanged.

Two supporting changes:

- `omarchy-launch-spotify` gains a branch for `~/.local/share/applications/Spotify.desktop`, so SUPER+SHIFT+M opens the web app instead of re-running the installer. (Focus already worked — the webapp's class `…open.spotify.com…` matches the existing `\bspotify\b` regex.)
- The menu row dims once either client is present (`pkg-present spotify || Spotify.desktop`).

#### Test plan

- [x] On aarch64 4.0.3-1 (`pacman -Si spotify` → absent): installer takes the webapp branch, calls `omarchy-webapp-install Spotify https://open.spotify.com …`, launches via `omarchy-launch-webapp`, prints an honest message
- [x] menu-guards/menu tests pass; `bash -n` clean

Generated with [Devin](https://devin.ai)