### PR TITLE
fix(browsers): disable hardware video decode on Chromium-family browsers

### DIFF
--- a/config/chromium-flags.conf
+++ b/config/chromium-flags.conf
@@ -2,4 +2,5 @@
 --ozone-platform-hint=wayland
 --password-store=gnome-libsecret
 --enable-features=TouchpadOverscrollHistoryNavigation,WebRTCPipeWireCapturer
+--disable-features=AcceleratedVideoDecoder
 --load-extension=/usr/share/omarchy/default/chromium/extensions/copy-url,/usr/share/omarchy/default/chromium/extensions/yt-dlp,/usr/share/omarchy/default/chromium/extensions/whatsapp-slim

--- a/migrations/1789045438.sh
+++ b/migrations/1789045438.sh
@@ -1,0 +1,25 @@
+echo "Disable hardware video decode in Chromium-family browsers"
+
+# On Apple Silicon the VA-API path talks to the AVD decoder, which renders
+# green frames on a subset of streams (#388/#370). The decoder gate in current
+# Chromium is the AcceleratedVideoDecoder feature — the older
+# --disable-accelerated-video-decode switch only feeds the about:gpu status
+# page and is consumed nowhere on the Linux decode path.
+#
+# omarchy-install-browser copies config/chromium-flags.conf into each
+# browser's flags file at install time, so new installs already carry this.
+# Existing installs never got a re-copy: merge the feature into whatever
+# *-flags.conf files are present.
+
+for conf in "$HOME"/.config/*-flags.conf; do
+  [[ -f $conf ]] || continue
+  grep -q '^--disable-features=.*AcceleratedVideoDecoder' "$conf" && continue
+
+  if grep -q '^--disable-features=' "$conf"; then
+    # A second --disable-features argument would replace, not extend, the
+    # existing list — merge into it instead.
+    sed -i -E 's/^--disable-features=(.*)$/--disable-features=\1,AcceleratedVideoDecoder/' "$conf"
+  else
+    printf '%s\n' "--disable-features=AcceleratedVideoDecoder" >>"$conf"
+  fi
+done

--- a/test/shell.d/chromium-avd-decode-test.sh
+++ b/test/shell.d/chromium-avd-decode-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+
+migration="$ROOT/migrations/1789045438.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+home="$test_dir/home"
+mkdir -p "$home/.config"
+
+run_migration() {
+  HOME="$home" bash -euo pipefail "$migration" >/dev/null
+}
+
+conf="$home/.config/brave-flags.conf"
+flag="--disable-features=AcceleratedVideoDecoder"
+
+# A plain flags file gets the workaround appended.
+printf -- '--ozone-platform=wayland\n' >"$conf"
+run_migration
+grep -qxF -- "$flag" "$conf" || fail "migration does not append the decode workaround"
+pass "migration appends the decode workaround to a plain flags file"
+
+# An existing --disable-features list is extended, not shadowed by a second
+# argument Chromium would read instead of it.
+printf -- '--disable-features=SomeOtherThing\n' >"$conf"
+run_migration
+grep -qxF -- '--disable-features=SomeOtherThing,AcceleratedVideoDecoder' "$conf" ||
+  fail "migration does not merge into an existing disable-features list"
+pass "migration merges into an existing disable-features list"
+
+# Already disabled means untouched, and a rerun stays a no-op.
+printf '%s\n' "$flag" >"$conf"
+before=$(sha256sum "$conf" | cut -d' ' -f1)
+run_migration
+run_migration
+[[ $(sha256sum "$conf" | cut -d' ' -f1) == "$before" ]] ||
+  fail "migration is not idempotent over an already-disabled file"
+pass "migration is idempotent over an already-disabled file"
+
+# Every browser flags file in the config dir is covered.
+for extra in brave-origin-flags.conf chrome-flags.conf chromium-flags.conf; do
+  printf -- '--ozone-platform=wayland\n' >"$home/.config/$extra"
+done
+run_migration
+for extra in brave-origin-flags.conf chrome-flags.conf chromium-flags.conf; do
+  grep -qxF -- "$flag" "$home/.config/$extra" || fail "migration misses $extra"
+done
+pass "migration covers every installed browser flags file"
+
+# A config directory with no flags files is a clean no-op.
+rm -f "$home"/.config/*-flags.conf
+run_migration || fail "migration fails with no flags files present"
+pass "migration no-ops when no browser flags files exist"


### PR DESCRIPTION
## Summary

Fixes the Omarchy-side half of #388 / #370.

On Apple Silicon, browser hardware video decode runs through the AVD driver via `libva-v4l2_request-avd` — and renders green frames on a subset of streams. A prior shipped workaround used `--disable-accelerated-video-decode`, but that switch is dead on Linux: in Chromium 152 (`content/public/common/content_switches.cc`) it's documented as ChromeOS-only policy plumbing, and the actual decoder gate — `GetPreferredLinuxDecoderImplementation()` in `media/mojo/services/gpu_mojo_media_client_linux.cc` — checks **only** the `AcceleratedVideoDecoder` feature. That's enabled by default in builds with VA-API (Brave, Brave Origin — matching the reporters' `strings` findings) and compiled out of Arch's `chromium`, which is why stock Chromium never shows the bug.

Changes:

- `config/chromium-flags.conf` gains `--disable-features=AcceleratedVideoDecoder`. `omarchy-install-browser` already copies this file into every browser's `*-flags.conf` (chromium, chrome, brave, brave-origin, edge), so one line covers the whole family. On VA-API-less builds it's a no-op; native players (mpv/ffmpeg/GStreamer) keep full AVD decode — only browsers drop to software.
- New migration `1789045438.sh` merges the flag into `~/.config/*-flags.conf` files already on disk — extending an existing `--disable-features=` list instead of shadowing it (a repeated flag would replace, not combine).

#### Test plan

- [x] `test/shell.d/chromium-avd-decode-test.sh`: append, merge-into-existing-list, idempotence, multi-browser coverage, no-op — 5/5 pass
- [x] Source-verified against Chromium `152.0.7977.75` (the version in ALARM repos)
- [x] Flag parses cleanly on installed chromium (`--dump-dom` smoke test)

Generated with [Devin](https://devin.ai)