### PR TITLE
Fix recurring first-run update prompts on Mac

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -134,6 +134,26 @@ keep_apple_silicon_mkinitcpio_drop_ins() {
     fail "lost the limine-entry-tool.d cleanup in $pkgbuild"
 }
 
+# Upstream enumerates user units instead of installing the whole directory.
+# First-run requires the Mac keyboard unit too; omitting it leaves setup
+# incomplete and repeats the update notification on every graphical login.
+ensure_keyboard_backlight_unit() {
+  local pkgbuild="$1"
+  local unit=omarchy-brightness-keyboard-auto.service
+  local anchor='  install -Dm644 default/systemd/user/bt-agent.service "$pkgdir/usr/lib/systemd/user/bt-agent.service"'
+  local install_line="  install -Dm644 default/systemd/user/$unit \"\$pkgdir/usr/lib/systemd/user/$unit\""
+
+  # Accept upstream adopting this install, but stop for an unfamiliar recipe
+  # instead of silently producing another incomplete package.
+  grep -Fxq "$install_line" "$pkgbuild" && return 0
+  [[ $(grep -Fxc "$anchor" "$pkgbuild") == 1 ]] ||
+    fail "omarchy-settings user-unit installation changed; re-check $pkgbuild"
+  ! grep -Fq "$unit" "$pkgbuild" ||
+    fail "omarchy-settings has an unfamiliar keyboard-unit installation; re-check $pkgbuild"
+  sed -i "\|^  install -Dm644 default/systemd/user/bt-agent.service |a\\$install_line" "$pkgbuild"
+  grep -Fxq "$install_line" "$pkgbuild" || fail "could not add $unit to $pkgbuild"
+}
+
 # makepkg runs with --nodeps because the runtime dependencies include packages
 # built here, so pacman cannot resolve them yet. That skips makedepends too,
 # leaving the build tools to be installed up front.
@@ -187,6 +207,7 @@ build_package() {
   fi
   if [[ $package == "omarchy-settings" ]]; then
     keep_apple_silicon_mkinitcpio_drop_ins "$build_dir/$package/PKGBUILD"
+    ensure_keyboard_backlight_unit "$build_dir/$package/PKGBUILD"
   fi
   if [[ $package == "omarchy" || $package == "omarchy-settings" ]]; then
     set_pkgrel "$build_dir/$package/PKGBUILD"

--- a/migrations/1789205735.sh
+++ b/migrations/1789205735.sh
@@ -1,0 +1,60 @@
+echo "Enable the restored package-owned keyboard backlight service"
+
+# The original migration (1788139121) could complete with a dangling wants
+# symlink because omarchy-settings omitted this unit. Recheck the delivered
+# package before repairing existing users; first-run handles new users.
+unit=omarchy-brightness-keyboard-auto.service
+unit_path="/usr/lib/systemd/user/$unit"
+if [[ ! -f $unit_path ]]; then
+  echo "Missing $unit_path; update omarchy-settings before retrying this migration." >&2
+  exit 1
+fi
+
+wants_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/graphical-session.target.wants"
+if [[ -e $wants_dir/$unit || -L $wants_dir/$unit ]]; then
+  # Only the original absolute package link belongs to this repair. Enabling
+  # through systemctl can replace a deliberate custom link or regular file.
+  if [[ ! -L $wants_dir/$unit ]] || [[ $(readlink "$wants_dir/$unit") != "$unit_path" ]]; then
+    echo "Preserving the existing custom keyboard backlight service entry."
+    exit 0
+  fi
+fi
+
+user_manager_socket="${XDG_RUNTIME_DIR:-/run/user/$UID}/systemd/private"
+if ! systemctl --user show-environment >/dev/null 2>&1; then
+  if [[ -S $user_manager_socket ]]; then
+    echo "Cannot reach the running user service manager; retry this migration after reconnecting." >&2
+    exit 1
+  fi
+  # No manager is running (for example, an offline update). Preserve existing
+  # links and overrides; the next manager loads the newly delivered unit.
+  mkdir -p "$wants_dir"
+  if [[ ! -e $wants_dir/$unit && ! -L $wants_dir/$unit ]]; then
+    ln -s "$unit_path" "$wants_dir/$unit"
+  fi
+else
+  # A failed operation must leave the migration pending, just as a failed
+  # first-run step must leave setup retryable. ExecCondition handles machines
+  # without an ambient light sensor or keyboard backlight.
+  systemctl --user daemon-reload
+  # A user may deliberately mask this optional feature. Keep that choice
+  # without blocking the migration queue; other inspection failures still fail.
+  if ! unit_state=$(systemctl --user is-enabled "$unit"); then
+    case "$unit_state" in
+      disabled | masked | masked-runtime) ;;
+      *)
+        echo "Could not inspect the keyboard backlight service; retry this migration." >&2
+        exit 1
+        ;;
+    esac
+  fi
+  if [[ $unit_state == "masked" || $unit_state == "masked-runtime" ]]; then
+    echo "Preserving the masked keyboard backlight service."
+    exit 0
+  fi
+  systemctl --user enable "$unit"
+  graphical_state=$(systemctl --user show --property=ActiveState --value graphical-session.target)
+  if [[ $graphical_state == "active" ]]; then
+    systemctl --user start "$unit"
+  fi
+fi

--- a/test/shell.d/brightness-keyboard-auto-test.sh
+++ b/test/shell.d/brightness-keyboard-auto-test.sh
@@ -84,11 +84,10 @@ grep -F 'Automatic control pauses while the screen is locked or the lid is close
   fail "manual does not describe lock and lid-close as a pause"
 pass "manual describes lock and lid-close as pausing automatic control"
 
-migration=$(ls "$ROOT"/migrations/*keyboard*als* "$ROOT"/migrations/*als*keyboard* 2>/dev/null | tail -n 1 || true)
-if [[ -z $migration ]]; then
-  migration=$(grep -l omarchy-brightness-keyboard-auto.service "$ROOT"/migrations/*.sh | tail -n 1 || true)
-fi
-[[ -n $migration ]] || fail "a migration enables the ALS keyboard backlight unit"
+# These checks cover the original rollout. Later repairs have their own
+# behavioral tests and need not use the original migration's literal syntax.
+migration="$ROOT/migrations/1788139121.sh"
+[[ -f $migration ]] || fail "the original migration enables the ALS keyboard backlight unit"
 grep -F 'omarchy-brightness-keyboard-auto.service' "$migration" >/dev/null
 grep -F 'systemctl --user enable' "$migration" >/dev/null
 grep -F '/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service' "$migration" >/dev/null ||

--- a/test/shell.d/first-run-test.sh
+++ b/test/shell.d/first-run-test.sh
@@ -85,3 +85,58 @@ grep -F 'Failed: finalize user (exit code: 42)' \
   "$retry_tmp/home/.local/state/omarchy/first-run.log" >/dev/null ||
   fail "first-run records a finalization failure"
 pass "failed user finalization keeps first-run retryable"
+
+# Exercise the full completion gate with the real notification parser and the
+# three leaves involved in the recurring update prompt. Stub only unrelated
+# setup and the external service/network/notification transports.
+require_command jq
+lifecycle="$retry_tmp/lifecycle"
+mkdir -p "$lifecycle/bin" "$lifecycle/omarchy/install/user/first-run"
+for leaf in timezone wifi enable-user-units; do
+  cp "$ROOT/install/user/first-run/$leaf.sh" "$lifecycle/omarchy/install/user/first-run/"
+done
+for leaf in welcome gnome-theme gtk-primary-paste audio-tuning; do
+  printf 'true\n' >"$lifecycle/omarchy/install/user/first-run/$leaf.sh"
+done
+for command in omarchy-provision-user omarchy-hook-install omarchy-notification-wait nm-online; do
+  printf '#!/bin/bash\nexit 0\n' >"$lifecycle/bin/$command"
+done
+printf '#!/bin/bash\nprintf "UTC\\n"\n' >"$lifecycle/bin/timedatectl"
+cat >"$lifecycle/bin/systemctl" <<'SH'
+#!/bin/bash
+[[ $* != '--user daemon-reload' ]] || exit 0
+[[ ${KEYBOARD_UNIT_PRESENT:-yes} == yes ]]
+SH
+cat >"$lifecycle/bin/busctl" <<'SH'
+#!/bin/bash
+for argument in "$@"; do
+  [[ $argument != 'Update System' ]] || printf 'update\n' >>"$NOTIFICATIONS"
+done
+exit 0
+SH
+chmod +x "$lifecycle/bin/"*
+
+login() {
+  HOME="$lifecycle/home" XDG_CONFIG_HOME="$lifecycle/home/.config" \
+    PATH="$lifecycle/bin:$ROOT/bin:$PATH" OMARCHY_PATH="$lifecycle/omarchy" \
+    NOTIFICATIONS="$lifecycle/notifications" KEYBOARD_UNIT_PRESENT="$1" \
+    bash "$ROOT/bin/omarchy-provision-first-run" 2>&1 | cat >"$lifecycle/output"
+  # wifi.sh detaches its network probe. A pipe stays open until that child
+  # exits, giving each simulated login a deterministic notification boundary.
+}
+
+marker="$lifecycle/home/.local/state/omarchy/done/first-run-user"
+login yes
+login yes
+[[ -f $marker ]] || fail "successful real first-run records completion"
+[[ $(wc -l <"$lifecycle/notifications") == 1 ]] || fail "two successful logins show the update prompt once"
+pass "real timezone action and shipped user unit allow first-run to finish once"
+
+rm -rf "$lifecycle/home" "$lifecycle/notifications"
+login no
+[[ ! -e $marker ]] || fail "missing user unit keeps first-run retryable"
+login yes
+[[ -f $marker ]] || fail "restored user unit allows the next login to finish"
+login yes
+[[ $(wc -l <"$lifecycle/notifications") == 2 ]] || fail "repair stops update prompts after the successful retry"
+pass "missing package unit retries setup until repaired, then stops repeating prompts"

--- a/test/shell.d/keyboard-unit-migration-test.sh
+++ b/test/shell.d/keyboard-unit-migration-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+mkdir -p "$test_tmp/bin" "$test_tmp/units"
+unit=omarchy-brightness-keyboard-auto.service
+# Redirect only the package filesystem root; retain all migration control
+# flow and real filesystem operations in a disposable HOME.
+sed "s|/usr/lib/systemd/user/|$test_tmp/units/|g" \
+  "$ROOT/migrations/1789205735.sh" >"$test_tmp/migration.sh"
+cat >"$test_tmp/bin/systemctl" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >>"$CALLS"
+case "$*" in
+  '--user show-environment') [[ ${MANAGER:-online} == online ]] ;;
+  '--user is-enabled omarchy-brightness-keyboard-auto.service')
+    [[ ${FAIL_ACTION:-} != is-enabled ]] || exit 1
+    printf '%s\n' "${UNIT_STATE:-disabled}"
+    [[ ${UNIT_STATE:-disabled} == enabled ]]
+    ;;
+  '--user show --property=ActiveState --value graphical-session.target')
+    [[ ${FAIL_ACTION:-} != show ]] || exit 1
+    printf '%s\n' "${GRAPHICAL_STATE:-active}"
+    ;;
+  *) [[ $2 != "${FAIL_ACTION:-}" ]] ;;
+esac
+SH
+chmod +x "$test_tmp/bin/systemctl"
+export HOME="$test_tmp/home" XDG_CONFIG_HOME="$test_tmp/home/.config"
+export XDG_RUNTIME_DIR="$test_tmp/run" CALLS="$test_tmp/calls"
+export PATH="$test_tmp/bin:$PATH"
+run_migration() { bash -euo pipefail "$test_tmp/migration.sh"; }
+
+if run_migration >"$test_tmp/output" 2>&1; then
+  fail "missing package unit leaves the migration pending"
+fi
+[[ ! -e $CALLS ]] || fail "missing package unit does not touch user services"
+pass "missing package unit fails before creating a dangling link"
+
+cp "$ROOT/default/systemd/user/$unit" "$test_tmp/units/$unit"
+MANAGER=offline run_migration
+wants="$XDG_CONFIG_HOME/systemd/user/graphical-session.target.wants/$unit"
+[[ -f $wants ]] || fail "offline repair enables the delivered package unit"
+MANAGER=offline run_migration
+[[ $(readlink "$wants") == "$test_tmp/units/$unit" ]] || fail "repeated repair preserves its unit link"
+ln -sfn "$test_tmp/custom.service" "$wants"
+MANAGER=offline run_migration
+[[ $(readlink "$wants") == "$test_tmp/custom.service" ]] || fail "offline repair preserves a custom unit link"
+pass "offline repair is repeatable and preserves existing links"
+
+: >"$CALLS"
+run_migration
+[[ $(readlink "$wants") == "$test_tmp/custom.service" ]] || fail "online repair preserves a custom unit link"
+[[ ! -s $CALLS ]] || fail "custom unit link prevents online service mutation"
+rm "$wants"
+printf '# custom unit\n' >"$wants"
+run_migration
+grep -Fx '# custom unit' "$wants" >/dev/null || fail "online repair preserves a regular custom wants entry"
+[[ ! -s $CALLS ]] || fail "custom regular entry prevents online service mutation"
+rm "$wants"
+ln -s "$test_tmp/units/$unit" "$wants"
+pass "online repair preserves custom links and regular wants entries"
+
+for state in masked masked-runtime; do
+  : >"$CALLS"
+  UNIT_STATE="$state" run_migration
+  ! grep -Eq -- '--user (enable|start) ' "$CALLS" || fail "$state service is not enabled or started"
+done
+pass "persistent and runtime masks preserve user opt-outs without blocking migration"
+
+: >"$CALLS"
+run_migration
+grep -Fx -- "--user enable $unit" "$CALLS" >/dev/null || fail "online repair enables the unit"
+grep -Fx -- "--user start $unit" "$CALLS" >/dev/null || fail "active session starts the unit"
+: >"$CALLS"
+GRAPHICAL_STATE=inactive run_migration
+! grep -q -- '--user start' "$CALLS" || fail "inactive graphical session does not start the unit"
+pass "online repair starts the unit only in an active graphical session"
+
+for action in daemon-reload is-enabled enable show start; do
+  if FAIL_ACTION="$action" run_migration >"$test_tmp/output" 2>&1; then
+    fail "failed $action leaves the migration pending"
+  fi
+done
+pass "reload, enablement inspection, enable, session lookup, and start failures all remain retryable"

--- a/test/shell.d/keyboard-unit-package-test.sh
+++ b/test/shell.d/keyboard-unit-package-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "$0")/base-test.sh"
+source "$ROOT/build-packages.sh"
+
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+recipe="$test_tmp/PKGBUILD"
+cat >"$recipe" <<'SH'
+package() {
+  install -Dm644 default/systemd/user/bt-agent.service "$pkgdir/usr/lib/systemd/user/bt-agent.service"
+}
+SH
+ensure_keyboard_backlight_unit "$recipe"
+cp "$recipe" "$test_tmp/once"
+ensure_keyboard_backlight_unit "$recipe"
+cmp "$recipe" "$test_tmp/once" || fail "keyboard-unit adaptation is idempotent"
+pass "keyboard-unit adaptation accepts an already corrected recipe"
+
+(
+  cd "$ROOT"
+  pkgdir="$test_tmp/package"
+  source "$recipe"
+  package
+)
+unit=omarchy-brightness-keyboard-auto.service
+cmp "$ROOT/default/systemd/user/$unit" "$test_tmp/package/usr/lib/systemd/user/$unit" ||
+  fail "settings package delivers the source keyboard unit at the native systemd path"
+[[ $(stat -c %a "$test_tmp/package/usr/lib/systemd/user/$unit") == 644 ]] ||
+  fail "keyboard unit has package permissions 0644"
+pass "adapted package stages the required unit bytes and permissions"
+
+for mismatch in missing-anchor unfamiliar-install duplicate-anchor; do
+  case "$mismatch" in
+    missing-anchor) printf 'package() { :; }\n' >"$recipe" ;;
+    unfamiliar-install)
+      sed "/$unit/d" "$test_tmp/once" >"$recipe"
+      printf '# %s\n' "$unit" >>"$recipe"
+      ;;
+    duplicate-anchor)
+      sed "/$unit/d" "$test_tmp/once" >"$recipe"
+      sed -n '/install -Dm644/p' "$recipe" >>"$recipe.extra"
+      cat "$recipe.extra" >>"$recipe"
+      ;;
+  esac
+  if (ensure_keyboard_backlight_unit "$recipe") >"$test_tmp/output" 2>&1; then
+    fail "keyboard-unit adaptation rejects $mismatch"
+  fi
+done
+pass "keyboard-unit adaptation fails closed when the recipe no longer matches"


### PR DESCRIPTION
First-run setup retries at every graphical login when `omarchy-settings` omits `omarchy-brightness-keyboard-auto.service`, repeating the “Update System” notification even after an update.

Include the missing vendor service through the Mac package-build adaptation. Add migration `1789205735.sh` to repair existing installs whose original migration completed with a dangling service link. Preserve custom wants entries and persistent/runtime masks, and keep actual service-operation failures retryable. New installs receive the service through the settings package and normal first-run enablement.

Regression coverage checks package contents, migration behavior, and first-run completion across repeated logins. The timezone notification argv correction is already in the base branch; distributing the matching desktop/settings package pair delivers both repairs.

Validation at `bd1f2742b4dff9a14fe36d2d2243801b6622b158`:

- Focused first-run, timezone, keyboard package/migration, and original keyboard tests pass. Command metadata and syntax checks pass.
- Unsigned aarch64 package archives built from the final source contain the exact service and migration bytes. A real pacman upgrade from the cached `4.0.2-2` pair to a validation `4.0.2-3` pair passed in a disposable root, preserving user data and migration markers. That transaction excluded dependencies, install scriptlets, and desktop hooks.
- The actual migration runner passed missing-payload retry, restored-payload offline completion, and repeat-run checks.
- `./test/all`: CLI passes; 269 of 271 shell test files pass. Failures remain in `network-qr-test.sh` and `settings-package-units-test.sh`; this is not a clean full-suite result. ShellCheck was unavailable.

Native active-user-manager/ALS behavior, a live complete upgrade, physical fresh installation, and reboot remain unverified. These local package artifacts are validation builds, not a signed release.
