### PR TITLE
fix(install): fail honestly when Dropbox cannot be installed

### DIFF
--- a/bin/omarchy-install-service-dropbox
+++ b/bin/omarchy-install-service-dropbox
@@ -2,6 +2,16 @@
 
 # omarchy:summary=Install and start the Dropbox service. Must then be authenticated via the web.
 
+set -e
+
+# Everything below needs dropbox-cli, which only exists as an AUR package built
+# around Dropbox's x86_64-only daemon. When the repos cannot serve it there is
+# no Dropbox to start — say so instead of enabling a bar widget for nothing.
+if ! omarchy-pkg-present dropbox-cli && ! pacman -Si dropbox-cli &>/dev/null; then
+  echo "Dropbox is not available on this system (no aarch64 build exists)."
+  exit 1
+fi
+
 echo "Installing all dependencies..."
 omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox
 


### PR DESCRIPTION
## Summary

Fixes #300.

The Dropbox installer enabled the `omarchy.dropbox` bar widget even when `omarchy-pkg-add` skipped every package in its list — on aarch64 all of `dropbox`, `dropbox-cli`, `libappindicator-gtk3`, and `nautilus-dropbox` are AUR/x86-only names the repos filter drops. Users got a permanently-broken widget ("Dropbox CLI is not installed") and a fake success message.

Since the Dropbox daemon has no aarch64 build at all, there's no fallback to offer — the script now checks `dropbox-cli` installability up front, prints the real reason, and exits 1 before touching the bar. A machine where `dropbox-cli` is already installed still proceeds, so nothing changes for a working setup.

#### Test plan

- [x] On aarch64 4.0.3-1: prints "Dropbox is not available on this system (no aarch64 build exists)", exits 1, plugin untouched
- [x] `bash -n` clean

Generated with [Devin](https://devin.ai)