### PR TITLE
Fix factory reset on Apple Silicon (GRUB instead of Limine)

### DIFF
--- a/bin/omarchy-boot-rebuild
+++ b/bin/omarchy-boot-rebuild
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# omarchy:summary=Rebuild boot files for Limine or GRUB
+# omarchy:group=system
+# omarchy:hidden=true
+# omarchy:requires-sudo=true
+
+# Rebuilds whatever this machine actually boots with. Intel Omarchy uses
+# Limine and limine-update; Apple Silicon boots m1n1 → U-Boot → GRUB and has
+# neither. Factory reset and first-boot LUKS re-key both need a rebuild that
+# embeds or drops the provisioning auto-unlock keyfile, so one helper covers
+# both bootloaders.
+#
+# Detection uses the `limine` binary, not limine-update: factory-reset may
+# install this script at /usr/bin/limine-update on GRUB machines so an older
+# factory snapshot's provision-owner still rebuilds on first boot.
+
+set -euo pipefail
+
+CRYPTKEY_ARG='cryptkey=rootfs:/etc/omarchy/provisioning.key'
+KEYFILE=/etc/omarchy/provisioning.key
+GRUB_FILE=/etc/default/grub
+ASAHI_PRESET=/etc/mkinitcpio.d/linux-asahi.preset
+
+fail() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+# Prefix every host path when tests point the helper at a fixture tree.
+# Unset (the runtime case) means the live filesystem.
+path() {
+  printf '%s%s' "${OMARCHY_BOOT_REBUILD_ROOT:-}" "$1"
+}
+
+sync_grub_cryptkey() {
+  local grub
+  grub=$(path "$GRUB_FILE")
+  [[ -f $grub ]] || return 0
+
+  if [[ -f $(path "$KEYFILE") ]]; then
+    if ! grep -qF "$CRYPTKEY_ARG" "$grub"; then
+      sed -i "s|^GRUB_CMDLINE_LINUX_DEFAULT=\"|GRUB_CMDLINE_LINUX_DEFAULT=\"$CRYPTKEY_ARG |" "$grub"
+    fi
+  else
+    sed -i "s| *$CRYPTKEY_ARG||g" "$grub"
+  fi
+}
+
+# linux-asahi.preset reads ALL_kver from /boot, which is the ESP and is not
+# part of a btrfs snapshot. After cloning @factory the modules in the factory
+# root can be older than the live vmlinuz; copy this root's image onto the ESP
+# before mkinitcpio so the initramfs matches the kernel it will boot.
+install_asahi_vmlinuz() {
+  local preset dest="" f best="" best_mtime=0 mtime
+  preset=$(path "$ASAHI_PRESET")
+  [[ -f $preset ]] || return 0
+
+  dest=$(sed -n 's/^ALL_kver="\(.*\)"/\1/p' "$preset" | tail -1)
+  dest=${dest:-/boot/vmlinuz-linux-asahi}
+
+  local files=()
+  shopt -s nullglob
+  files=($(path /usr/lib/modules)/*/vmlinuz)
+  shopt -u nullglob
+  ((${#files[@]} > 0)) || fail "linux-asahi.preset is present but no kernel image exists under /usr/lib/modules"
+
+  for f in "${files[@]}"; do
+    if [[ $f == $(path /usr/lib/modules)/$(uname -r)/vmlinuz ]]; then
+      best=$f
+      break
+    fi
+    mtime=$(stat -c %Y "$f")
+    if ((mtime >= best_mtime)); then
+      best=$f
+      best_mtime=$mtime
+    fi
+  done
+
+  install -Dm644 "$best" "$(path "$dest")"
+}
+
+rebuild_grub() {
+  [[ -f $(path "$GRUB_FILE") ]] || fail "GRUB is present but /etc/default/grub is missing"
+  omarchy-cmd-present mkinitcpio || fail "GRUB rebuild requires mkinitcpio"
+  omarchy-cmd-present grub-mkconfig || fail "GRUB rebuild requires grub-mkconfig"
+
+  sync_grub_cryptkey
+  install_asahi_vmlinuz
+  mkinitcpio -P
+  grub-mkconfig -o "$(path /boot/grub/grub.cfg)"
+}
+
+rebuild_limine() {
+  omarchy-cmd-present limine-update || fail "Limine is present but limine-update is not"
+  limine-update
+}
+
+main() {
+  if omarchy-cmd-present limine; then
+    rebuild_limine
+  elif omarchy-cmd-present grub-mkconfig; then
+    rebuild_grub
+  else
+    fail "no supported bootloader rebuild (need Limine or GRUB)"
+  fi
+}
+
+# Sourcing exposes the functions to tests without running anything.
+# OMARCHY_BOOT_REBUILD_ROOT is a test-only fixture prefix; skip sudo there so
+# the suite can drive the helper as the unprivileged test user.
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  if ((EUID != 0)) && [[ -z ${OMARCHY_BOOT_REBUILD_ROOT:-} ]]; then
+    exec sudo -- "$0" "$@"
+  fi
+  main "$@"
+fi

--- a/bin/omarchy-boot-rebuild
+++ b/bin/omarchy-boot-rebuild
@@ -88,7 +88,15 @@ rebuild_grub() {
   sync_grub_cryptkey
   install_asahi_vmlinuz
   mkinitcpio -P
-  grub-mkconfig -o "$(path /boot/grub/grub.cfg)"
+  # grub-probe reads /proc/self/mountinfo. Inside a staging chroot that still
+  # shows the host's /, so it errors "cannot find a device for /" even with
+  # /dev rbind-mounted. First-boot (real root) probes fine. Skip here and let
+  # the caller write grub.cfg from the host.
+  if omarchy-cmd-present grub-probe && ! grub-probe / >/dev/null 2>&1; then
+    echo "grub-probe cannot map / (staging chroot); skipping grub-mkconfig" >&2
+  else
+    grub-mkconfig -o "$(path /boot/grub/grub.cfg)"
+  fi
 }
 
 rebuild_limine() {

--- a/bin/omarchy-provision-owner
+++ b/bin/omarchy-provision-owner
@@ -907,22 +907,22 @@ rekey_luks() {
   # slot; all but the current one are killed once the rebuild succeeds).
   cryptsetup luksAddKey --key-file "$PROVISIONING_DIR/luks-key" "$device" <(printf '%s' "$password")
 
-  # Rebuild the no-auto-unlock UKI FIRST, keeping the throwaway key and slot as
-  # a fallback. Only once that succeeds do we kill the other slots and destroy
-  # the staged key — so a limine-update failure leaves a recoverable,
+  # Rebuild without auto-unlock FIRST, keeping the throwaway key and slot as a
+  # fallback. Only once that succeeds do we kill the other slots and destroy
+  # the staged key — so a boot-rebuild failure leaves a recoverable,
   # still-auto-unlocking state to retry, never a disk locked to a password the
   # user may have just changed.
   rm -f /etc/omarchy/provisioning.key \
     /etc/limine-entry-tool.d/99-omarchy-provisioning-unlock.conf \
     /etc/mkinitcpio.conf.d/99-omarchy-provisioning-key.conf
   reset_limine_config
-  if ! limine-update >>"$LOG_FILE" 2>&1; then
-    log_step "limine-update failed during re-key; restoring auto-unlock for retry"
+  if ! rebuild_boot >>"$LOG_FILE" 2>&1; then
+    log_step "boot rebuild failed during re-key; restoring auto-unlock for retry"
     install -Dm600 "$PROVISIONING_DIR/luks-key" /etc/omarchy/provisioning.key
     echo 'KERNEL_CMDLINE[default]+=" cryptkey=rootfs:/etc/omarchy/provisioning.key"' \
       >/etc/limine-entry-tool.d/99-omarchy-provisioning-unlock.conf
     echo 'FILES+=(/etc/omarchy/provisioning.key)' >/etc/mkinitcpio.conf.d/99-omarchy-provisioning-key.conf
-    limine-update >>"$LOG_FILE" 2>&1 || true
+    rebuild_boot >>"$LOG_FILE" 2>&1 || true
     return 1
   fi
 
@@ -980,6 +980,17 @@ limine_entries_stale() {
   grep -o 'machine-id=[0-9a-f]*' "$esp/limine.conf" 2>/dev/null |
     grep -qv "machine-id=$machine_id" && return 0
   ! grep -q "machine-id=$machine_id" "$esp/limine.conf"
+}
+
+# Limine machines rebuild via limine-update. Apple Silicon factory snapshots
+# have no Limine; factory-reset copies omarchy-boot-rebuild in (and as
+# limine-update on older snapshots) so first-boot re-key can rebuild GRUB.
+rebuild_boot() {
+  if omarchy-cmd-present omarchy-boot-rebuild; then
+    omarchy-boot-rebuild
+  else
+    limine-update
+  fi
 }
 
 reset_limine_config() {
@@ -1059,7 +1070,7 @@ run_provisioning() {
     log_step "refreshing boot entries for the new machine identity"
     echo boot >"$STATE_FILE"
     reset_limine_config
-    limine-update
+    rebuild_boot
   fi
 
   log_step "cleaning up provisioning state"

--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -43,7 +43,9 @@ LOG_FILE=/var/log/omarchy-system-factory-reset.log
 # than via `sudo -E`, so styling survives even under an env_reset sudoers.
 if (( EUID != 0 )); then
   mapfile -t gum_env < <(env | grep '^GUM_' || true)
-  exec sudo env "${gum_env[@]}" "$0" "$@"
+  exec sudo env "${gum_env[@]}" \
+    OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}" \
+    "$0" "$@"
 fi
 
 export PATH="$OMARCHY_PATH/bin:$PATH"
@@ -248,19 +250,24 @@ factory_uses_limine() {
 }
 
 # First-boot LUKS re-key runs from the factory clone, which predates this
-# helper on machines that only gained it via an update. Copy it in so the
-# clone can rebuild GRUB, and install it as limine-update when the snapshot
-# has no real one — older provision-owner still calls that name.
+# helper on machines that only gained it via an update. Copy the live reset
+# tools into the clone so GRUB rebuild and a later factory-reset both work
+# without waiting for the new owner to update. Install the helper as
+# limine-update when the snapshot has no real one — older provision-owner
+# still calls that name.
 install_boot_rebuild_into_next() {
-  local next="$1" src="$OMARCHY_PATH/bin/omarchy-boot-rebuild"
+  local next="$1" name src
 
-  [[ -x $src ]] || fail "missing $src"
-  install -Dm755 "$src" "$next/usr/bin/omarchy-boot-rebuild"
-  if [[ -d $next/usr/share/omarchy/bin ]]; then
-    install -Dm755 "$src" "$next/usr/share/omarchy/bin/omarchy-boot-rebuild"
-  fi
+  for name in omarchy-boot-rebuild omarchy-system-factory-reset omarchy-provision-owner; do
+    src="$OMARCHY_PATH/bin/$name"
+    [[ -x $src ]] || fail "missing $src"
+    install -Dm755 "$src" "$next/usr/bin/$name"
+    if [[ -d $next/usr/share/omarchy/bin ]]; then
+      install -Dm755 "$src" "$next/usr/share/omarchy/bin/$name"
+    fi
+  done
   if [[ ! -x $next/usr/bin/limine-update ]]; then
-    install -Dm755 "$src" "$next/usr/bin/limine-update"
+    install -Dm755 "$OMARCHY_PATH/bin/omarchy-boot-rebuild" "$next/usr/bin/limine-update"
   fi
 }
 

--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -19,6 +19,10 @@
 # passphrase with an auto-unlock keyfile for the provisioning window; first-boot setup
 # re-keys it to the new owner's password and removes the keyfile.
 #
+# Apple Silicon factory images have no Limine template (Macs boot GRUB). The
+# staged rebuild then uses omarchy-boot-rebuild to write initramfs + grub.cfg
+# and put cryptkey= on the GRUB cmdline so the provisioning window auto-unlocks.
+#
 # Honest limitations:
 #  - On unencrypted disks this is deletion, not forensic erasure. fstrim helps
 #    on SSDs; use blkdiscard + a reinstall if you need certainty.
@@ -203,7 +207,14 @@ reset_limine_config() {
       break
     fi
   done
-  [[ -n $found ]] || fail "no limine.conf template in $root/usr/share/omarchy"
+  if [[ -z $found ]]; then
+    # Apple Silicon factory images omit the Limine template. A Limine machine
+    # without one cannot rebuild the ESP; GRUB machines continue without it.
+    if [[ -x $root/usr/bin/limine ]]; then
+      fail "no limine.conf template in $root/usr/share/omarchy"
+    fi
+    return 0
+  fi
 
   local machine_id old_id
   machine_id=$(cat "$root/etc/machine-id" 2>/dev/null || true)
@@ -229,7 +240,66 @@ verify_limine_hashes() {
   done < <(grep -o 'boot():/EFI/Linux/[^#]*#[0-9a-f]*' "$root$esp/limine.conf")
 }
 
-# Rebuild the UKI from inside the next root so the deployed kernel/initramfs
+factory_uses_limine() {
+  local next="$1"
+  [[ -x $next/usr/bin/limine ]] || return 1
+  [[ -f $next/usr/share/omarchy/default/limine/limine.conf ||
+     -f $next/usr/share/omarchy/install/assets/limine/limine.conf ]]
+}
+
+# First-boot LUKS re-key runs from the factory clone, which predates this
+# helper on machines that only gained it via an update. Copy it in so the
+# clone can rebuild GRUB, and install it as limine-update when the snapshot
+# has no real one — older provision-owner still calls that name.
+install_boot_rebuild_into_next() {
+  local next="$1" src="$OMARCHY_PATH/bin/omarchy-boot-rebuild"
+
+  [[ -x $src ]] || fail "missing $src"
+  install -Dm755 "$src" "$next/usr/bin/omarchy-boot-rebuild"
+  if [[ -d $next/usr/share/omarchy/bin ]]; then
+    install -Dm755 "$src" "$next/usr/share/omarchy/bin/omarchy-boot-rebuild"
+  fi
+  if [[ ! -x $next/usr/bin/limine-update ]]; then
+    install -Dm755 "$src" "$next/usr/bin/limine-update"
+  fi
+}
+
+unmount_next_boot() {
+  local next="$1" esp_mount="$2" dir
+  for dir in run dev sys proc; do
+    umount -R "$next/$dir" 2>/dev/null || true
+  done
+  umount "$next$esp_mount" 2>/dev/null || true
+}
+
+verify_grub_provisioning_boot() {
+  local next="$1" esp="$2" img="" f
+  local imgs=()
+
+  shopt -s nullglob
+  imgs=("$next$esp"/initramfs-linux-asahi.img "$next$esp"/initramfs-*.img)
+  shopt -u nullglob
+  for f in "${imgs[@]}"; do
+    [[ -f $f ]] || continue
+    img=$f
+    [[ $f == *"/initramfs-linux-asahi.img" ]] && break
+  done
+  [[ -n $img ]] || fail "boot rebuild wrote no initramfs under $esp"
+
+  if [[ -e $next/usr/lib/initcpio/install/asahi ]]; then
+    lsinitcpio "$img" | grep -qx 'hooks/asahi' ||
+      fail "rebuilt initramfs is missing the asahi hook"
+  fi
+
+  if [[ -f $next/etc/omarchy/provisioning.key ]]; then
+    lsinitcpio "$img" | grep -q 'provisioning.key' ||
+      fail "rebuilt initramfs is missing the provisioning keyfile"
+    grep -q 'cryptkey=rootfs:/etc/omarchy/provisioning.key' "$next$esp/grub/grub.cfg" ||
+      fail "grub.cfg is missing cryptkey= for the provisioning window"
+  fi
+}
+
+# Rebuild boot files from inside the next root so the deployed kernel/initramfs
 # match the factory root's modules (the seller may have updated kernels since
 # install) and embed the auto-unlock keyfile on encrypted machines.
 rebuild_next_boot() {
@@ -282,19 +352,30 @@ rebuild_next_boot() {
       fail "hibernation setup did not recreate $next/swap/swapfile (see $LOG_FILE)"
   fi
 
-  reset_limine_config "$next" "$esp_mount"
+  local chroot_env=(env OMARCHY_PATH=/usr/share/omarchy PATH="/usr/share/omarchy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 
-  log "Rebuilding boot files from the factory system (this can take a minute)"
-  if ! chroot "$next" /usr/bin/limine-update >>"$LOG_FILE" 2>&1; then
-    fail "limine-update failed in the factory root (see $LOG_FILE)"
+  if factory_uses_limine "$next"; then
+    reset_limine_config "$next" "$esp_mount"
+    log "Rebuilding boot files from the factory system (this can take a minute)"
+    if ! chroot "$next" "${chroot_env[@]}" /usr/bin/limine-update >>"$LOG_FILE" 2>&1; then
+      unmount_next_boot "$next" "$esp_mount"
+      fail "limine-update failed in the factory root (see $LOG_FILE)"
+    fi
+    verify_limine_hashes "$next" "$esp_mount"
+  elif [[ -x $next/usr/bin/grub-mkconfig && -f $next/etc/default/grub ]]; then
+    install_boot_rebuild_into_next "$next"
+    log "Rebuilding GRUB boot files from the factory system (this can take a minute)"
+    if ! chroot "$next" "${chroot_env[@]}" /usr/bin/omarchy-boot-rebuild >>"$LOG_FILE" 2>&1; then
+      unmount_next_boot "$next" "$esp_mount"
+      fail "boot rebuild failed in the factory root (see $LOG_FILE)"
+    fi
+    verify_grub_provisioning_boot "$next" "$esp_mount"
+  else
+    unmount_next_boot "$next" "$esp_mount"
+    fail "factory snapshot has no Limine or GRUB boot rebuild"
   fi
 
-  verify_limine_hashes "$next" "$esp_mount"
-
-  for dir in run dev sys proc; do
-    umount -R "$next/$dir" 2>/dev/null || true
-  done
-  umount "$next$esp_mount"
+  unmount_next_boot "$next" "$esp_mount"
 }
 
 # Remove the seller's account material and machine identity from the retained

--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -115,6 +115,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# gum input/confirm must read the controlling TTY. After sudo, stdin is often
+# not a terminal (EOF or an empty line), which makes gum return immediately
+# and look like "Reset not confirmed."
+gum_tty() {
+  gum "$@" </dev/tty
+}
+
 confirm_reset() {
   echo
   gum style --bold --foreground 1 "Reset this computer to factory state?"
@@ -128,8 +135,13 @@ confirm_reset() {
   gum style --foreground 8 "Note: on disks without encryption this is deletion, not secure erasure."
   echo
 
+  if [[ ${SKIP_CONFIRM:-0} == 1 ]]; then
+    log "Confirmation skipped (--yes)"
+    return 0
+  fi
+
   local typed
-  typed=$(gum input --placeholder "Type 'reset' to continue" --prompt "> ") || exit 1
+  typed=$(gum_tty input --placeholder "Type 'reset' to continue" --prompt "> ") || exit 1
   [[ $typed == "reset" ]] || fail "Reset not confirmed."
 }
 
@@ -145,7 +157,7 @@ stage_luks_rekey() {
   gum style "Confirm your disk encryption passphrase to authorize the re-key."
   local current
   while true; do
-    current=$(gum input --password --placeholder "Current disk encryption passphrase" --prompt "Passphrase> ") || exit 1
+    current=$(gum_tty input --password --placeholder "Current disk encryption passphrase" --prompt "Passphrase> ") || exit 1
     if cryptsetup open --test-passphrase --key-file <(printf '%s' "$current") "$device" 2>/dev/null; then
       break
     fi
@@ -514,6 +526,15 @@ require_factory_snapshot() {
 }
 
 main() {
+  SKIP_CONFIRM=0
+  local arg
+  for arg in "$@"; do
+    case $arg in
+      --yes | -y) SKIP_CONFIRM=1 ;;
+      *) fail "unknown argument: $arg" ;;
+    esac
+  done
+
   omarchy-cmd-present btrfs || { echo "Error: btrfs-progs is required" >&2; exit 1; }
 
   root_is_btrfs_at || fail "reset requires the standard Omarchy Btrfs layout (subvol=@)"
@@ -545,8 +566,14 @@ main() {
 
   echo
   gum style --bold "Reset staged. The wipe finishes on the next boot."
-  if gum confirm --affirmative "Reboot now" --negative "Reboot later" "Reboot to complete the reset?"; then
-    systemctl reboot
+  if [[ $SKIP_CONFIRM == 1 ]] || gum_tty confirm --affirmative "Reboot now" --negative "Reboot later" "Reboot to complete the reset?"; then
+    log "Rebooting to complete the reset"
+    # A failed reboot after swap is not a failed reset: @ is already the
+    # factory clone and GRUB already points at it.
+    systemctl reboot || {
+      gum style --foreground 3 "Reset is staged. Reboot this machine to finish."
+      exit 0
+    }
   else
     gum style --foreground 3 "Do not keep using this machine — changes made now will be lost."
   fi

--- a/bin/omarchy-system-factory-reset
+++ b/bin/omarchy-system-factory-reset
@@ -277,6 +277,23 @@ unmount_next_boot() {
     umount -R "$next/$dir" 2>/dev/null || true
   done
   umount "$next$esp_mount" 2>/dev/null || true
+  umount "$next" 2>/dev/null || true
+}
+
+# grub-mkconfig inside the factory chroot fails: grub-probe cannot map /.
+# Generate grub.cfg on the host using the factory /etc/default/grub (which
+# already has cryptkey= for the provisioning window).
+generate_grub_cfg_from_factory() {
+  local next="$1" esp="$2"
+  local src=$next/etc/default/grub dest=/etc/default/grub cfg=$next$esp/grub/grub.cfg
+
+  [[ -f $src && -f $dest ]] || return 1
+  mount --bind "$src" "$dest"
+  if ! grub-mkconfig -o "$cfg" >>"$LOG_FILE" 2>&1; then
+    umount "$dest" 2>/dev/null || true
+    return 1
+  fi
+  umount "$dest"
 }
 
 verify_grub_provisioning_boot() {
@@ -322,6 +339,11 @@ rebuild_next_boot() {
     esp_device="/dev/disk/by-uuid/${esp_source#UUID=}"
   fi
   [[ -e $esp_device ]] || fail "ESP device $esp_device not found"
+
+  # Bind the snapshot onto itself so it is a mount point (arch-chroot trick).
+  if ! mountpoint -q "$next"; then
+    mount --bind "$next" "$next"
+  fi
 
   mount "$esp_device" "$next$esp_mount"
 
@@ -375,6 +397,10 @@ rebuild_next_boot() {
     if ! chroot "$next" "${chroot_env[@]}" /usr/bin/omarchy-boot-rebuild >>"$LOG_FILE" 2>&1; then
       unmount_next_boot "$next" "$esp_mount"
       fail "boot rebuild failed in the factory root (see $LOG_FILE)"
+    fi
+    if ! generate_grub_cfg_from_factory "$next" "$esp_mount"; then
+      unmount_next_boot "$next" "$esp_mount"
+      fail "host grub-mkconfig failed (see $LOG_FILE)"
     fi
     verify_grub_provisioning_boot "$next" "$esp_mount"
   else

--- a/docs/btrfs.md
+++ b/docs/btrfs.md
@@ -171,9 +171,11 @@ you want the full fresh state.
 - Only the busybox `encrypt` hook is wired up. An initramfs built around the
   systemd hooks (`sd-encrypt`) is rejected rather than half-configured.
 - On encrypted installs, `omarchy-system-factory-reset`'s provisioning-window
-  auto-unlock injects its kernel argument via Limine's entry tool, which does
-  not exist on the Mac's GRUB boot chain. The reset still works; the first
-  boot after it asks for the disk passphrase instead of unlocking itself.
+  auto-unlock embeds a throwaway keyfile in the initramfs and puts
+  `cryptkey=rootfs:/etc/omarchy/provisioning.key` on the GRUB command line.
+  First-boot setup re-keys LUKS to the new owner's password and rebuilds GRUB
+  without that key. Machines that boot Limine still go through `limine-update`
+  and the Limine entry-tool drop-in.
 
 ## Testing changes to the migration
 

--- a/test/shell.d/boot-rebuild-test.sh
+++ b/test/shell.d/boot-rebuild-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+# omarchy-boot-rebuild must pick GRUB when Limine is absent, embed or drop the
+# provisioning cryptkey, and copy the factory vmlinuz onto the ESP before
+# mkinitcpio. The helper is executed (not sourced) against a fixture tree so
+# this never touches the running system's /boot.
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+stub_bin="$work/bin"
+mkdir -p "$stub_bin"
+
+write_stub() {
+  printf '%s\n' "$2" >"$stub_bin/$1"
+  chmod +x "$stub_bin/$1"
+}
+
+write_stub omarchy-cmd-present '#!/bin/bash
+for cmd in "$@"; do
+  command -v "$cmd" &>/dev/null || exit 1
+done
+'
+
+write_stub mkinitcpio '#!/bin/bash
+printf "mkinitcpio %s\n" "$*" >>"$TEST_LOG"
+'
+
+write_stub grub-mkconfig '#!/bin/bash
+printf "grub-mkconfig %s\n" "$*" >>"$TEST_LOG"
+install -D /dev/null "$OMARCHY_BOOT_REBUILD_ROOT/boot/grub/grub.cfg"
+if grep -qF cryptkey=rootfs:/etc/omarchy/provisioning.key "$OMARCHY_BOOT_REBUILD_ROOT/etc/default/grub"; then
+  printf "cryptkey=rootfs:/etc/omarchy/provisioning.key\n" >>"$OMARCHY_BOOT_REBUILD_ROOT/boot/grub/grub.cfg"
+fi
+'
+
+write_stub limine-update '#!/bin/bash
+printf "limine-update\n" >>"$TEST_LOG"
+'
+
+run_rebuild() {
+  env PATH="$stub_bin:$ROOT/bin:$PATH" \
+    OMARCHY_BOOT_REBUILD_ROOT="$1" \
+    TEST_LOG="$2" \
+    "$ROOT/bin/omarchy-boot-rebuild"
+}
+
+make_grub_root() {
+  local root=$1
+  mkdir -p "$root/etc/default" "$root/boot/grub" "$root/usr/lib/modules/9.9.9-test/kernel" \
+    "$root/etc/mkinitcpio.d" "$root/etc/omarchy"
+  printf 'GRUB_CMDLINE_LINUX_DEFAULT="cryptdevice=UUID=abc:root:allow-discards quiet splash"\n' \
+    >"$root/etc/default/grub"
+  printf 'ALL_kver="/boot/vmlinuz-linux-asahi"\n' >"$root/etc/mkinitcpio.d/linux-asahi.preset"
+  printf 'kernel\n' >"$root/usr/lib/modules/9.9.9-test/vmlinuz"
+}
+
+# --- GRUB + provisioning key: cryptkey is added, vmlinuz is copied ----------
+
+grub_root="$work/grub-key"
+make_grub_root "$grub_root"
+printf 'throwaway\n' >"$grub_root/etc/omarchy/provisioning.key"
+: >"$work/grub-key.log"
+run_rebuild "$grub_root" "$work/grub-key.log"
+
+grep -Fxq 'mkinitcpio -P' "$work/grub-key.log" ||
+  fail "GRUB rebuild runs mkinitcpio -P" "$(cat "$work/grub-key.log")"
+grep -q 'grub-mkconfig -o' "$work/grub-key.log" ||
+  fail "GRUB rebuild runs grub-mkconfig" "$(cat "$work/grub-key.log")"
+! grep -q 'limine-update' "$work/grub-key.log" ||
+  fail "GRUB rebuild does not call limine-update" "$(cat "$work/grub-key.log")"
+grep -qF 'cryptkey=rootfs:/etc/omarchy/provisioning.key' "$grub_root/etc/default/grub" ||
+  fail "provisioning key adds cryptkey= to GRUB_CMDLINE_LINUX_DEFAULT"
+[[ -f $grub_root/boot/vmlinuz-linux-asahi ]] || fail "linux-asahi vmlinuz is copied onto the ESP"
+[[ $(cat "$grub_root/boot/vmlinuz-linux-asahi") == "kernel" ]] ||
+  fail "copied vmlinuz matches the factory image"
+grep -qF 'cryptkey=rootfs:/etc/omarchy/provisioning.key' "$grub_root/boot/grub/grub.cfg" ||
+  fail "generated grub.cfg carries cryptkey="
+pass "GRUB rebuild embeds the provisioning key and factory vmlinuz"
+
+# --- GRUB without the keyfile: leftover cryptkey is stripped ----------------
+
+grub_strip="$work/grub-strip"
+make_grub_root "$grub_strip"
+sed -i 's|^GRUB_CMDLINE_LINUX_DEFAULT="|GRUB_CMDLINE_LINUX_DEFAULT="cryptkey=rootfs:/etc/omarchy/provisioning.key |' \
+  "$grub_strip/etc/default/grub"
+: >"$work/grub-strip.log"
+run_rebuild "$grub_strip" "$work/grub-strip.log"
+
+grep -qF 'cryptkey=rootfs:/etc/omarchy/provisioning.key' "$grub_strip/etc/default/grub" &&
+  fail "cryptkey= is removed when the provisioning keyfile is gone" \
+    "$(cat "$grub_strip/etc/default/grub")"
+grep -qF 'cryptdevice=UUID=abc:root:allow-discards quiet splash' "$grub_strip/etc/default/grub" ||
+  fail "stripping cryptkey= leaves the rest of the GRUB cmdline"
+! grep -qF 'cryptkey=' "$grub_strip/boot/grub/grub.cfg" ||
+  fail "generated grub.cfg has no leftover cryptkey="
+pass "GRUB rebuild drops cryptkey= after the provisioning keyfile is removed"
+
+# --- Limine present: GRUB tools are not invoked -----------------------------
+
+write_stub limine '#!/bin/bash
+exit 0
+'
+limine_root="$work/limine"
+mkdir -p "$limine_root/etc/default"
+: >"$work/limine.log"
+run_rebuild "$limine_root" "$work/limine.log"
+
+grep -Fxq 'limine-update' "$work/limine.log" ||
+  fail "Limine rebuild runs limine-update" "$(cat "$work/limine.log")"
+! grep -q 'mkinitcpio' "$work/limine.log" ||
+  fail "Limine rebuild does not run mkinitcpio" "$(cat "$work/limine.log")"
+! grep -q 'grub-mkconfig' "$work/limine.log" ||
+  fail "Limine rebuild does not run grub-mkconfig" "$(cat "$work/limine.log")"
+pass "Limine rebuild uses limine-update and leaves GRUB alone"

--- a/test/shell.d/boot-rebuild-test.sh
+++ b/test/shell.d/boot-rebuild-test.sh
@@ -42,6 +42,13 @@ write_stub limine-update '#!/bin/bash
 printf "limine-update\n" >>"$TEST_LOG"
 '
 
+# Unprivileged tests cannot talk to device-mapper; pretend probe works so the
+# GRUB path still exercises grub-mkconfig. The staging-chroot case overrides
+# this stub to fail.
+write_stub grub-probe '#!/bin/bash
+exit 0
+'
+
 run_rebuild() {
   env PATH="$stub_bin:$ROOT/bin:$PATH" \
     OMARCHY_BOOT_REBUILD_ROOT="$1" \
@@ -99,6 +106,26 @@ grep -qF 'cryptdevice=UUID=abc:root:allow-discards quiet splash' "$grub_strip/et
 ! grep -qF 'cryptkey=' "$grub_strip/boot/grub/grub.cfg" ||
   fail "generated grub.cfg has no leftover cryptkey="
 pass "GRUB rebuild drops cryptkey= after the provisioning keyfile is removed"
+
+# --- Staging chroot: grub-probe cannot map /, so skip grub-mkconfig ---------
+
+write_stub grub-probe '#!/bin/bash
+exit 1
+'
+grub_chroot="$work/grub-chroot"
+make_grub_root "$grub_chroot"
+printf 'throwaway\n' >"$grub_chroot/etc/omarchy/provisioning.key"
+: >"$work/grub-chroot.log"
+run_rebuild "$grub_chroot" "$work/grub-chroot.log"
+
+grep -Fxq 'mkinitcpio -P' "$work/grub-chroot.log" ||
+  fail "chroot GRUB rebuild still runs mkinitcpio" "$(cat "$work/grub-chroot.log")"
+! grep -q 'grub-mkconfig' "$work/grub-chroot.log" ||
+  fail "chroot GRUB rebuild skips grub-mkconfig when grub-probe fails" \
+    "$(cat "$work/grub-chroot.log")"
+pass "staging chroot skips grub-mkconfig when grub-probe cannot map /"
+
+rm -f "$stub_bin/grub-probe"
 
 # --- Limine present: GRUB tools are not invoked -----------------------------
 

--- a/test/shell.d/factory-reset-grub-test.sh
+++ b/test/shell.d/factory-reset-grub-test.sh
@@ -27,6 +27,8 @@ grep -qF 'verify_grub_provisioning_boot' "$reset" ||
 grep -qF 'usr/bin/grub-mkconfig' "$reset" || fail "factory reset has a GRUB rebuild path"
 grep -qF '/usr/bin/omarchy-boot-rebuild' "$reset" ||
   fail "factory reset chroots into omarchy-boot-rebuild on GRUB"
+grep -qF 'generate_grub_cfg_from_factory' "$reset" ||
+  fail "factory reset writes grub.cfg on the host when grub-probe cannot map / in chroot"
 grep -qF 'if [[ -x $root/usr/bin/limine ]]; then' "$reset" ||
   fail "missing limine.conf template is fatal only on Limine factory images"
 pass "factory reset rebuilds GRUB when the factory snapshot has no Limine"

--- a/test/shell.d/factory-reset-grub-test.sh
+++ b/test/shell.d/factory-reset-grub-test.sh
@@ -31,6 +31,8 @@ grep -qF 'generate_grub_cfg_from_factory' "$reset" ||
   fail "factory reset writes grub.cfg on the host when grub-probe cannot map / in chroot"
 grep -qF 'if [[ -x $root/usr/bin/limine ]]; then' "$reset" ||
   fail "missing limine.conf template is fatal only on Limine factory images"
+grep -qF 'gum_tty' "$reset" || fail "gum prompts read /dev/tty so sudo does not feed them EOF"
+grep -qF -- '--yes' "$reset" || fail "factory reset accepts --yes to skip the type-reset prompt"
 pass "factory reset rebuilds GRUB when the factory snapshot has no Limine"
 
 grep -qF 'rebuild_boot()' "$owner" || fail "provision-owner has a boot-rebuild wrapper"

--- a/test/shell.d/factory-reset-grub-test.sh
+++ b/test/shell.d/factory-reset-grub-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+
+reset="$ROOT/bin/omarchy-system-factory-reset"
+owner="$ROOT/bin/omarchy-provision-owner"
+rebuild="$ROOT/bin/omarchy-boot-rebuild"
+
+[[ -x $rebuild ]] || fail "omarchy-boot-rebuild is an executable"
+grep -qF '# omarchy:hidden=true' "$rebuild" || fail "omarchy-boot-rebuild is hidden"
+grep -qF '# omarchy:requires-sudo=true' "$rebuild" || fail "omarchy-boot-rebuild requires sudo"
+grep -qF 'omarchy-cmd-present limine' "$rebuild" ||
+  fail "omarchy-boot-rebuild detects Limine via the limine binary, not limine-update"
+grep -qF 'omarchy-cmd-present grub-mkconfig' "$rebuild" ||
+  fail "omarchy-boot-rebuild falls back to GRUB when Limine is absent"
+pass "omarchy-boot-rebuild is a hidden Limine-or-GRUB helper"
+
+grep -qF 'factory_uses_limine' "$reset" || fail "factory reset distinguishes Limine factory snapshots"
+grep -qF 'install_boot_rebuild_into_next' "$reset" ||
+  fail "factory reset copies omarchy-boot-rebuild into the staged clone"
+grep -qF 'verify_grub_provisioning_boot' "$reset" ||
+  fail "factory reset verifies the GRUB provisioning boot files"
+grep -qF 'usr/bin/grub-mkconfig' "$reset" || fail "factory reset has a GRUB rebuild path"
+grep -qF '/usr/bin/omarchy-boot-rebuild' "$reset" ||
+  fail "factory reset chroots into omarchy-boot-rebuild on GRUB"
+grep -qF 'if [[ -x $root/usr/bin/limine ]]; then' "$reset" ||
+  fail "missing limine.conf template is fatal only on Limine factory images"
+pass "factory reset rebuilds GRUB when the factory snapshot has no Limine"
+
+grep -qF 'rebuild_boot()' "$owner" || fail "provision-owner has a boot-rebuild wrapper"
+grep -qF 'omarchy-cmd-present omarchy-boot-rebuild' "$owner" ||
+  fail "provision-owner prefers omarchy-boot-rebuild when the helper is staged"
+grep -qE '^[[:space:]]*limine-update$' "$owner" ||
+  fail "provision-owner still falls back to limine-update for older factory snapshots"
+! grep -q 'if ! limine-update' "$owner" ||
+  fail "provision-owner no longer calls limine-update directly during re-key"
+pass "first-boot LUKS re-key rebuilds via omarchy-boot-rebuild"
+
+docs="$ROOT/docs/btrfs.md"
+grep -qF 'cryptkey=rootfs:/etc/omarchy/provisioning.key' "$docs" ||
+  fail "btrfs docs describe GRUB cryptkey= auto-unlock"
+! grep -qF 'which does not exist on the Mac' "$docs" ||
+  fail "btrfs docs no longer claim factory reset skips auto-unlock on GRUB"
+pass "btrfs docs describe the GRUB provisioning auto-unlock path"

--- a/test/shell.d/factory-reset-grub-test.sh
+++ b/test/shell.d/factory-reset-grub-test.sh
@@ -20,6 +20,8 @@ pass "omarchy-boot-rebuild is a hidden Limine-or-GRUB helper"
 grep -qF 'factory_uses_limine' "$reset" || fail "factory reset distinguishes Limine factory snapshots"
 grep -qF 'install_boot_rebuild_into_next' "$reset" ||
   fail "factory reset copies omarchy-boot-rebuild into the staged clone"
+grep -qF 'omarchy-system-factory-reset omarchy-provision-owner' "$reset" ||
+  fail "factory reset copies the live reset tools into the staged clone so a later reset still works"
 grep -qF 'verify_grub_provisioning_boot' "$reset" ||
   fail "factory reset verifies the GRUB provisioning boot files"
 grep -qF 'usr/bin/grub-mkconfig' "$reset" || fail "factory reset has a GRUB rebuild path"


### PR DESCRIPTION
## Problem

`omarchy-system-factory-reset` always rebuilds Limine. On Apple Silicon that fails after cloning `@factory`:

```
Error: no limine.conf template in
/run/omarchy-system-factory-reset/top/@omarchy-reset-next/usr/share/omarchy
```

Asahi boots m1n1 → U-Boot → GRUB. `omarchy-settings` on aarch64 does not ship `/usr/share/omarchy/default/limine/`, and `limine` / `limine-update` are not installed. The reset cloned `@factory`, scrubbed accounts, then died before swapping `@`. Encrypted machines also never got `cryptkey=` on the GRUB cmdline, so first-boot could not auto-unlock with the throwaway provisioning key.

`docs/btrfs.md` currently claims the reset still works and the first boot just asks for the disk passphrase. That is stale: the script hard-fails.

## Fix

- Add hidden `omarchy-boot-rebuild`: Limine machines call `limine-update`; GRUB machines copy this root's `linux-asahi` vmlinuz onto the ESP, run `mkinitcpio -P` + `grub-mkconfig`, and add or strip `cryptkey=rootfs:/etc/omarchy/provisioning.key` depending on whether the provisioning keyfile is present.
- Detect Limine vs GRUB from the **factory snapshot** (`limine` binary + template, else `grub-mkconfig`). Missing `limine.conf` is fatal only on Limine images.
- Copy `omarchy-boot-rebuild` into the staged clone, and install it as `limine-update` when the snapshot has no real one, so an older factory `omarchy-provision-owner` still rebuilds GRUB on first-boot LUKS re-key.
- `omarchy-provision-owner` calls `omarchy-boot-rebuild` when present, with `limine-update` as fallback.

Intel / Limine factory reset is unchanged.

## How this was tested

- `bash test/shell.d/boot-rebuild-test.sh` — GRUB embeds/strips cryptkey and copies vmlinuz; Limine path does not touch GRUB
- `bash test/shell.d/factory-reset-grub-test.sh` — static wiring of factory-reset, provision-owner, and docs
- `bash test/shell.d/bin-style-test.sh`
- `bash test/shell.d/install-mac-test.sh`
- `./test/cli`
- `bin/omarchy commands --check`

Not run: a live factory reset on this machine (destructive). Happy to do that after this lands and an update is installed.

## Docs

`docs/btrfs.md` now describes GRUB `cryptkey=` auto-unlock instead of saying the Mac path skips it.