### PR TITLE
fix(screensaver): report a missing ttfx once instead of respawning it

### DIFF
--- a/bin/omarchy-screensaver
+++ b/bin/omarchy-screensaver
@@ -13,6 +13,15 @@ exit_screensaver() {
   exit 0
 }
 
+# Without ttfx there is nothing to draw, and a respawn loop over a missing
+# command paints the terminal with launch errors. Say so once and leave
+# before any state — hidden cursor, background color — needs restoring.
+if omarchy-cmd-missing ttfx; then
+  echo "The screensaver needs ttfx, which is not installed." >&2
+  echo "Install it with: omarchy pkg add ttfx" >&2
+  exit 1
+fi
+
 # Exit the screensaver on signals and input from keyboard and mouse
 trap exit_screensaver SIGINT SIGTERM SIGHUP SIGQUIT
 

--- a/test/shell.d/screensaver-missing-ttfx-test.sh
+++ b/test/shell.d/screensaver-missing-ttfx-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname -- "${BASH_SOURCE[0]}")/base-test.sh"
+
+stub_dir=$(mktemp -d)
+trap 'rm -rf "$stub_dir"' EXIT
+
+# With ttfx missing the script must report once and exit instead of
+# respawning a missing command in a loop.
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/omarchy-cmd-missing"
+chmod +x "$stub_dir/omarchy-cmd-missing"
+
+status=0
+output=$(PATH="$stub_dir:$PATH" timeout 5 "$ROOT/bin/omarchy-screensaver" 2>&1) || status=$?
+(( status == 1 )) || fail "screensaver does not exit 1 when ttfx is missing (got $status)"
+grep -q "not installed" <<<"$output" || fail "screensaver gives no message when ttfx is missing"
+(( $(grep -c "not installed" <<<"$output") == 1 )) ||
+  fail "screensaver reports the missing engine more than once"
+pass "screensaver reports a missing ttfx once and exits"
+
+# With ttfx present the guard passes through to the draw loop. pgrep sees a
+# running ttfx; the focused window is not the screensaver, so the loop takes
+# its normal focus-loss exit.
+printf '#!/bin/bash\nexit 1\n' >"$stub_dir/omarchy-cmd-missing"
+printf '#!/bin/bash\ntouch "${TTFX_MARKER:?}"\nsleep 60\n' >"$stub_dir/ttfx"
+printf '#!/bin/bash\nexit 0\n' >"$stub_dir/pgrep"
+printf '#!/bin/bash\n[[ ${1:-} == activewindow ]] && printf "{}"\nexit 0\n' >"$stub_dir/hyprctl"
+chmod +x "$stub_dir"/{omarchy-cmd-missing,ttfx,pgrep,hyprctl}
+status=0
+TTFX_MARKER="$stub_dir/ttfx-ran" PATH="$stub_dir:$PATH" timeout 5 "$ROOT/bin/omarchy-screensaver" >/dev/null 2>&1 || status=$?
+[[ -f $stub_dir/ttfx-ran ]] || fail "screensaver never launches ttfx when present"
+(( status == 0 )) || fail "screensaver exits uncleanly on focus loss (got $status)"
+pass "screensaver proceeds to the draw loop when ttfx is present"


### PR DESCRIPTION
## Summary

Fixes #381.

With `ttfx` absent, the backgrounded launch inside the unconditional `while true` fails instantly, the inner `pgrep` wait sees no process, and the outer loop retries forever — painting the terminal with launch errors and never reaching the input/focus checks.

The fix guards before any state is mutated — before the cursor is hidden or the background painted — so there is nothing to restore: report the missing engine once, point at `omarchy pkg add ttfx`, exit 1.

#### Test plan

- [x] New `test/shell.d/screensaver-missing-ttfx-test.sh`: missing → single report + exit 1; present → proceeds into the draw loop and exits cleanly via the focus-loss path (stubbed `pgrep`/`hyprctl`, no session state touched) — 2/2 pass

Generated with [Devin](https://devin.ai)